### PR TITLE
c ffi: init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbindgen"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
+dependencies = [
+ "clap",
+ "heck",
+ "indexmap 2.13.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "tempfile",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,7 +459,7 @@ dependencies = [
  "clap",
  "globwalk",
  "serde",
- "toml",
+ "toml 1.0.6+spec-1.1.0",
 ]
 
 [[package]]
@@ -3808,6 +3827,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml"
 version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
@@ -3815,10 +3849,19 @@ dependencies = [
  "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -4281,6 +4324,17 @@ name = "ts_elixir"
 version = "0.2.0"
 dependencies = [
  "rustler",
+ "tailscale",
+ "tokio",
+ "tracing",
+ "ts_cli_util",
+]
+
+[[package]]
+name = "ts_ffi"
+version = "0.2.0"
+dependencies = [
+ "cbindgen",
  "tailscale",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "ts_disco_protocol",
     "ts_dynbitset",
     "ts_elixir/native/ts_elixir",
+    "ts_ffi",
     "ts_hexdump",
     "ts_http_util",
     "ts_keys",

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
       filter = lib.fileset.unions [
         ./deny.toml
         ./.rustfmt.toml
+        ./ts_ffi/cbindgen.toml
         ./ts_netstack_smoltcp/examples/axum_tun
         ./examples/axum
         (lib.fileset.fileFilter (file: file.hasExt "rs") ./.)
@@ -114,6 +115,25 @@
       });
 
       crates' = builtins.listToAttrs crates;
+      crates'' = crates' // {
+        ts_ffi = let
+          with_header = crates'.ts_ffi.overrideAttrs (prevAttrs: {
+            doCheck = false;
+
+            postInstall = ''
+              mkdir -p $out/include
+              cp -v ts_ffi/tailscale.h $out/include
+            '';
+          });
+
+        in with_header.overrideAttrs (prevAttrs: {
+          passthru = (prevAttrs.passthru or {} // {
+            examples = pkgs.callPackage ./ts_ffi/examples {
+              libtailscalers = with_header;
+            };
+          });
+        });
+      };
 
       workspace = pkgs.craneLib.buildPackage (deps.passthru.buildDeps // {
         pname = "tailscale-rs-wksp";
@@ -134,12 +154,14 @@
         };
       });
 
-    in crates' // ({
+    in crates'' // ({
       deps = deps;
       docs = docs;
       doc = docs;
       workspace = workspace;
       default = workspace;
+
+      libtailscalers = crates''.ts_ffi;
     });
 
   in inputs.flake-parts.lib.mkFlake { inputs = inputs; } {
@@ -258,6 +280,10 @@
 
           cargo-flamegraph
           heaptrack
+
+          # for ffi
+          gnumake
+          stdenv.cc
         ];
       };
     };

--- a/ts_ffi/.gitignore
+++ b/ts_ffi/.gitignore
@@ -1,0 +1,3 @@
+/tailscale.h
+tcp_echo
+udp_ping

--- a/ts_ffi/Cargo.toml
+++ b/ts_ffi/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "ts_ffi"
+version.workspace = true
+description = "c ffi bindings for tailscale-rs"
+categories = ["api-bindings", "network-programming"]
+keywords = ["tailscale", "c", "cbindgen", "bindings", "ffi"]
+
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+tailscale.workspace = true
+ts_cli_util.workspace = true
+
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true, features = ["release_max_level_info"] }
+
+[build-dependencies]
+cbindgen = "0.29"
+
+[lib]
+name = "tailscalers"
+crate-type = ["cdylib", "staticlib"]
+
+[lints]
+workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["cbindgen"]

--- a/ts_ffi/README.md
+++ b/ts_ffi/README.md
@@ -1,0 +1,6 @@
+# ts_ffi
+
+C bindings to `tailscale-rs`.
+
+`tailscale.h` is automatically generated in this directory when you `cargo build`. The library name
+is `tailscalers` (`../target/*/libtailscalers.{a,so}`).

--- a/ts_ffi/build.rs
+++ b/ts_ffi/build.rs
@@ -1,0 +1,19 @@
+//! Builder for `ts_ffi` invoking cbindgen.
+
+use std::{env, path::PathBuf};
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    let bindings = cbindgen::Builder::new()
+        .with_crate(crate_dir)
+        .with_config(cbindgen::Config::from_file("cbindgen.toml").unwrap())
+        .generate()
+        .unwrap();
+
+    bindings.write_to_file("tailscale.h");
+
+    let out = env::var("OUT_DIR").unwrap();
+    let out = PathBuf::from(out);
+    bindings.write_to_file(out.join("tailscale.h"));
+}

--- a/ts_ffi/cbindgen.toml
+++ b/ts_ffi/cbindgen.toml
@@ -1,0 +1,23 @@
+language = "C"
+include_guard = "TAILSCALE_H"
+cpp_compat = true
+documentation = true
+
+[export]
+prefix = "ts_"
+renaming_overrides_prefixing = true
+
+include = [
+    "sockaddr",
+    "sockaddr_in",
+    "sockaddr_in6",
+    "sockaddr_storage",
+    "in_addr",
+    "in6_addr",
+    "sa_family",
+]
+
+[export.rename]
+AF_INET = "TS_AF_INET"
+AF_INET6 = "TS_AF_INET6"
+MAX_SOCKADDR_DATA_SIZE = "TS_MAX_SOCKADDR_DATA_SIZE"

