### PR TITLE
tailscale, runtime: make error types more descriptive

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,8 +4,15 @@ use netstack::netcore;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
     /// Internal operation failed, likely a bug.
-    #[error("internal operation failed, likely a bug")]
+    #[error("internal operation returned an error")]
     InternalFailure,
+
+    /// The runtime state was degraded: a component that we expected to be able to
+    /// communicate with hung up or could not be reached.
+    ///
+    /// This usually means that an internal component has panicked or is wedged.
+    #[error("runtime degraded, component unreachable")]
+    RuntimeDegraded,
 
     /// An operation timed out.
     #[error("operation timed out")]
@@ -18,9 +25,12 @@ pub enum Error {
 
 impl From<ts_runtime::Error> for Error {
     fn from(value: ts_runtime::Error) -> Self {
-        match value {
-            ts_runtime::Error::Timeout => Error::Timeout,
-            ts_runtime::Error::RuntimeState => Error::InternalFailure,
+        match value.kind {
+            ts_runtime::ErrorKind::Timeout => Error::Timeout,
+            ts_runtime::ErrorKind::ActorGone => Error::RuntimeDegraded,
+            ts_runtime::ErrorKind::MailboxFull | ts_runtime::ErrorKind::ReplyErr => {
+                Error::InternalFailure
+            }
         }
     }
 }
@@ -28,8 +38,9 @@ impl From<ts_runtime::Error> for Error {
 impl From<netcore::Error> for Error {
     fn from(value: netcore::Error) -> Self {
         match value {
+            netcore::Error::ChannelClosed => Error::RuntimeDegraded,
+
             netcore::Error::WrongType
-            | netcore::Error::ChannelClosed
             | netcore::Error::BadRequest
             | netcore::Error::InvariantViolated => Error::InternalFailure,
 

--- a/ts_runtime/src/env.rs
+++ b/ts_runtime/src/env.rs
@@ -7,7 +7,7 @@ use kameo::{
 use kameo_actors::message_bus::{MessageBus, Publish, Register};
 use tokio::sync::watch;
 
-use crate::Error;
+use crate::{Error, error::ResultExt};
 
 #[derive(Clone)]
 pub struct Env {
@@ -40,7 +40,8 @@ impl Env {
     {
         self.bus
             .tell(Register(slf.clone().recipient::<M>()))
-            .await?;
+            .await
+            .with_actor_info(&self.bus)?;
 
         Ok(())
     }
@@ -49,7 +50,10 @@ impl Env {
     where
         M: Clone + Send + 'static,
     {
-        self.bus.tell(Publish(msg)).await?;
+        self.bus
+            .tell(Publish(msg))
+            .await
+            .with_actor_info(&self.bus)?;
 
         Ok(())
     }

--- a/ts_runtime/src/error.rs
+++ b/ts_runtime/src/error.rs
@@ -1,28 +1,189 @@
-use kameo::error::SendError;
+use core::fmt::{Formatter, Write};
 
-/// Runtime errors.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum Error {
-    /// The runtime encountered an internal error due to an invalid state.
-    ///
-    /// An internal component has panicked, or the runtime is in the midst of
-    /// shutting down. It's unlikely this operation can be retried successfully.
-    #[error("ts_runtime in invalid state")]
-    RuntimeState,
+use kameo::{
+    Actor,
+    actor::{ActorRef, WeakActorRef},
+    error::SendError,
+};
 
-    /// An operation timed out.
-    #[error("operation timed out")]
-    Timeout,
+pub(crate) trait ResultExt {
+    type T;
+
+    /// Attach actor info to this result if it's an error.
+    fn with_actor_info(self, aref: impl Into<ActorInfo>) -> Result<Self::T, Error>;
 }
+
+impl<T, E> ResultExt for Result<T, E>
+where
+    E: Into<Error>,
+{
+    type T = T;
+
+    fn with_actor_info(self, aref: impl Into<ActorInfo>) -> Result<T, Error> {
+        self.map_err(|e| e.into().with_actor_info(aref))
+    }
+}
+
+/// Errors that may occur while executing or interacting with the runtime.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Error {
+    /// Kind of error this is.
+    pub kind: ErrorKind,
+
+    /// Rust type name of sent message that caused the error.
+    ///
+    /// May not be populated if this was not generated as a result of sending a message.
+    pub message_ty: Option<&'static str>,
+
+    /// Actor to which the message was being sent (optional).
+    ///
+    /// May not be populated if either this wasn't from an actor message, or the actor ref
+    /// wasn't available when the error was constructed.
+    pub target_actor: Option<ActorInfo>,
+}
+
+impl Error {
+    /// Attach information about a destination actor to this error.
+    ///
+    /// Typically, `aref` will be `&ActorRef`.
+    pub fn with_actor_info(self, aref: impl Into<ActorInfo>) -> Self {
+        Self {
+            target_actor: Some(aref.into()),
+            ..self
+        }
+    }
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        // format is "sending MESSAGE_TYPE to ACTOR: ERROR_DESC", the complexity is to account for
+        // independently-optional fields
+
+        if let Some(ty) = self.message_ty {
+            write!(f, "sending {ty}")?;
+
+            if self.target_actor.is_some() {
+                f.write_char(' ')?;
+            }
+        }
+
+        if let Some(actor) = &self.target_actor {
+            write!(f, "{actor}")?;
+        }
+
+        if self.message_ty.is_some() || self.target_actor.is_some() {
+            f.write_str(": ")?;
+        }
+
+        self.kind.fmt(f)
+    }
+}
+
+impl core::error::Error for Error {}
 
 impl<M, E> From<SendError<M, E>> for Error {
     fn from(err: SendError<M, E>) -> Self {
+        Self {
+            kind: err.into(),
+            message_ty: Some(core::any::type_name::<M>()),
+            target_actor: None,
+        }
+    }
+}
+
+/// Info about an actor that caused an error.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct ActorInfo {
+    /// The Rust type name of the actor.
+    pub ty: &'static str,
+
+    /// The actor's unique id.
+    pub id: kameo::actor::ActorId,
+}
+
+impl<A> From<&ActorRef<A>> for ActorInfo
+where
+    A: Actor,
+{
+    fn from(aref: &ActorRef<A>) -> Self {
+        Self {
+            ty: core::any::type_name::<A>(),
+            id: aref.id(),
+        }
+    }
+}
+
+impl<A> From<ActorRef<A>> for ActorInfo
+where
+    A: Actor,
+{
+    fn from(aref: ActorRef<A>) -> Self {
+        Self::from(&aref)
+    }
+}
+
+impl<A> From<&WeakActorRef<A>> for ActorInfo
+where
+    A: Actor,
+{
+    fn from(aref: &WeakActorRef<A>) -> Self {
+        Self {
+            ty: core::any::type_name::<A>(),
+            id: aref.id(),
+        }
+    }
+}
+
+impl<A> From<WeakActorRef<A>> for ActorInfo
+where
+    A: Actor,
+{
+    fn from(aref: WeakActorRef<A>) -> Self {
+        Self::from(&aref)
+    }
+}
+
+impl core::fmt::Display for ActorInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}({})", self.ty, self.id)
+    }
+}
+
+/// Kinds of errors that may occur while running the runtime.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ErrorKind {
+    /// An actor that was expected to be available was unreachable, probably because it
+    /// either panicked or exited. It's unlikely this operation can be retried successfully.
+    ActorGone,
+
+    /// The actor replied with an error.
+    ReplyErr,
+
+    /// The target actor's mailbox was full.
+    MailboxFull,
+
+    /// An operation timed out.
+    Timeout,
+}
+
+impl core::fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ActorGone => write!(f, "expected actor is unreachable"),
+            Self::ReplyErr => write!(f, "actor replied with an error"),
+            Self::MailboxFull => write!(f, "actor's mailbox was full"),
+            Self::Timeout => write!(f, "operation timed out"),
+        }
+    }
+}
+
+impl<M, E> From<SendError<M, E>> for ErrorKind {
+    fn from(err: SendError<M, E>) -> Self {
         match err {
-            SendError::ActorNotRunning(_)
-            | SendError::ActorStopped
-            | SendError::HandlerError(_)
-            | SendError::MailboxFull(_) => Error::RuntimeState,
-            SendError::Timeout(_) => Error::Timeout,
+            SendError::ActorNotRunning(_) | SendError::ActorStopped => ErrorKind::ActorGone,
+            SendError::HandlerError(_) => ErrorKind::ReplyErr,
+            SendError::MailboxFull(..) => ErrorKind::MailboxFull,
+            SendError::Timeout(_) => ErrorKind::Timeout,
         }
     }
 }

--- a/ts_runtime/src/lib.rs
+++ b/ts_runtime/src/lib.rs
@@ -30,7 +30,7 @@ mod route_updater;
 mod src_filter;
 
 pub(crate) use env::Env;
-pub use error::Error;
+pub use error::{Error, ErrorKind};
 
 /// The runtime for a tailscale device.
 pub struct Runtime {
@@ -87,7 +87,11 @@ impl Runtime {
         let (channel,) = self
             .netstack
             .upgrade()
-            .ok_or(Error::RuntimeState)?
+            .ok_or(Error {
+                kind: ErrorKind::ActorGone,
+                target_actor: None,
+                message_ty: None,
+            })?
             .ask(netstack_actor::GetChannel)
             .await?;
 


### PR DESCRIPTION
Re @nrc's previous error-detail-related notes. I split out the runtime error type with an `ErrorKind` and gave it fields to attach the generating actor and message type (if present), and added some more specific kinds. 

I don't have an answer for what "more detailed" looks like for `tailscale::Error` though (other than distinguishing actor-died errors from general internal errors) &mdash; @nrc do you have more on what you imagine that might look like? I'm not sure what additional caller-relevant detail motivated the suggestion.