### PR TITLE
ts_control, ts_control_serde: small logging fixes

### DIFF
--- a/ts_control/src/tokio/register.rs
+++ b/ts_control/src/tokio/register.rs
@@ -89,6 +89,12 @@ pub async fn register(
     tracing::debug!(%status, "received registration response");
 
     if !status.is_success() {
+        // Attempt to collect the body to log the error, truncating to prevent spamming the logs.
+        let mut body = response.collect_bytes().await.unwrap_or_default();
+        body.truncate(512);
+        let body = core::str::from_utf8(&body).unwrap_or("<invalid utf8>");
+        tracing::error!(%body, %status, "registration failed");
+
         return Err(RegistrationError::RegistrationFailed(status.as_u16()));
     }
 

--- a/ts_control_noise/src/io.rs
+++ b/ts_control_noise/src/io.rs
@@ -99,7 +99,7 @@ impl<Conn: AsyncRead> AsyncRead for NoiseIo<Conn> {
                     // reached EOF, or the ReadBuf had a capacity of 0 - in either case, forward
                     // the result to the caller to handle.
                     if *bytes_read == 0 {
-                        tracing::warn!("ReadHeader: got EOF when reading packet header");
+                        tracing::warn!("poll_read: ReadHeader: got EOF when reading packet header");
                         return Poll::Ready(Ok(()));
                     }
 
@@ -128,7 +128,9 @@ impl<Conn: AsyncRead> AsyncRead for NoiseIo<Conn> {
                     // reached EOF, or the ReadBuf had a capacity of 0 - in either case, forward
                     // the result to the caller to handle.
                     if bytes_read == 0 {
-                        tracing::warn!("poll_read: ReadHeader: got EOF when reading packet body");
+                        tracing::warn!(
+                            "poll_read: ReadBody({ty:?}): got EOF when reading packet body"
+                        );
                         return Poll::Ready(Ok(()));
                     }
 
@@ -157,11 +159,10 @@ impl<Conn: AsyncRead> AsyncRead for NoiseIo<Conn> {
                                 Ok(plaintext_len) => {
                                     let packet = body.split_to(plaintext_len);
                                     tracing::trace!(
-                                        "poll_read: ReadBody({ty:?}): received {plaintext_len} bytes from control"
-                                    );
-                                    tracing::trace!(
+                                        bytes_received = plaintext_len,
                                         "poll_read: ReadBody({ty:?}): received packet:\n{}",
-                                        body.iter()
+                                        packet
+                                            .iter()
                                             .hexdump(Case::Lower)
                                             .flatten()
                                             .collect::<String>()


### PR DESCRIPTION
Logs registration errors, aligns a few log message formats in poll_read, and hexdumps the `packet` instead of the `body` in the `AsyncReadState::ReadBody` arm - we want to see the packet plaintext, not the auth tag (which is all `body` will contain after the `split_to(plaintext_len)`).