--- a/ts_ffi/examples/Makefile
+++ b/ts_ffi/examples/Makefile
@@ -1,0 +1,51 @@
+# makefile for the ts_ffi examples
+
+RUST_PROFILE := dev
+
+ifeq ($(RUST_PROFILE),dev)
+	RUST_PROFILE_DIR := debug
+else
+	RUST_PROFILE_DIR := $(RUST_PROFILE)
+endif
+
+CC := gcc
+
+# the `l:libtailscalers.a` forces linkage to the static archive to make the executables easier to call
+# (no need to futz with LD_LIBRARY_PATH with the dynamic lib)
+CFLAGS := -Wall -Wextra -Werror -O2 -I.. -l:libtailscalers.a -lpthread -lm
+
+# Windows targets the -gnu toolchain to make the build consistent (we can still use gcc rather than
+# msvc), needs explicit linkage to certain Windows-specific system libraries, and produces
+# .exe-suffixed binaries:
+ifeq ($(OS),Windows_NT)
+	RUST_TARGET := x86_64-pc-windows-gnu
+	CFLAGS += -lntdll -luserenv -lbcrypt
+	TARGET_SUFFIX := .exe
+endif
+
+# If we have an explicit target set, this is usually because it's not our default target, and we
+# need to specify a subdir in the build output dir. This approach can have false positives,
+# unfortunately, but cargo doesn't make our lives easy here wrt. figuring out where the built
+# artifacts actually went.
+ifneq ($(RUST_TARGET),)
+	RUST_TARGET_PATH := $(RUST_TARGET)/
+	RUST_TARGET_FLAG := --target $(RUST_TARGET)
+endif
+
+CFLAGS += -L../../target/$(RUST_TARGET_PATH)$(RUST_PROFILE_DIR)/
+TARGET_NAMES := udp_ping tcp_echo
+TARGETS := $(patsubst %,%$(TARGET_SUFFIX),$(TARGET_NAMES))
+
+# libtailscalers: let cargo handle build incrementality
+.PHONY: all clean libtailscalers
+
+all: $(TARGETS)
+
+clean:
+	rm -f $(TARGETS)
+
+$(TARGETS): %$(TARGET_SUFFIX): libtailscalers $(wildcard %/*.c)
+	$(CC) -o $@ $(wildcard $*/*.c) $(CFLAGS)
+	
+libtailscalers:
+	cargo build -p ts_ffi --profile $(RUST_PROFILE) $(RUST_TARGET_FLAG)

--- a/ts_ffi/examples/default.nix
+++ b/ts_ffi/examples/default.nix
@@ -1,0 +1,36 @@
+# build the examples.
+#
+# this doesn't use the makefile because it assumes nix has already built the lib, which is available
+# as `libtailscalers`.
+{
+    stdenv,
+    libtailscalers,
+}: stdenv.mkDerivation {
+    name = "ts_ffi_examples";
+    version = libtailscalers.version;
+
+    src = ./.;
+
+    CFLAGS = "-Wall -Wextra -Werror -O2 -lm -lpthread -l:libtailscalers.a -L${libtailscalers}/lib/ -I${libtailscalers}/include/";
+
+    buildPhase = ''
+        runHook preBuild
+
+        cc -o udp_ping_ udp_ping/*.c $CFLAGS
+        cc -o tcp_echo_ tcp_echo/*.c $CFLAGS
+
+        runHook postBuild
+    '';
+
+    installPhase = ''
+        runHook preInstall
+
+        mkdir -p "$out/bin"
+        cp udp_ping_ "$out/bin/udp_ping"
+        cp tcp_echo_ "$out/bin/tcp_echo"
+
+        runHook postInstall
+    '';
+
+    doCheck = false;
+}

--- a/ts_ffi/examples/tcp_echo/tcp_echo.c
+++ b/ts_ffi/examples/tcp_echo/tcp_echo.c
@@ -1,0 +1,98 @@
+/*
+ * Tailnet-bound TCP echo server.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+
+#ifdef WIN32
+#include <Winsock2.h>
+#define PTHREAD_FMT "[%llu] "
+#else
+#include <arpa/inet.h>
+#define PTHREAD_FMT "[%lu]"
+#endif
+
+#include "tailscale.h"
+
+#define USAGE \
+    "usage: tcp_echo CONFIG_PATH AUTH_TOKEN\n" \
+    "  e.g. tcp_echo test.json tskey-auth-XXX"
+
+static void* run_conn_echo(void* arg) {
+    uint8_t* buf = malloc(1024);
+    ts_tcp_stream* stream = arg;
+    pthread_t id = pthread_self();
+
+    struct ts_sockaddr remote_addr = ts_tcp_remote(stream);
+    struct ts_sockaddr_in remote_addr_in = remote_addr.sa_data.sockaddr_in;
+
+    char* addr_str = inet_ntoa(*(struct in_addr*)&remote_addr_in.sin_addr);
+
+    printf(PTHREAD_FMT "accept from %s:%u\n", id, addr_str, remote_addr_in.sin_port);
+
+    while (1) {
+        int ret = ts_tcp_recv(stream, buf, 1024 - 1);
+        if (ret == 0) {
+            printf(PTHREAD_FMT "hang up\n", id);
+            return NULL;
+        };
+        if (ret < 0) {
+            printf(PTHREAD_FMT "recv error\n", id);
+            return NULL;
+        }
+
+        buf[ret] = 0;
+        printf(PTHREAD_FMT "received %d bytes: %s\n", id, ret, buf);
+
+        int sent = ts_tcp_send(stream, buf, ret);
+        if (sent != ret) {
+            printf(PTHREAD_FMT "echo didn't complete, bailing\n", id);
+            return NULL;
+        }
+
+        printf(PTHREAD_FMT "echo\n", id);
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc != 3) {
+        puts(USAGE);
+        exit(EXIT_FAILURE);
+    }
+
+    const struct ts_device* dev = ts_init(
+        argv[1],
+        argv[2]
+    );
+    assert(dev);
+
+    struct ts_sockaddr addr = {
+        .sa_family = TS_AF_INET,
+        .sa_data = {
+            .sockaddr_in = {
+                .sin_port = 1234,
+            },
+        },
+    };
+    assert(!ts_ipv4(dev, &addr.sa_data.sockaddr_in.sin_addr));
+
+    char* addr_str = inet_ntoa(*(struct in_addr*)&addr.sa_data.sockaddr_in.sin_addr);
+    printf("listening on %s:%u\n", addr_str, 1234);
+
+    struct ts_tcp_listener* listener = ts_tcp_listen(dev, &addr);
+    assert(listener);
+
+    while (1) {
+        struct ts_tcp_stream* stream = ts_tcp_accept(listener);
+        assert(stream);
+
+        pthread_t id;
+
+        assert(!pthread_create(&id, NULL, &run_conn_echo, stream));
+    }
+}

--- a/ts_ffi/examples/udp_ping/udp_ping.c
+++ b/ts_ffi/examples/udp_ping/udp_ping.c
@@ -1,0 +1,70 @@
+/*
+ * Tailnet UDP demo that sends a ping message to a peer and prints incoming messages.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifdef WIN32
+#include <Winsock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+#include "tailscale.h"
+
+#define USAGE \
+    "usage: udp_ping CONFIG_PATH AUTH_TOKEN PEER_ADDR\n" \
+    "  e.g. udp_ping test.json tskey-auth-XXX 1.2.3.4:5678"
+
+int main(int argc, char** argv) {
+    if (argc != 4) {
+        puts(USAGE);
+        exit(EXIT_FAILURE);
+    }
+
+    const struct ts_device* dev = ts_init(
+        argv[1],
+        argv[2]
+    );
+    assert(dev);
+
+    struct ts_sockaddr addr = {
+        .sa_family = TS_AF_INET,
+        .sa_data = {
+            .sockaddr_in = {
+                .sin_port = 1234,
+            },
+        },
+    };
+    assert(!ts_ipv4(dev, &addr.sa_data.sockaddr_in.sin_addr));
+
+    char* addr_str = inet_ntoa(*(struct in_addr*)&addr.sa_data.sockaddr_in.sin_addr);
+    printf("bound to %s:%u\n", addr_str, 1234);
+
+    struct ts_udp_socket* sock = ts_udp_bind(dev, &addr);
+    assert(sock);
+
+    struct ts_sockaddr peer_addr;
+    assert(ts_parse_sockaddr(argv[3], &peer_addr) >= 0);
+
+    const char* msg = "hello from c";
+    int ret = ts_udp_sendto(sock, &peer_addr, (const uint8_t*)msg, strlen(msg));
+    assert(ret >= 0);
+    puts("sent ping, waiting for incoming");
+
+    static uint8_t BUF[1024];
+
+    while (1) {
+        ret = ts_udp_recvfrom(sock, &peer_addr, BUF, 1024 - 1);
+        assert(ret >= 0);
+
+        BUF[ret] = 0;
+        printf("received %d bytes: %s\n", ret, BUF);
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/ts_ffi/src/lib.rs
+++ b/ts_ffi/src/lib.rs
@@ -1,0 +1,157 @@
+#![allow(non_camel_case_types)]
+
+//! C FFI for tailscale-rs.
+//!
+//! # Safety
+//!
+//! All resources created by this library must be treated in accordance with the Rust
+//! borrowing and ownership rules. Keep in mind that this _requires_ all memory to be
+//! initialized before handing it into Rust-land.
+//!
+//! Null-checking is the responsibility of the caller, both on function call and return. We
+//! don't check for parameter nullity: all params are assumed non-null unless noted
+//! otherwise. Null return values are used for error signaling and must be inspected.
+//!
+//! Handles provided by this library are threadsafe -- operations will be implicitly
+//! synchronized and serialized by the runtime. The only caveat is that you cannot `deinit`
+//! or `close` a handle concurrently with other operations: this requires external
+//! synchronization.
+
+use std::{
+    ffi::{CStr, c_char},
+    sync::{LazyLock, Once},
+};
+
+mod net_types;
+mod tcp;
+mod udp;
+
+pub use net_types::{
+    AF_INET, AF_INET6, in_addr_t, in6_addr_t, sa_family_t, sockaddr, sockaddr_data, sockaddr_in,
+    sockaddr_in6,
+};
+pub use tcp::{
+    tcp_listener, tcp_stream, ts_tcp_close, ts_tcp_close_listener, ts_tcp_connect, ts_tcp_listen,
+    ts_tcp_listener_local, ts_tcp_local, ts_tcp_recv, ts_tcp_remote, ts_tcp_send,
+};
+pub use udp::{ts_udp_bind, ts_udp_close, ts_udp_recvfrom, ts_udp_sendto, udp_socket};
+
+static TOKIO_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    tracing::info!("started tokio runtime");
+
+    rt
+});
+
+type Result<T> = std::result::Result<T, Box<dyn core::error::Error + Send + Sync + 'static>>;
+
+/// A Tailscale device, also variously called a "node" or "peer".
+///
+/// A device is the unit of identity in a tailnet; it has a tailnet IP and can send and
+/// receive IP datagrams to other peers.
+pub struct device(tailscale::Device);
+
+/// Initialize a new Tailscale device.
+///
+/// `config_path` is the path to a config file on your system. It will be created if it doesn't
+/// exist.
+///
+/// `auth_token` is an optional auth token (you may pass `NULL`) that is used to authenticate the
+/// device if required. If you pass `NULL`, the credentials in `config_path` must already be
+/// authorized to make a successful connection.
+///
+/// # Safety
+///
+/// `config_path` and `auth_token` must be able to be read according to [`CStr`] rules, i.e.
+/// they must be NUL-terminated and valid for reading up to and including the NUL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ts_init(
+    config_path: *const c_char,
+    auth_token: *const c_char,
+) -> Option<Box<device>> {
+    static TRACING_ONCE: Once = Once::new();
+    TRACING_ONCE.call_once(ts_cli_util::init_tracing);
+
+    async fn _ts_init(config_path: &CStr, auth_token: Option<&CStr>) -> Result<device> {
+        let config_path = config_path.to_str()?.to_string();
+        tracing::info!(config_path);
+
+        let auth_token = auth_token
+            .and_then(|x| x.to_str().ok())
+            .map(ToOwned::to_owned);
+
+        let dev = tailscale::Device::new(
+            &tailscale::Config {
+                key_state: tailscale::load_key_file(&config_path, Default::default()).await?,
+                ..Default::default()
+            },
+            auth_token,
+        )
+        .await?;
+
+        Result::<_>::Ok(device(dev))
+    }
+
+    // SAFETY: ensured by function precondition
+    unsafe {
+        TOKIO_RUNTIME.block_on(_ts_init(
+            CStr::from_ptr(config_path),
+            if auth_token.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(auth_token))
+            },
+        ))
+    }
+    .inspect_err(|e| {
+        tracing::error!(err = %e, "ts_init failed");
+    })
+    .ok()
+    .map(Box::new)
+}
+
+/// Deinitialize and shut down a Tailscale device.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_deinit(dev: Box<device>) {
+    drop(dev)
+}
+
+/// Get the IPv4 address of the Tailscale node, blocking until it's available.
+///
+/// Returns a negative number on error.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_ipv4(dev: &device, dst: &mut in_addr_t) -> isize {
+    let addr = match TOKIO_RUNTIME.block_on(dev.0.ipv4()) {
+        Ok(addr) => addr,
+        Err(e) => {
+            tracing::error!(error = %e, "getting ipv4");
+            return -1;
+        }
+    };
+
+    dst.0 = addr.octets();
+
+    0
+}
+
+/// Get the IPv6 address of the Tailscale node, blocking until it's available.
+///
+/// Returns a negative number on error.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_ipv6(dev: &device, dst: &mut in6_addr_t) -> isize {
+    let addr = match TOKIO_RUNTIME.block_on(dev.0.ipv6()) {
+        Ok(addr) => addr,
+        Err(e) => {
+            tracing::error!(error = %e, "getting ipv6");
+            return -1;
+        }
+    };
+
+    dst.0 = addr.segments();
+
+    0
+}

--- a/ts_ffi/src/net_types.rs
+++ b/ts_ffi/src/net_types.rs
@@ -1,0 +1,370 @@
+//! Platform-independent recapitulation of `<sys/socket.h>`
+//!
+//! This is done to avoid platform-specific dependencies on the way `<sys/socket.h>` is
+//! arranged and on availability of it on your system. Notably, Rust's `libc` crate does not
+//! provide a useful `sockaddr` type or variants on Windows, and further, the functionality
+//! provided by this library doesn't logically represent a dependency on libc itself. The
+//! interface here attempts to be compatible to make things easy, but these types are
+//! specifically for interfacing with the _tailscale_ libraries, not your system, so it's ok
+//! if things diverge.
+
+use std::{
+    ffi::{CStr, c_char},
+    fmt::{Debug, Formatter},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+};
+
+/// Socket address family.
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct sa_family_t(pub u16);
+
+impl Debug for sa_family_t {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            AF_INET => write!(f, "AF_INET"),
+            AF_INET6 => write!(f, "AF_INET6"),
+            _ => write!(f, "sa_family_t({})", self.0),
+        }
+    }
+}
+
+/// IPv4 address family.
+pub const AF_INET: sa_family_t = sa_family_t(2);
+/// IPv6 address family.
+pub const AF_INET6: sa_family_t = sa_family_t(23);
+
+/// IPv4 address.
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct in_addr_t(pub [u8; 4]);
+
+impl From<&in_addr_t> for Ipv4Addr {
+    fn from(value: &in_addr_t) -> Self {
+        Ipv4Addr::from_octets(value.0)
+    }
+}
+
+impl From<in_addr_t> for Ipv4Addr {
+    fn from(value: in_addr_t) -> Self {
+        Ipv4Addr::from_octets(value.0)
+    }
+}
+
+impl From<&Ipv4Addr> for in_addr_t {
+    fn from(value: &Ipv4Addr) -> Self {
+        Self(value.octets())
+    }
+}
+
+impl From<Ipv4Addr> for in_addr_t {
+    fn from(value: Ipv4Addr) -> Self {
+        Self(value.octets())
+    }
+}
+
+impl Debug for in_addr_t {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Ipv4Addr::from(self).fmt(f)
+    }
+}
+
+/// IPv6 address.
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct in6_addr_t(pub [u16; 8]);
+
+impl Debug for in6_addr_t {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Ipv6Addr::from(*self).fmt(f)
+    }
+}
+
+impl From<in6_addr_t> for Ipv6Addr {
+    fn from(value: in6_addr_t) -> Self {
+        Ipv6Addr::from(value.0)
+    }
+}
+
+impl From<&in6_addr_t> for Ipv6Addr {
+    fn from(value: &in6_addr_t) -> Self {
+        Ipv6Addr::from(value.0)
+    }
+}
+
+impl From<Ipv6Addr> for in6_addr_t {
+    fn from(value: Ipv6Addr) -> Self {
+        Self(value.segments())
+    }
+}
+
+impl From<&Ipv6Addr> for in6_addr_t {
+    fn from(value: &Ipv6Addr) -> Self {
+        Self(value.segments())
+    }
+}
+
+/// Socket address.
+///
+/// Meant for compat between `<sys/socket.h>` `sockaddr`s and tailscale sockets. On most
+/// platforms, you should be able to cast directly from the sockaddr types into this struct,
+/// though this isn't guaranteed if your libc makes unusual choices.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct sockaddr {
+    /// Address family.
+    ///
+    /// Only `AF_INET` and `AF_INET6` are supported.
+    pub sa_family: sa_family_t,
+
+    /// The address info payload for this `ts_sockaddr` type.
+    pub sa_data: sockaddr_data,
+}
+
+impl Debug for sockaddr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self.sa_family {
+            // SAFETY: ensured by sa_family = AF_INET
+            AF_INET => unsafe { &self.sa_data.sockaddr_in }.fmt(f),
+            // SAFETY: ensured by sa_family = AF_INET6
+            AF_INET6 => unsafe { &self.sa_data.sockaddr_in6 }.fmt(f),
+
+            unknown => f
+                .debug_struct("sockaddr")
+                .field("sa_family", &unknown)
+                .finish_non_exhaustive(),
+        }
+    }
+}
+
+/// Address-family-specific payload for a [`sockaddr`].
+///
+/// Only `AF_INET` and `AF_INET6` are supported.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union sockaddr_data {
+    /// IPv4 sockaddr payload.
+    pub sockaddr_in: sockaddr_in,
+    /// IPv6 sockaddr payload.
+    pub sockaddr_in6: sockaddr_in6,
+}
+
+impl TryFrom<sockaddr> for SocketAddr {
+    type Error = ();
+
+    fn try_from(sockaddr: sockaddr) -> Result<Self, Self::Error> {
+        sockaddr.try_into()
+    }
+}
+
+impl TryFrom<&sockaddr> for SocketAddr {
+    type Error = ();
+
+    fn try_from(sockaddr: &sockaddr) -> Result<Self, Self::Error> {
+        match sockaddr.sa_family {
+            AF_INET => {
+                // SAFETY: ensured by sa_family = AF_INET
+                let sin = unsafe { &sockaddr.sa_data.sockaddr_in };
+                let addrv4: SocketAddrV4 = sin.into();
+
+                Ok(addrv4.into())
+            }
+            AF_INET6 => {
+                // SAFETY: ensured by sa_family = AF_INET6
+                let sin6 = unsafe { &sockaddr.sa_data.sockaddr_in6 };
+                let addrv6: SocketAddrV6 = sin6.into();
+
+                Ok(addrv6.into())
+            }
+            invalid_af => {
+                tracing::error!(?invalid_af);
+                Err(())
+            }
+        }
+    }
+}
+
+impl From<SocketAddr> for sockaddr {
+    fn from(value: SocketAddr) -> Self {
+        match value {
+            SocketAddr::V4(addr) => sockaddr {
+                sa_family: AF_INET,
+
+                sa_data: sockaddr_data {
+                    sockaddr_in: addr.into(),
+                },
+            },
+            SocketAddr::V6(addr) => sockaddr {
+                sa_family: AF_INET6,
+
+                sa_data: sockaddr_data {
+                    sockaddr_in6: addr.into(),
+                },
+            },
+        }
+    }
+}
+
+/// C-compatible IPv4 socket address.
+#[derive(Copy, Clone, Debug)]
+#[repr(C)]
+pub struct sockaddr_in {
+    /// Port number.
+    pub sin_port: u16,
+    /// IPv4 address.
+    pub sin_addr: in_addr_t,
+}
+
+impl From<&SocketAddrV4> for sockaddr_in {
+    fn from(addr: &SocketAddrV4) -> Self {
+        sockaddr_in {
+            sin_addr: addr.ip().into(),
+            sin_port: addr.port(),
+        }
+    }
+}
+
+impl From<SocketAddrV4> for sockaddr_in {
+    fn from(addr: SocketAddrV4) -> Self {
+        (&addr).into()
+    }
+}
+
+impl From<sockaddr_in> for SocketAddrV4 {
+    fn from(value: sockaddr_in) -> Self {
+        (&value).into()
+    }
+}
+
+impl From<&sockaddr_in> for SocketAddrV4 {
+    fn from(value: &sockaddr_in) -> Self {
+        SocketAddrV4::new(value.sin_addr.into(), value.sin_port)
+    }
+}
+
+/// C-compatible IPv6 socket address.
+#[derive(Copy, Clone, Debug)]
+#[repr(C)]
+pub struct sockaddr_in6 {
+    /// Port number.
+    pub sin6_port: u16,
+    /// Flow label.
+    pub sin6_flowinfo: u32,
+    /// IPv6 address.
+    pub sin6_addr: in6_addr_t,
+    /// Scope id.
+    pub sin6_scope_id: u32,
+}
+
+impl From<&SocketAddrV6> for sockaddr_in6 {
+    fn from(addr: &SocketAddrV6) -> Self {
+        sockaddr_in6 {
+            sin6_addr: addr.ip().into(),
+            sin6_port: addr.port(),
+            sin6_scope_id: addr.scope_id(),
+            sin6_flowinfo: addr.flowinfo(),
+        }
+    }
+}
+
+impl From<SocketAddrV6> for sockaddr_in6 {
+    fn from(addr: SocketAddrV6) -> Self {
+        (&addr).into()
+    }
+}
+
+impl From<&sockaddr_in6> for SocketAddrV6 {
+    fn from(sin6: &sockaddr_in6) -> Self {
+        SocketAddrV6::new(
+            sin6.sin6_addr.into(),
+            sin6.sin6_port,
+            sin6.sin6_flowinfo,
+            sin6.sin6_flowinfo,
+        )
+    }
+}
+
+impl From<sockaddr_in6> for SocketAddrV6 {
+    fn from(sin6: sockaddr_in6) -> Self {
+        (&sin6).into()
+    }
+}
+
+/// Parse a [`sockaddr`] from a C string.
+///
+/// This helper is provided to avoid the need to use `inet_pton`, `getaddrinfo`, and the
+/// like if you know you have a string in a conventional `$ADDR:$PORT` shape.
+///
+/// # Safety
+///
+/// `s` must be able to be read according to [`CStr`] rules, i.e.
+/// it must be NUL-terminated and valid for reading up to and including the NUL.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_parse_sockaddr(s: *const c_char, addr: &mut sockaddr) -> isize {
+    // SAFETY: ensured by function precondition
+    let Ok(s) = (unsafe { CStr::from_ptr(s) }).to_str() else {
+        tracing::error!("bad utf8");
+        return -1;
+    };
+
+    let parsed = match s.parse::<SocketAddr>() {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            tracing::error!(error = %e, "invalid addr");
+            return -1;
+        }
+    };
+
+    *addr = parsed.into();
+
+    0
+}
+
+/// Parse an IP address from a string into a [`sockaddr`], setting `sa_family` and the
+/// address field. The port is zeroed, and flow info and scope id are left unchanged.
+///
+/// This is a convenience to allow easily constructing a `sockaddr` with a string IP,
+/// but using a port from a different source.
+///
+/// # Safety
+///
+/// `s` must be able to be read according to [`CStr`] rules, i.e.
+/// it must be NUL-terminated and valid for reading up to and including the NUL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ts_parse_ip(s: *const c_char, addr: &mut sockaddr) -> isize {
+    // SAFETY: ensured by function precondition
+    let Ok(s) = (unsafe { CStr::from_ptr(s) }).to_str() else {
+        tracing::error!("bad utf8");
+        return -1;
+    };
+
+    let parsed = match s.parse::<IpAddr>() {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            tracing::error!(error = %e, "invalid addr");
+            return -1;
+        }
+    };
+
+    *addr = SocketAddr::from((parsed, 0)).into();
+
+    0
+}
+
+/// Convenience to set a port on a [`sockaddr`] regardless of its `sa_family`.
+///
+/// Returns a negative number if `sa_family` is invalid.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_sockaddr_set_port(addr: &mut sockaddr, port: u16) -> isize {
+    match addr.sa_family {
+        AF_INET => {
+            unsafe { addr.sa_data.sockaddr_in }.sin_port = port;
+            0
+        }
+        AF_INET6 => {
+            unsafe { addr.sa_data.sockaddr_in6 }.sin6_port = port;
+            0
+        }
+        _ => -1,
+    }
+}

--- a/ts_ffi/src/tcp.rs
+++ b/ts_ffi/src/tcp.rs
@@ -1,0 +1,133 @@
+use crate::TOKIO_RUNTIME;
+
+/// A Tailscale TCP listener handle.
+pub struct tcp_listener(tailscale::TcpListener);
+
+/// A Tailscale TCP stream handle.
+pub struct tcp_stream(tailscale::TcpStream);
+
+/// Start a TCP listener on the given `addr`.
+///
+/// Returns null if the listener couldn't be created.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_tcp_listen(
+    dev: &crate::device,
+    addr: &crate::sockaddr,
+) -> Option<Box<tcp_listener>> {
+    let addr = addr.try_into().ok()?;
+
+    match TOKIO_RUNTIME.block_on(dev.0.tcp_listen(addr)) {
+        Ok(sock) => Some(Box::new(tcp_listener(sock))),
+        Err(e) => {
+            tracing::error!(err = %e, "tcp listen");
+            None
+        }
+    }
+}
+
+/// Accept an incoming connection on the given listener.
+///
+/// Returns null if there was an error.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_tcp_accept(listener: &tcp_listener) -> Option<Box<tcp_stream>> {
+    match listener.0.accept_blocking() {
+        Ok(sock) => Some(Box::new(tcp_stream(sock))),
+        Err(e) => {
+            tracing::error!(err = %e, "tcp accept");
+            None
+        }
+    }
+}
+
+/// Get the local endpoint `listener` is listening on.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_tcp_listener_local(listener: &tcp_listener) -> crate::sockaddr {
+    listener.0.local_endpoint().into()
+}
+
+/// Close the specified socket.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_tcp_close_listener(sock: Box<tcp_listener>) {
+    drop(sock)
+}
+
+/// Open a TCP connection to the specified `remote`.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_tcp_connect(
+    dev: &crate::device,
+    remote: &crate::sockaddr,
+) -> Option<Box<tcp_stream>> {
+    let addr = remote.try_into().ok()?;
+
+    match TOKIO_RUNTIME.block_on(dev.0.tcp_connect(addr)) {
+        Ok(sock) => Some(Box::new(tcp_stream(sock))),
+        Err(e) => {
+            tracing::error!(err = %e, "binding sock");
+            None
+        }
+    }
+}
+
+/// Send bytes to the specified socket, blocking until at least one byte is sent.
+///
+/// Returns the number of bytes written, or a negative number if an error occurred. This is
+/// guaranteed to be less than or equal to `len`.
+///
+/// # Safety
+///
+/// `buf` must be safe to convert into a Rust slice of length `len` (see
+/// [`core::slice::from_raw_parts`]).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ts_tcp_send(stream: &tcp_stream, buf: *const u8, len: usize) -> isize {
+    // SAFETY: ensured by function precondition
+    let b = unsafe { core::slice::from_raw_parts(buf, len) };
+
+    match stream.0.send_blocking(b) {
+        Err(e) => {
+            tracing::error!(err = %e, "tcp accept");
+            -1
+        }
+        Ok(n) => n as _,
+    }
+}
+
+/// Receive bytes from the specified socket, blocking until at least one byte is received.
+///
+/// Returns the number of bytes read, or a negative number if an error occurred. This is
+/// guaranteed to be less than or equal to `len`.
+///
+/// # Safety
+///
+/// `buf` must be safe to convert into a mutable Rust slice of length `len` (see
+/// [`core::slice::from_raw_parts_mut`]).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ts_tcp_recv(stream: &tcp_stream, buf: *mut u8, len: usize) -> isize {
+    // SAFETY: ensured by function precondition
+    let b = unsafe { core::slice::from_raw_parts_mut(buf, len) };
+
+    match stream.0.recv_blocking(b) {
+        Err(e) => {
+            tracing::error!(err = %e, "tcp accept");
+            -1
+        }
+        Ok(read) => read as isize,
+    }
+}
+
+/// Get the local endpoint for this TCP stream.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_tcp_local(stream: &tcp_stream) -> crate::sockaddr {
+    stream.0.local_endpoint().into()
+}
+
+/// Get the remote endpoint this TCP stream is connected to.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_tcp_remote(stream: &tcp_stream) -> crate::sockaddr {
+    stream.0.remote_endpoint().into()
+}
+
+/// Close the specified socket.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_tcp_close(sock: Box<tcp_stream>) {
+    drop(sock);
+}

--- a/ts_ffi/src/udp.rs
+++ b/ts_ffi/src/udp.rs
@@ -1,0 +1,103 @@
+use crate::TOKIO_RUNTIME;
+
+/// A Tailscale UDP socket handle.
+pub struct udp_socket(tailscale::UdpSocket);
+
+/// Bind a UDP socket on `addr`.
+///
+/// Returns null if an error occurred.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_udp_bind(
+    dev: &crate::device,
+    addr: &crate::sockaddr,
+) -> Option<Box<udp_socket>> {
+    let addr = addr.try_into().ok()?;
+
+    match TOKIO_RUNTIME.block_on(dev.0.udp_bind(addr)) {
+        Ok(sock) => Some(Box::new(udp_socket(sock))),
+        Err(e) => {
+            tracing::error!(error = %e, "binding udp socket");
+            None
+        }
+    }
+}
+
+/// Close the specified UDP socket.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_udp_close(sock: Box<udp_socket>) {
+    drop(sock);
+}
+
+/// Send data over the specified socket to the given `addr`.
+///
+/// Returns a negative number if an error occurred.
+///
+/// # Safety
+///
+/// `buf` must be safe to convert into a Rust slice of length `len` (see
+/// [`core::slice::from_raw_parts`]).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ts_udp_sendto(
+    sock: &udp_socket,
+    addr: &crate::sockaddr,
+    msg: *const u8,
+    len: usize,
+) -> isize {
+    // SAFETY: ensured by function precondition
+    let msg = unsafe { core::slice::from_raw_parts(msg, len) };
+
+    let Ok(addr) = addr.try_into() else {
+        return -1;
+    };
+
+    if let Err(e) = sock.0.send_to_blocking(addr, msg) {
+        tracing::error!(err = %e, "udp_send failed");
+        return -1;
+    }
+
+    0
+}
+
+/// Receive a packet from the socket.
+///
+/// `addr` may be `None` (null) if the sender's address isn't needed.
+///
+/// Returns the length of the packet, or a negative number on error. This is guaranteed to
+/// be less than or equal to `len`.
+///
+/// # Safety
+///
+/// `buf` must be safe to convert into a mutable Rust slice of length `len` (see
+/// [`core::slice::from_raw_parts_mut`]).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ts_udp_recvfrom(
+    sock: &udp_socket,
+    addr: Option<&mut crate::sockaddr>,
+    buf: *mut u8,
+    len: usize,
+) -> isize {
+    // SAFETY: ensured by function precondition
+    let buf = unsafe { core::slice::from_raw_parts_mut(buf, len) };
+
+    match sock.0.recv_from_blocking(buf) {
+        Err(e) => {
+            tracing::error!(err = %e, "udp_recv failed");
+            -1
+        }
+        Ok((who, len)) => {
+            tracing::trace!(%who);
+
+            if let Some(addr) = addr {
+                *addr = who.into();
+            }
+
+            len as _
+        }
+    }
+}
+
+/// Get the local endpoint to which the socket is bound.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_udp_local(sock: &udp_socket) -> crate::sockaddr {
+    sock.0.local_endpoint().into()
+}


### PR DESCRIPTION
C bindings similar to the other languages. 

A header file (`tailscale.h`) is auto-generated during the build using `cbindgen`. I currently have it `.gitignore`d out, though that does mean it doesn't appear in the diff here.

<details>
<summary>current <code>tailscale.h</code> contents</summary>

```c
#ifndef TAILSCALE_H
#define TAILSCALE_H

#include <stdarg.h>
#include <stdbool.h>
#include <stdint.h>
#include <stdlib.h>

/**
 * A tailscale device, also variously called a "node" or "peer".
 *
 * A device is the unit of identity in a tailnet; it has a tailnet IP and can send and
 * receive IP datagrams to other peers.
 */
typedef struct ts_device ts_device;

/**
 * A tailscale TCP listener handle.
 */
typedef struct ts_tcp_listener ts_tcp_listener;

/**
 * A tailscale TCP stream handle.
 */
typedef struct ts_tcp_stream ts_tcp_stream;

/**
 * A tailscale UDP socket handle.
 */
typedef struct ts_udp_socket ts_udp_socket;

/**
 * IPv4 address.
 */
typedef uint8_t ts_in_addr_t[4];

/**
 * IPv6 address.
 */
typedef uint16_t ts_in6_addr_t[8];

/**
 * Alias defining the socket address family.
 */
typedef uint16_t ts_sa_family_t;

/**
 * C-compatible IPv4 address.
 */
typedef struct ts_sockaddr_in {
  /**
   * Port number.
   */
  uint16_t sin_port;
  /**
   * IPv4 address.
   */
  ts_in_addr_t sin_addr;
} ts_sockaddr_in;

/**
 * C-compatible IPv6 address.
 */
typedef struct ts_sockaddr_in6 {
  /**
   * Port number.
   */
  uint16_t sin6_port;
  /**
   * Flow label.
   */
  uint32_t sin6_flowinfo;
  /**
   * IPv6 address.
   */
  ts_in6_addr_t sin6_addr;
  /**
   * Scope id.
   */
  uint32_t sin6_scope_id;
} ts_sockaddr_in6;

/**
 * Address-family-specific payload for a [`sockaddr`].
 *
 * Only `AF_INET` and `AF_INET6` are supported.
 */
typedef union ts_sockaddr_data {
  /**
   * IPv4 sockaddr payload.
   */
  struct ts_sockaddr_in sockaddr_in;
  /**
   * IPv6 sockaddr payload.
   */
  struct ts_sockaddr_in6 sockaddr_in6;
} ts_sockaddr_data;

/**
 * Socket address.
 *
 * Meant for compat between `<sys/socket.h>` `sockaddr`s and tailscale sockets. On most
 * platforms, you should be able to cast directly from the sockaddr types into this struct,
 * though this isn't guaranteed if your libc makes unusual choices.
 */
typedef struct ts_sockaddr {
  /**
   * Address family.
   *
   * Only `AF_INET` and `AF_INET6` are supported.
   */
  ts_sa_family_t sa_family;
  /**
   * The address info payload for this `ts_sockaddr` type.
   */
  union ts_sockaddr_data sa_data;
} ts_sockaddr;

/**
 * IPv4 address family.
 */
#define TS_AF_INET 2

/**
 * IPv6 address family.
 */
#define TS_AF_INET6 23

#ifdef __cplusplus
extern "C" {
#endif // __cplusplus

/**
 * Initialize a new tailscale device.
 *
 * `config_path` is the path to a config file on your system. It will be created if it doesn't
 * exist.
 *
 * `auth_token` is an optional auth token (you may pass `NULL`) that is used to authenticate the
 * device if required.
 *
 * # Safety
 *
 * `config_path` and `auth_token` must be able to be read according to [`CStr`] rules, i.e.
 * they must be nul-terminated and valid for reading up to the nul-terminator.
 */
struct ts_device *ts_init(const char *config_path, const char *auth_token);

/**
 * Deinitialize and shut down a tailscale device.
 */
void ts_deinit(struct ts_device *dev);

/**
 * Get the IPv4 address of the Tailscale node, blocking until it's available.
 *
 * Returns a negative number on error.
 */
intptr_t ts_ipv4(const struct ts_device *dev, ts_in_addr_t *dst);

/**
 * Get the IPv6 address of the Tailscale node, blocking until it's available.
 *
 * Returns a negative number on error.
 */
intptr_t ts_ipv6(const struct ts_device *dev, ts_in6_addr_t *dst);

/**
 * Parse a [`sockaddr`] from a C string.
 *
 * This helper is provided to avoid the need to use `inet_pton`, `getaddrinfo` and the like
 * if you know you have a string in a conventional `$ADDR:$PORT` shape.
 *
 * # Safety
 *
 * `s` must be able to be read according to [`CStr`] rules, i.e.
 * it must be nul-terminated and valid for reading up to the nul-terminator.
 */
intptr_t ts_parse_sockaddr(const char *s, struct ts_sockaddr *addr);

/**
 * Parse an IP address from a string into a [`sockaddr`], setting `sa_family` and the
 * address field. The port is zeroed, and flow info and scope id are left unchanged.
 *
 * This is a convenience to allow easily constructing a `sockaddr` with a string IP,
 * but using a port from a different source.
 *
 * # Safety
 *
 * `s` must be able to be read according to [`CStr`] rules, i.e.
 * it must be nul-terminated and valid for reading up to the nul-terminator.
 */
intptr_t ts_parse_ip(const char *s, struct ts_sockaddr *addr);

/**
 * Convenience to set a port on a [`sockaddr`] regardless of its `sa_family`.
 *
 * Returns a negative number if `sa_family` is invalid.
 */
intptr_t ts_sockaddr_set_port(struct ts_sockaddr *addr, uint16_t port);

/**
 * Start a TCP listener on the given `addr`.
 *
 * Returns null if the listener couldn't be created.
 */
struct ts_tcp_listener *ts_tcp_listen(const struct ts_device *dev, const struct ts_sockaddr *addr);

/**
 * Accept an incoming connection on the given listener.
 *
 * Returns null if there was an error.
 */
struct ts_tcp_stream *ts_tcp_accept(const struct ts_tcp_listener *listener);

/**
 * Get the local endpoint `listener` is listening on.
 */
struct ts_sockaddr ts_tcp_listener_local(const struct ts_tcp_listener *listener);

/**
 * Close the specified socket.
 */
void ts_tcp_close_listener(struct ts_tcp_listener *sock);

/**
 * Open a tcp connection to the specified `remote`.
 */
struct ts_tcp_stream *ts_tcp_connect(const struct ts_device *dev, const struct ts_sockaddr *remote);

/**
 * Send bytes to the specified socket, blocking until at least one byte is sent.
 *
 * Returns the number of bytes written, or a negative number if an error occurred. This is
 * guaranteed to be less than or equal to `len`.
 *
 * # Safety
 *
 * `buf` must be safe to convert into a Rust slice of length `len` (see
 * [`core::slice::from_raw_parts`]).
 */
intptr_t ts_tcp_send(const struct ts_tcp_stream *stream, const uint8_t *buf, uintptr_t len);

/**
 * Receive bytes from the specified socket, blocking until at least one byte is received.
 *
 * Returns the number of bytes read, or a negative number if an error occurred. This is
 * guaranteed to be less than or equal to `len`.
 *
 * # Safety
 *
 * `buf` must be safe to convert into a mutable Rust slice of length `len` (see
 * [`core::slice::from_raw_parts_mut`]).
 */
intptr_t ts_tcp_recv(const struct ts_tcp_stream *stream, uint8_t *buf, uintptr_t len);

/**
 * Get the local endpoint for this TCP stream.
 */
struct ts_sockaddr ts_tcp_local(const struct ts_tcp_stream *stream);

/**
 * Get the remote endpoint this TCP stream is connected to.
 */
struct ts_sockaddr ts_tcp_remote(const struct ts_tcp_stream *stream);

/**
 * Close the specified socket.
 */
void ts_tcp_close(struct ts_tcp_stream *sock);

/**
 * Bind a UDP socket on `addr`.
 *
 * Returns null if an error occurred.
 */
struct ts_udp_socket *ts_udp_bind(const struct ts_device *dev, const struct ts_sockaddr *addr);

/**
 * Close the specified UDP socket.
 */
void ts_udp_close(struct ts_udp_socket *sock);

/**
 * Send data over the specified socket to the given `addr`.
 *
 * Returns a negative number if an error occurred.
 *
 * # Safety
 *
 * `buf` must be safe to convert into a Rust slice of length `len` (see
 * [`core::slice::from_raw_parts`]).
 */
intptr_t ts_udp_sendto(const struct ts_udp_socket *sock,
                       const struct ts_sockaddr *addr,
                       const uint8_t *msg,
                       uintptr_t len);

/**
 * Receive a packet from the socket.
 *
 * `addr` may be `None` (null) if the sender's address isn't needed.
 *
 * Returns the length of the packet, or a negative number on error. This is guaranteed to
 * be less than or equal to `len`.
 *
 * # Safety
 *
 * `buf` must be safe to convert into a mutable Rust slice of length `len` (see
 * [`core::slice::from_raw_parts_mut`]).
 */
intptr_t ts_udp_recvfrom(const struct ts_udp_socket *sock,
                         struct ts_sockaddr *addr,
                         uint8_t *buf,
                         uintptr_t len);

/**
 * Get the local endpoint to which the socket is bound.
 */
struct ts_sockaddr ts_udp_local(const struct ts_udp_socket *sock);

#ifdef __cplusplus
}  // extern "C"
#endif  // __cplusplus

#endif  /* TAILSCALE_H */
```

</details>

## safety and ffi approach

Review note: `unsafe fn` means the function would be unsafe to call _from rust_, not that there are invariants that need to hold across an FFI boundary. This can be a bit unintuitive; a function like `extern "C" fn do_something(arg: &mut i32)` is completely safe to call from rust (and hence positively should not be marked `unsafe`), but has relevant invariants to uphold in its C translation `void do_something(int32_t* arg)`: the pointer must be non-null, aligned, valid for read and write for the extent of `size_of::<i32>()`, and initialized. Calling `do_something(&mut arg)` from rust means that those invariants are implicitly maintained by the compiler, so the function is safe. The C caller needs to ensure them, but this isn't strictly a _safety_ issue from the rust perspective, as what rust means by `unsafe` and the conventional "Safety" section of a function rustdoc are rust-specific terms of art. The invariants the C caller needs to uphold are documented in some cases but left implicit where they're obvious from the perspective of conventional C api design. Notably, other than null-checking, none of the ref-related invariants can be checked at runtime, and nullity checks greatly inflate the code, so null checking is left up to the caller.

I use ref arguments where possible, which automatically get converted to pointers in the C bindings. `Option<&[mut] T>` accepts a nullable pointer on the C side. Resource types (sockets and `ts_device`) are `Box`ed: we own the allocation, which is destroyed with `*deinit` and `*close` function calls. `Box`es are also converted into pointers automatically on the C side. I use a mix of negative int return with out params and nullable return pointers for error signaling as appropriate for each function. There are no error numbers defined right now, an error return is always `-1`.

## `sockaddr*`

Rather than passing strings for socket addrs as I had been doing before, this emulates the `<sys/socket.h>` `sockaddr*` types, with the optimistic intent that the layouts be the same, so that users can cast freely back and forth to our `ts_sockaddr`. If they're not the same because your system `<sys/socket.h>` does something differently, the current stance is that it's on the user to rectify that and handle converting to our `ts_sockaddr` types manually. I think this is a good compromise that lets us optimistically support most platforms while avoiding a bunch of build-time logic and dependencies to (heuristically) attempt to figure out the target platform's sockaddr layout.

If you haven't seen these before, the idea is that `sockaddr` looks like this:

```c
struct sockaddr {
    sa_family_t sa_family;
    uint8_t     sa_data[];
}
```

Which functions as a tagged union over a number of socket-specific data types with different address families:

```c
struct sockaddr_in {
    sa_family_t sin_family;
    uint16_t    sin_port;
    in_addr_t   sin_addr;
}
```

The `sockaddr` type is used as a minimal common struct to inspect the family (e.g. `AF_INET`) to discover what type of socket it is and cast the sockaddr to the relevant socket type (here `sockaddr_in`). This approach doesn't translate across the FFI boundary very well, as flexible array members/Rust's dynamically sized types aren't compatible. So instead, I went with a layout-compatible `union`-based approach, since we know that the only two address families tailscale will ever need to support are `AF_INET` and `AF_INET6`. I say layout-compatible, but I would love more eyes on that to double-check that struct-of-union is actually layout-equivalent to the `sockaddr_*` types from `<sys/socket.h>`. I believe so, but also know that padding doesn't necessarily always behave as you might expect, just looking for a sanity check.