### PR TITLE
ts_control{_noise, _serde}, ts_http_util: better C2N ping handling, log fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4318,6 +4318,7 @@ dependencies = [
  "futures",
  "http",
  "http-body-util",
+ "httparse",
  "hyper",
  "hyper-util",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ heapless = "0.9"
 hex = "0.4"
 hkdf = { version = "0.12", features = ["std"] }
 http = "1.4"
+httparse = "1"
 http-body-util = "0.1"
 hyper = { version = "1", default-features = false, features = ["http2"] }
 hyper-util = { version = "0.1", default-features = false, features = ["http1"] }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1,3 +1,4 @@
+
 # cargo-vet config file
 
 [cargo-vet]
@@ -25,17 +26,9 @@ criteria = "safe-to-deploy"
 version = "1.1.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.alloca]]
-version = "0.4.0"
-criteria = "safe-to-run"
-
 [[exemptions.allocator-api2]]
 version = "0.2.21"
 criteria = "safe-to-deploy"
-
-[[exemptions.anes]]
-version = "0.1.6"
-criteria = "safe-to-run"
 
 [[exemptions.anstream]]
 version = "0.6.21"
@@ -199,7 +192,7 @@ criteria = "safe-to-run"
 
 [[exemptions.core-foundation]]
 version = "0.10.1"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.cpufeatures]]
 version = "0.2.17"
@@ -213,14 +206,6 @@ criteria = "safe-to-deploy"
 version = "1.5.0"
 criteria = "safe-to-run"
 
-[[exemptions.criterion]]
-version = "0.8.2"
-criteria = "safe-to-run"
-
-[[exemptions.criterion-plot]]
-version = "0.8.2"
-criteria = "safe-to-run"
-
 [[exemptions.crossbeam-deque]]
 version = "0.8.6"
 criteria = "safe-to-deploy"
@@ -232,10 +217,6 @@ criteria = "safe-to-deploy"
 [[exemptions.crossbeam-utils]]
 version = "0.8.21"
 criteria = "safe-to-deploy"
-
-[[exemptions.crunchy]]
-version = "0.2.4"
-criteria = "safe-to-run"
 
 [[exemptions.crypto-common]]
 version = "0.1.7"
@@ -345,14 +326,6 @@ criteria = "safe-to-run"
 version = "0.12.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.foreign-types]]
-version = "0.3.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.foreign-types-shared]]
-version = "0.1.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.futures]]
 version = "0.3.32"
 criteria = "safe-to-deploy"
@@ -433,10 +406,6 @@ criteria = "safe-to-deploy"
 version = "0.4.13"
 criteria = "safe-to-deploy"
 
-[[exemptions.half]]
-version = "2.7.1"
-criteria = "safe-to-run"
-
 [[exemptions.hash32]]
 version = "0.3.1"
 criteria = "safe-to-deploy"
@@ -497,10 +466,6 @@ criteria = "safe-to-run"
 version = "1.8.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.hyper-tls]]
-version = "0.6.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.hyper-util]]
 version = "0.1.20"
 criteria = "safe-to-deploy"
@@ -548,10 +513,6 @@ criteria = "safe-to-deploy"
 [[exemptions.is_terminal_polyfill]]
 version = "1.70.2"
 criteria = "safe-to-deploy"
-
-[[exemptions.itertools]]
-version = "0.13.0"
-criteria = "safe-to-run"
 
 [[exemptions.itertools]]
 version = "0.14.0"
@@ -633,10 +594,6 @@ criteria = "safe-to-run"
 version = "1.1.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.native-tls]]
-version = "0.2.18"
-criteria = "safe-to-deploy"
-
 [[exemptions.netconfig-rs]]
 version = "0.1.5"
 criteria = "safe-to-deploy"
@@ -701,20 +658,8 @@ criteria = "safe-to-deploy"
 version = "0.3.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.openssl]]
-version = "0.10.75"
-criteria = "safe-to-deploy"
-
 [[exemptions.openssl-probe]]
 version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.openssl-sys]]
-version = "0.9.111"
-criteria = "safe-to-deploy"
-
-[[exemptions.page_size]]
-version = "0.6.0"
 criteria = "safe-to-run"
 
 [[exemptions.parking]]
@@ -772,22 +717,6 @@ criteria = "safe-to-deploy"
 [[exemptions.piper]]
 version = "0.2.5"
 criteria = "safe-to-deploy"
-
-[[exemptions.pkg-config]]
-version = "0.3.32"
-criteria = "safe-to-deploy"
-
-[[exemptions.plotters]]
-version = "0.3.7"
-criteria = "safe-to-run"
-
-[[exemptions.plotters-backend]]
-version = "0.3.7"
-criteria = "safe-to-run"
-
-[[exemptions.plotters-svg]]
-version = "0.3.7"
-criteria = "safe-to-run"
 
 [[exemptions.poly1305]]
 version = "0.8.0"
@@ -863,14 +792,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rand_xorshift]]
 version = "0.4.0"
-criteria = "safe-to-run"
-
-[[exemptions.rayon]]
-version = "1.11.0"
-criteria = "safe-to-run"
-
-[[exemptions.rayon-core]]
-version = "1.13.0"
 criteria = "safe-to-run"
 
 [[exemptions.redox_syscall]]
@@ -967,7 +888,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.schannel]]
 version = "0.1.29"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.schemars]]
 version = "0.9.0"
@@ -983,11 +904,11 @@ criteria = "safe-to-deploy"
 
 [[exemptions.security-framework]]
 version = "3.7.0"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.security-framework-sys]]
 version = "2.17.0"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.semver]]
 version = "1.0.27"
@@ -1091,7 +1012,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tempfile]]
 version = "3.27.0"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.terminal_size]]
 version = "0.4.3"
@@ -1135,10 +1056,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tokio-macros]]
 version = "2.6.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.tokio-native-tls]]
-version = "0.3.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-rustls]]
@@ -1237,10 +1154,6 @@ criteria = "safe-to-deploy"
 version = "0.1.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.vcpkg]]
-version = "0.2.15"
-criteria = "safe-to-deploy"
-
 [[exemptions.version_check]]
 version = "0.9.5"
 criteria = "safe-to-deploy"
@@ -1313,17 +1226,9 @@ criteria = "safe-to-deploy"
 version = "1.2.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.winapi-i686-pc-windows-gnu]]
-version = "0.4.0"
-criteria = "safe-to-run"
-
 [[exemptions.winapi-util]]
 version = "0.1.11"
 criteria = "safe-to-deploy"
-
-[[exemptions.winapi-x86_64-pc-windows-gnu]]
-version = "0.4.0"
-criteria = "safe-to-run"
 
 [[exemptions.windows]]
 version = "0.61.3"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -106,30 +106,6 @@ version = "1.5.0"
 notes = "Unsafe review in https://crrev.com/c/5838022"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.cast]]
-who = "George Burgess IV <gbiv@google.com>"
-criteria = "safe-to-run"
-version = "0.3.0"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.ciborium]]
-who = "Daniel Verkamp <dverkamp@chromium.org>"
-criteria = "safe-to-run"
-version = "0.2.2"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.ciborium-io]]
-who = "Daniel Verkamp <dverkamp@chromium.org>"
-criteria = "safe-to-run"
-version = "0.2.2"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.ciborium-ll]]
-who = "Daniel Verkamp <dverkamp@chromium.org>"
-criteria = "safe-to-run"
-version = "0.2.2"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
 [[audits.google.audits.core-foundation-sys]]
 who = "Manish Goregaokar <manishearth@google.com>"
 criteria = "safe-to-deploy"
@@ -396,18 +372,6 @@ version = "0.2.19"
 notes = "Contains a single line of float-to-int unsafe with decent safety comments"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.openssl-macros]]
-who = "George Burgess IV <gbiv@google.com>"
-criteria = "safe-to-deploy"
-version = "0.1.0"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.openssl-macros]]
-who = "George Burgess IV <gbiv@google.com>"
-criteria = "safe-to-deploy"
-delta = "0.1.0 -> 0.1.1"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
 [[audits.google.audits.potential_utf]]
 who = "Manish Goregaokar <manishearth@google.com>"
 criteria = "safe-to-deploy"
@@ -504,12 +468,6 @@ version = "0.13.1"
 notes = "Exposes unsafe codegen APIs but does not itself contain unsafe"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.tinytemplate]]
-who = "Ying Hsu <yinghsu@chromium.org>"
-criteria = "safe-to-run"
-version = "1.2.1"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
 [[audits.google.audits.tinyvec_macros]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
@@ -528,17 +486,6 @@ who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-run"
 version = "0.2.0"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.winapi]]
-who = "danakj@chromium.org"
-criteria = "safe-to-run"
-version = "0.3.9"
-notes = """
-Reviewed in https://crrev.com/c/5171063
-
-Previously reviewed during security review and the audit is grandparented in.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.writeable]]
 who = "Manish Goregaokar <manishearth@google.com>"
@@ -909,13 +856,6 @@ who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.4.0 -> 0.4.2"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.oorandom]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
-criteria = "safe-to-run"
-version = "11.1.5"
-notes = "Small random number generator, explicitly not cryptographically secure, no use of unsafe code, no dependencies"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.potential_utf]]
 who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"

--- a/ts_control/src/tokio/client.rs
+++ b/ts_control/src/tokio/client.rs
@@ -200,10 +200,10 @@ pub async fn run(
         {
             // TODO(npry): netmap stream resumption on reconnect
             Ok(()) => {
-                tracing::warn!("netmap stream ended without error");
+                tracing::warn!("netmap stream ended without error, attempting restart");
             }
             Err(e) => {
-                tracing::error!(error = %e, "netmap stream failed");
+                tracing::error!(error = %e, "netmap stream failed, attempting restart");
                 tokio::time::sleep(core::time::Duration::from_millis(500)).await;
             }
         }
@@ -249,6 +249,7 @@ pub async fn run_once(
         .map_err(ConnectionError::MapStreamStartFailed)?;
 
     let mut stream = core::pin::pin!(map_stream(reader));
+    tracing::info!("netmap stream started");
 
     loop {
         tokio::select! {

--- a/ts_control/src/tokio/map_stream.rs
+++ b/ts_control/src/tokio/map_stream.rs
@@ -97,7 +97,7 @@ pub fn map_stream(reader: impl AsyncRead + Unpin) -> impl Stream<Item = StateUpd
             .ok()?;
 
         let mut buf = PacketMut::new(msg_len as usize);
-        tracing::debug!(?msg_len, "reading mapresponse");
+        tracing::debug!(?msg_len, "reading netmap");
 
         reader
             .read_exact(buf.as_mut())

--- a/ts_control/src/tokio/map_stream.rs
+++ b/ts_control/src/tokio/map_stream.rs
@@ -97,7 +97,7 @@ pub fn map_stream(reader: impl AsyncRead + Unpin) -> impl Stream<Item = StateUpd
             .ok()?;
 
         let mut buf = PacketMut::new(msg_len as usize);
-        tracing::debug!(?msg_len, "reading netmap");
+        tracing::trace!(?msg_len, "reading netmap");
 
         reader
             .read_exact(buf.as_mut())

--- a/ts_control/src/tokio/ping.rs
+++ b/ts_control/src/tokio/ping.rs
@@ -7,8 +7,14 @@ use url::Url;
 
 use crate::StateUpdate;
 
+/// Path requested in HTTP GET via a Control-to-Node (C2N) [`ts_control_serde::PingRequest`] to
+/// invoke the C2N echo handler.
 const C2N_PATH_ECHO: &str = "/echo";
+/// HTTP 400 Bad Request response sent for all unimplemented C2N methods/paths.
 const C2N_PATH_UNKNOWN: &str = "HTTP/1.1 400 Bad Request\r\n\r\nunknown c2n path";
+/// The start of an HTTP/1.1 200 response with no headers, just missing the body. Intended for use
+/// with C2N echo responses, which can append the request body.
+const C2N_RESPONSE_ECHO_PREAMBLE: &str = "HTTP/1.1 200 OK\r\n\r\n";
 
 #[derive(Debug, thiserror::Error)]
 pub enum PingError {
@@ -35,9 +41,9 @@ fn parse_c2n_ping(payload: &str) -> Result<Request<String>, PingError> {
 }
 
 /// Handles [`ts_control_serde::PingRequest`]s from the control plane to this Tailscale node.
-/// Currently only handles Control-to-Node (C2N) echo requests; non-C2N requests will be skipped
-/// with a warning, while C2N requests that aren't for the "/echo" path will return a "400 Bad
-/// Request" to the control plane.
+/// Currently only handles Control-to-Node (C2N) echo requests; non-C2N requests are skipped with a
+/// warning, while C2N requests for an unhandled path return a "400 Bad Request" to the control
+/// plane.
 ///
 /// ## C2N Mechanism
 ///
@@ -53,10 +59,8 @@ fn parse_c2n_ping(payload: &str) -> Result<Request<String>, PingError> {
 /// The handler must return a full HTTP response to the request containing the requested data and/or
 /// status - for example, "HTTP/1.1 200 OK <body>" or "HTTP/1.1 400 Bad Request".
 ///
-/// `tailscale-rs` doesn't currently implement handlers for most of the C2N methods/paths, and
-/// likely never will implement some paths (such as /debug/goroutines...we don't have goroutines).
-/// For all unimplemented handlers, we return an HTTP 400 Bad Request status with an error message
-/// to the control plane.
+/// `tailscale-rs` returns an HTTP 400 Bad Request status with an error message to the control
+/// plane for any unimplemented C2N methods/paths.
 pub async fn handle_ping(
     state: &StateUpdate,
     control_url: &Url,
@@ -92,7 +96,7 @@ pub async fn handle_ping(
         let c2n_response = match c2n_request_path {
             C2N_PATH_ECHO => {
                 tracing::trace!(c2n_request_path, "handling c2n echo");
-                format!("HTTP/1.1 200 OK\r\n\r\n{}", c2n_request.body())
+                format!("{}{}", C2N_RESPONSE_ECHO_PREAMBLE, c2n_request.body())
             }
             _ => {
                 tracing::debug!(c2n_request_path, "no handler for c2n path");

--- a/ts_control/src/tokio/ping.rs
+++ b/ts_control/src/tokio/ping.rs
@@ -97,7 +97,7 @@ pub async fn handle_ping(
             }
         };
 
-        let ping_response_url = control_url.join(&ping_request.url.path()).map_err(|_| PingError::MissingPayload)?;
+        let ping_response_url = control_url.join(ping_request.url.path()).map_err(|_| PingError::MissingPayload)?;
         tracing::trace!(%ping_response_url, ?c2n_response, "posting c2n response");
         let response = http2_client
             .post(&ping_response_url, None, c2n_response.into())

--- a/ts_control/src/tokio/ping.rs
+++ b/ts_control/src/tokio/ping.rs
@@ -1,12 +1,14 @@
 use alloc::string::String;
 
-use bytes::Bytes;
 use tokio::sync::watch;
 use ts_control_serde::PingType;
-use ts_http_util::{BytesBody, ClientExt, Http2};
+use ts_http_util::{BytesBody, ClientExt, Http2, Request};
 use url::Url;
 
 use crate::StateUpdate;
+
+const C2N_PATH_ECHO: &str = "/echo";
+const C2N_PATH_UNKNOWN: &str = "HTTP/1.1 400 Bad Request\r\n\r\nunknown c2n path";
 
 #[derive(Debug, thiserror::Error)]
 pub enum PingError {
@@ -20,78 +22,90 @@ pub enum PingError {
     WatchRecv(#[from] watch::error::RecvError),
 }
 
-/// Extracts the body portion of an HTTP/1.1 request with a `Transfer-Encoding` header of
-/// `chunked`. Used with C2N echo requests.
-fn extract_chunked_http_body(payload: &str) -> Option<String> {
-    let mut parts = payload.split("\r\n\r\n");
-    // Extract and move past the method and headers.
-    let _ = parts.next();
-
-    // The next part is the body; extract it, then handle the chunked encoding.
-    let body = parts.next()?;
-    tracing::trace!(body, "extracted ping request body");
-
-    // TODO (dylan): this needs to handle _all_ chunks, not just the first one.
-    // TODO (dylan): this needs to check if the transfer-encoding header is chunked before
-    // trying to process the body as chunked.
-    let mut chunk = body.split("\r\n");
-    let len = match chunk.next() {
-        Some("0") => return None,
-        Some(len) => usize::from_str_radix(len, 16),
-        None => return None,
-    }
-    .ok()?;
-
-    let content = chunk.next()?;
+/// Parses the payload of a Control-to-Node (C2N) [`ts_control_serde::PingRequest`] as an HTTP/1.1
+/// request, or returns an error.
+fn parse_c2n_ping(payload: &str) -> Result<Request<String>, PingError> {
+    let req = ts_http_util::http1::parse_request(payload.as_bytes()).map_err(PingError::Http)?;
     tracing::trace!(
-        payload_len = len,
-        payload = content,
+        payload_len = req.body().len(),
+        payload = req.body(),
         "extracted payload from ping request body"
     );
-    if content.len() != len {
-        return None;
-    }
-
-    Some(content.to_string())
+    Ok(req)
 }
 
-/// Handles [`PingRequest`]s from the control plane to this Tailscale node. Currently only handles
-/// C2N pings.
+/// Handles [`ts_control_serde::PingRequest`]s from the control plane to this Tailscale node.
+/// Currently only handles Control-to-Node (C2N) echo requests; non-C2N requests will be skipped
+/// with a warning, while C2N requests that aren't for the "/echo" path will return a "400 Bad
+/// Request" to the control plane.
+///
+/// ## C2N Mechanism
+///
+/// The C2N mechanism provides a way for the control plane to query a Tailscale node about their
+/// local state, or request changes to the node state. A lot of debugging and metrics-related
+/// features are implemented via this mechanism, along with a number of knobs such as changing the
+/// netfilter implementation or forcing a logs flush in the Tailscale Go client.
+///
+/// Ping requests of type [`PingType::C2N`] contain an entire HTTP/1.1 request as their payload.
+/// The method and path of this request determine which handler is invoked; for example, in the
+/// Tailscale Go client, "GET /echo ..." invokes the C2N echo handler, while
+/// "POST /netfilter-kind ..." changes the netfilter implementation the client uses (on Linux only).
+/// The handler must return a full HTTP response to the request containing the requested data and/or
+/// status - for example, "HTTP/1.1 200 OK <body>" or "HTTP/1.1 400 Bad Request".
+///
+/// `tailscale-rs` doesn't currently implement handlers for most of the C2N methods/paths, and
+/// likely never will implement some paths (such as /debug/goroutines...we don't have goroutines).
+/// For all unimplemented handlers, we return an HTTP 400 Bad Request status with an error message
+/// to the control plane.
 pub async fn handle_ping(
     state: &StateUpdate,
     control_url: &Url,
     http2_client: &Http2<BytesBody>,
 ) -> Result<(), PingError> {
-    let Some(request) = &state.ping else {
+    let Some(ping_request) = &state.ping else {
         return Ok(());
     };
 
-    tracing::trace!(request = ?request, "handling ping request");
-    for typ in &request.types {
+    tracing::trace!(request = ?ping_request, "handling ping request");
+    for typ in &ping_request.types {
         if typ != &PingType::C2N {
             tracing::warn!(ping_type = ?typ, "ignoring unsupported ping type");
             continue;
         }
 
-        let payload = request.payload.clone().ok_or(PingError::MissingPayload)?;
-        let body = match extract_chunked_http_body(&payload) {
-            Some(body) => body,
-            None => {
-                tracing::warn!("ignoring malformed ping request");
+        let ping_request_body = ping_request.payload.as_ref().ok_or(PingError::MissingPayload)?;
+        let c2n_request = match parse_c2n_ping(ping_request_body) {
+            Ok(c2n_request) => {
+                tracing::trace!(?c2n_request, "parsed c2n ping");
+                c2n_request
+            }
+            Err(_) => {
+                tracing::warn!(?ping_request_body, "ignoring malformed c2n ping");
                 continue;
             }
         };
-        tracing::debug!(body = %body, "extracted ping request echo body");
 
-        let resp_body = format!("HTTP/1.1 200 OK\r\n\r\n{}", body);
-        tracing::debug!(?body, "sending ping response embedded in POST");
+        let c2n_request_path = c2n_request.uri().path();
+        let c2n_response = match c2n_request_path {
+            C2N_PATH_ECHO => {
+                tracing::trace!(c2n_request_path, "handling c2n echo");
+                format!("HTTP/1.1 200 OK\r\n\r\n{}", c2n_request.body())
+            }
+            _ => {
+                tracing::debug!(c2n_request_path, "no handler for c2n path");
+                C2N_PATH_UNKNOWN.to_string()
+            }
+        };
+
+        let ping_response_url = control_url.join(&ping_request.url.path()).map_err(|_| PingError::MissingPayload)?;
+        tracing::trace!(%ping_response_url, ?c2n_response, "posting c2n response");
         let response = http2_client
-            .post(control_url, None, Bytes::from(resp_body).into())
+            .post(&ping_response_url, None, c2n_response.into())
             .await?;
         if !response.status().is_success() {
-            tracing::error!("error responding to ping: {}", response.status());
+            tracing::error!(status = %response.status(), "responding to c2n ping");
         } else {
-            tracing::debug!("ping response sent");
+            tracing::debug!("c2n response sent");
         }
     }
 

--- a/ts_control/src/tokio/ping.rs
+++ b/ts_control/src/tokio/ping.rs
@@ -73,7 +73,10 @@ pub async fn handle_ping(
             continue;
         }
 
-        let ping_request_body = ping_request.payload.as_ref().ok_or(PingError::MissingPayload)?;
+        let ping_request_body = ping_request
+            .payload
+            .as_ref()
+            .ok_or(PingError::MissingPayload)?;
         let c2n_request = match parse_c2n_ping(ping_request_body) {
             Ok(c2n_request) => {
                 tracing::trace!(?c2n_request, "parsed c2n ping");
@@ -97,7 +100,9 @@ pub async fn handle_ping(
             }
         };
 
-        let ping_response_url = control_url.join(ping_request.url.path()).map_err(|_| PingError::MissingPayload)?;
+        let ping_response_url = control_url
+            .join(ping_request.url.path())
+            .map_err(|_| PingError::MissingPayload)?;
         tracing::trace!(%ping_response_url, ?c2n_response, "posting c2n response");
         let response = http2_client
             .post(&ping_response_url, None, c2n_response.into())

--- a/ts_control_noise/src/io.rs
+++ b/ts_control_noise/src/io.rs
@@ -99,7 +99,9 @@ impl<Conn: AsyncRead> AsyncRead for NoiseIo<Conn> {
                     // reached EOF, or the ReadBuf had a capacity of 0 - in either case, forward
                     // the result to the caller to handle.
                     if *bytes_read == 0 {
-                        tracing::trace!("poll_read: ReadHeader: got EOF when reading packet header");
+                        tracing::trace!(
+                            "poll_read: ReadHeader: got EOF when reading packet header"
+                        );
                         return Poll::Ready(Ok(()));
                     }
 

--- a/ts_control_noise/src/io.rs
+++ b/ts_control_noise/src/io.rs
@@ -99,7 +99,7 @@ impl<Conn: AsyncRead> AsyncRead for NoiseIo<Conn> {
                     // reached EOF, or the ReadBuf had a capacity of 0 - in either case, forward
                     // the result to the caller to handle.
                     if *bytes_read == 0 {
-                        tracing::warn!("poll_read: ReadHeader: got EOF when reading packet header");
+                        tracing::trace!("poll_read: ReadHeader: got EOF when reading packet header");
                         return Poll::Ready(Ok(()));
                     }
 
@@ -128,7 +128,7 @@ impl<Conn: AsyncRead> AsyncRead for NoiseIo<Conn> {
                     // reached EOF, or the ReadBuf had a capacity of 0 - in either case, forward
                     // the result to the caller to handle.
                     if bytes_read == 0 {
-                        tracing::warn!(
+                        tracing::trace!(
                             "poll_read: ReadBody({ty:?}): got EOF when reading packet body"
                         );
                         return Poll::Ready(Ok(()));

--- a/ts_control_serde/src/ping.rs
+++ b/ts_control_serde/src/ping.rs
@@ -1,4 +1,5 @@
 use alloc::{string::String, vec::Vec};
+use core::fmt;
 use core::net::IpAddr;
 
 use serde::{Deserialize, Serialize};
@@ -37,7 +38,7 @@ pub enum PingType {
 /// A [`PingRequest`] with populated [`PingRequest::ip`] and [`PingRequest::types`] fields will
 /// send a ping to the IP and send a `POST` request containing a [`PingResponse`] to the URL
 /// containing results.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct PingRequest {
     /// The URL to reply to the [`PingRequest`] to.
@@ -78,6 +79,19 @@ pub struct PingRequest {
     /// request.
     #[serde(deserialize_with = "deserialize_base64_string", default)]
     pub payload: Option<String>,
+}
+
+impl fmt::Debug for PingRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PingRequest")
+            .field("url", &self.url.as_str())
+            .field("url_is_noise", &self.url_is_noise)
+            .field("log", &self.log)
+            .field("types", &self.types)
+            .field("ip", &self.ip)
+            .field("payload", &self.payload)
+            .finish()
+    }
 }
 
 /// Response to a [`PingRequest`].

--- a/ts_control_serde/src/ping.rs
+++ b/ts_control_serde/src/ping.rs
@@ -1,6 +1,5 @@
 use alloc::{string::String, vec::Vec};
-use core::fmt;
-use core::net::IpAddr;
+use core::{fmt, net::IpAddr};
 
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/ts_http_util/Cargo.toml
+++ b/ts_http_util/Cargo.toml
@@ -14,6 +14,7 @@ ts_tls_util.workspace = true
 bytes.workspace = true
 futures.workspace = true
 http.workspace = true
+httparse.workspace = true
 http-body-util.workspace = true
 hyper = { workspace = true, features = ["http1", "client"] }
 hyper-util = { workspace = true, features = ["tokio"] }

--- a/ts_http_util/src/http1.rs
+++ b/ts_http_util/src/http1.rs
@@ -1,5 +1,5 @@
-//! HTTP/1.1 client implementation, and utilities to establish an HTTP/1.1 connection over TCP or
-//! TLS.
+//! HTTP/1.1 client implementation, utilities to establish an HTTP/1.1 connection over TCP or
+//! TLS, and utilities to parse HTTP/1.1 requests.
 
 use std::{
     fmt::{Debug, Formatter},
@@ -140,10 +140,9 @@ fn parse_request_parts(buf: &[u8]) -> Result<(Parts, usize), Error> {
     }
 
     let version = match req.version {
-        Some(0) => http::Version::HTTP_10,
         Some(1) => http::Version::HTTP_11,
         _ => {
-            tracing::trace!(version = req.version, "invalid http version");
+            tracing::trace!(version = req.version, "invalid/unsupported http version");
             return Err(Error::InvalidParam);
         }
     };
@@ -175,7 +174,8 @@ fn parse_request_parts(buf: &[u8]) -> Result<(Parts, usize), Error> {
     Ok((parts, res.unwrap()))
 }
 
-/// Parses the given `body` of an HTTP/1 request, transparently handling chunked transfer encoding.
+/// Parses the given `body` of an HTTP/1.1 request, transparently handling chunked transfer
+/// encoding.
 ///
 /// `body` must contain the full request body before parsing, and only the request body - not the
 /// full HTTP request. Transfer encodings other than "chunked", such as "compress", "deflate", or
@@ -183,34 +183,33 @@ fn parse_request_parts(buf: &[u8]) -> Result<(Parts, usize), Error> {
 fn parse_body(headers: &HeaderMap, body: &[u8]) -> Result<Bytes, Error> {
     match headers.get("transfer-encoding") {
         None => Ok(Bytes::copy_from_slice(body)),
-        Some(encoding) => {
-            if encoding != ENCODING_CHUNKED {
-                tracing::trace!(?encoding, "unsupported transfer encoding");
-                Err(Error::InvalidParam)
-            } else {
-                let mut idx = 0;
-                let mut bytes = bytes::BytesMut::new();
-                while let Ok(httparse::Status::Complete((start_offset, chunk_size))) =
-                    httparse::parse_chunk_size(&body[idx..])
-                {
-                    let start_idx = idx + start_offset;
-                    let end_idx = start_idx + chunk_size as usize;
-                    let chunk = &body[start_idx..end_idx];
-                    tracing::trace!(start_idx, end_idx, ?chunk, "parsed chunk");
-                    bytes.extend_from_slice(chunk);
-                    idx += start_offset + chunk_size as usize;
-                }
-                Ok(bytes.freeze())
+        Some(encoding) if encoding == ENCODING_CHUNKED => {
+            let mut idx = 0;
+            let mut bytes = bytes::BytesMut::new();
+            while let Ok(httparse::Status::Complete((start_offset, chunk_size))) =
+                httparse::parse_chunk_size(&body[idx..])
+            {
+                let start_idx = idx + start_offset;
+                let end_idx = start_idx + chunk_size as usize;
+                let chunk = &body[start_idx..end_idx];
+                tracing::trace!(start_idx, end_idx, ?chunk, "parsed chunk");
+                bytes.extend_from_slice(chunk);
+                idx += start_offset + chunk_size as usize;
             }
+            Ok(bytes.freeze())
+        }
+        Some(encoding) => {
+            tracing::trace!(?encoding, "unsupported transfer encoding");
+            Err(Error::InvalidParam)
         }
     }
 }
 
-/// Parses the given byte slice into an HTTP/1.0 or HTTP/1.1 request with a [`String`] body, or
-/// returns an error.
+/// Parses the given byte slice into an HTTP/1.1 request with a [`String`] body, or returns an
+/// error.
 ///
-/// This function only supports HTTP requests, and does not support HTTP/0.9, HTTP/2, or HTTP/3
-/// requests. `buf` must contain the full request, including body, before parsing.
+/// This function only supports HTTP requests, and does not support HTTP/0.9, HTTP/1.0, HTTP/2, or
+/// HTTP/3 requests. `buf` must contain the full request, including body, before parsing.
 pub fn parse_request(buf: &[u8]) -> Result<Request<String>, Error> {
     let (parts, offset) = parse_request_parts(buf)?;
     let bytes = parse_body(&parts.headers, &buf[offset..])?;

--- a/ts_http_util/src/http1.rs
+++ b/ts_http_util/src/http1.rs
@@ -1,19 +1,19 @@
 //! HTTP/1.1 client implementation, and utilities to establish an HTTP/1.1 connection over TCP or
 //! TLS.
 
+use std::{
+    fmt::{Debug, Formatter},
+    str::FromStr,
+    sync::Arc,
+};
+
 use bytes::Bytes;
-use http::request::Parts;
-use http::{HeaderMap, HeaderName, HeaderValue, Request, Response};
+use http::{HeaderMap, HeaderName, HeaderValue, Request, Response, request::Parts};
 use hyper::{
     body::{Body, Incoming},
     client::conn::http1::{self, SendRequest},
 };
 use hyper_util::rt::tokio::WithHyperIo;
-use std::str::FromStr;
-use std::{
-    fmt::{Debug, Formatter},
-    sync::Arc,
-};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     sync::Mutex,

--- a/ts_http_util/src/http1.rs
+++ b/ts_http_util/src/http1.rs
@@ -134,25 +134,28 @@ fn parse_request_parts(buf: &[u8]) -> Result<(Parts, usize), Error> {
         tracing::trace!(error = %err, "error parsing http request");
         Error::InvalidParam
     })?;
-    if res.is_partial() || req.method.is_none() || req.path.is_none() {
+    if res.is_partial() {
         tracing::trace!(request = ?req, "incomplete http request");
         return Err(Error::InvalidParam);
     }
 
-    let version = match req.version {
-        Some(1) => http::Version::HTTP_11,
-        _ => {
-            tracing::trace!(version = req.version, "invalid/unsupported http version");
-            return Err(Error::InvalidParam);
-        }
+    let httparse::Request {
+        method: Some(method),
+        path: Some(uri),
+        version: Some(1),
+        headers,
+        ..
+    } = req else {
+        tracing::trace!("invalid http request");
+        return Err(Error::InvalidParam);
     };
 
     // We verified req.{method/path} are both Some(_) above - it's okay to unwrap here.
     let mut builder = Request::builder()
-        .version(version)
-        .method(req.method.unwrap())
-        .uri(req.path.unwrap());
-    for hdr in req.headers {
+        .version(http::Version::HTTP_11)
+        .method(method)
+        .uri(uri);
+    for hdr in headers {
         let name = HeaderName::from_str(hdr.name).map_err(|err| {
             tracing::trace!(error = %err, "error parsing http header name");
             Error::InvalidParam

--- a/ts_http_util/src/http1.rs
+++ b/ts_http_util/src/http1.rs
@@ -1,17 +1,19 @@
 //! HTTP/1.1 client implementation, and utilities to establish an HTTP/1.1 connection over TCP or
 //! TLS.
 
-use std::{
-    fmt::{Debug, Formatter},
-    sync::Arc,
-};
-
-use http::{Request, Response};
+use bytes::Bytes;
+use http::request::Parts;
+use http::{HeaderMap, HeaderName, HeaderValue, Request, Response};
 use hyper::{
     body::{Body, Incoming},
     client::conn::http1::{self, SendRequest},
 };
 use hyper_util::rt::tokio::WithHyperIo;
+use std::str::FromStr;
+use std::{
+    fmt::{Debug, Formatter},
+    sync::Arc,
+};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     sync::Mutex,
@@ -19,6 +21,12 @@ use tokio::{
 };
 
 use crate::{Client, Error};
+
+/// "Chunked" value of the [`Transfer-Encoding HTTP header`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Transfer-Encoding).
+const ENCODING_CHUNKED: HeaderValue = HeaderValue::from_static("chunked");
+
+/// The maximum number of HTTP headers that will be parsed for a single request.
+const MAX_PARSED_HEADERS: usize = 16;
 
 /// An HTTP/1.1 client that can connect to a server and send HTTP requests/receive HTTP responses.
 /// Supports the [HTTP/1.1 protocol upgrade mechanism].
@@ -111,4 +119,101 @@ where
 {
     let conn = crate::dial_tls(url, [b"http/1.1".to_vec()]).await?;
     connect(conn).await
+}
+
+/// Parses the given slice into a [`Parts`] containing the HTTP method, version, path, and headers.
+/// Returns the [`Parts`] and the offset to the start of the request body in `buf`, or an error.
+///
+/// Only supports up to [`MAX_PARSED_HEADERS`] individual HTTP headers in a single request; headers
+/// beyond this number will be discarded.
+fn parse_request_parts(buf: &[u8]) -> Result<(Parts, usize), Error> {
+    let mut headers = [httparse::EMPTY_HEADER; MAX_PARSED_HEADERS];
+    let mut req = httparse::Request::new(&mut headers);
+
+    let res = req.parse(buf).map_err(|err| {
+        tracing::trace!(error = %err, "error parsing http request");
+        Error::InvalidParam
+    })?;
+    if res.is_partial() || req.method.is_none() || req.path.is_none() {
+        tracing::trace!(request = ?req, "incomplete http request");
+        return Err(Error::InvalidParam);
+    }
+
+    let version = match req.version {
+        Some(0) => http::Version::HTTP_10,
+        Some(1) => http::Version::HTTP_11,
+        _ => {
+            tracing::trace!(version = req.version, "invalid http version");
+            return Err(Error::InvalidParam);
+        }
+    };
+
+    // We verified req.{method/path} are both Some(_) above - it's okay to unwrap here.
+    let mut builder = Request::builder()
+        .version(version)
+        .method(req.method.unwrap())
+        .uri(req.path.unwrap());
+    for hdr in req.headers {
+        let name = HeaderName::from_str(hdr.name).map_err(|err| {
+            tracing::trace!(error = %err, "error parsing http header name");
+            Error::InvalidParam
+        })?;
+        let value = HeaderValue::from_bytes(hdr.value).map_err(|err| {
+            tracing::trace!(error = %err, "error parsing http header value");
+            Error::InvalidParam
+        })?;
+        builder = builder.header(name, value);
+    }
+
+    let (parts, _) = builder
+        .body(())
+        .map_err(|err| {
+            tracing::trace!(error = %err, "error constructing parts");
+            Error::InvalidParam
+        })?
+        .into_parts();
+    Ok((parts, res.unwrap()))
+}
+
+/// Parses the given `body` of an HTTP/1 request, transparently handling chunked transfer encoding.
+///
+/// `body` must contain the full request body before parsing, and only the request body - not the
+/// full HTTP request. Transfer encodings other than "chunked", such as "compress", "deflate", or
+/// "gzip", are not currently handled and will result in an error.
+fn parse_body(headers: &HeaderMap, body: &[u8]) -> Result<Bytes, Error> {
+    match headers.get("transfer-encoding") {
+        None => Ok(Bytes::copy_from_slice(&body)),
+        Some(encoding) => {
+            if encoding != ENCODING_CHUNKED {
+                tracing::trace!(?encoding, "unsupported transfer encoding");
+                Err(Error::InvalidParam)
+            } else {
+                let mut idx = 0;
+                let mut bytes = bytes::BytesMut::new();
+                while let Ok(httparse::Status::Complete((start_offset, chunk_size))) =
+                    httparse::parse_chunk_size(&body[idx..])
+                {
+                    let start_idx = idx + start_offset;
+                    let end_idx = start_idx + chunk_size as usize;
+                    let chunk = &body[start_idx..end_idx];
+                    tracing::trace!(start_idx, end_idx, ?chunk, "parsed chunk");
+                    bytes.extend_from_slice(chunk);
+                    idx += start_offset + chunk_size as usize;
+                }
+                Ok(bytes.freeze())
+            }
+        }
+    }
+}
+
+/// Parses the given byte slice into an HTTP/1.0 or HTTP/1.1 request with a [`String`] body, or
+/// returns an error.
+///
+/// This function only supports HTTP requests, and does not support HTTP/0.9, HTTP/2, or HTTP/3
+/// requests. `buf` must contain the full request, including body, before parsing.
+pub fn parse_request(buf: &[u8]) -> Result<Request<String>, Error> {
+    let (parts, offset) = parse_request_parts(buf)?;
+    let bytes = parse_body(&parts.headers, &buf[offset..])?;
+    let body = String::from_utf8(bytes.to_vec()).map_err(|_| Error::InvalidParam)?;
+    Ok(Request::from_parts(parts, body))
 }

--- a/ts_http_util/src/http1.rs
+++ b/ts_http_util/src/http1.rs
@@ -145,7 +145,8 @@ fn parse_request_parts(buf: &[u8]) -> Result<(Parts, usize), Error> {
         version: Some(1),
         headers,
         ..
-    } = req else {
+    } = req
+    else {
         tracing::trace!("invalid http request");
         return Err(Error::InvalidParam);
     };

--- a/ts_http_util/src/http1.rs
+++ b/ts_http_util/src/http1.rs
@@ -171,7 +171,7 @@ fn parse_request_parts(buf: &[u8]) -> Result<(Parts, usize), Error> {
     let (parts, _) = builder
         .body(())
         .map_err(|err| {
-            tracing::trace!(error = %err, "error constructing parts");
+            tracing::trace!(error = %err, "error building, invalid http request");
             Error::InvalidParam
         })?
         .into_parts();

--- a/ts_http_util/src/http1.rs
+++ b/ts_http_util/src/http1.rs
@@ -182,7 +182,7 @@ fn parse_request_parts(buf: &[u8]) -> Result<(Parts, usize), Error> {
 /// "gzip", are not currently handled and will result in an error.
 fn parse_body(headers: &HeaderMap, body: &[u8]) -> Result<Bytes, Error> {
     match headers.get("transfer-encoding") {
-        None => Ok(Bytes::copy_from_slice(&body)),
+        None => Ok(Bytes::copy_from_slice(body)),
         Some(encoding) => {
             if encoding != ENCODING_CHUNKED {
                 tracing::trace!(?encoding, "unsupported transfer encoding");


### PR DESCRIPTION
Implements slightly more sane C2N `PingRequest` handling:
- Moves parsing logic to `ts_http_util` and uses the `httparse` crate to parse `PingRequest` payloads into HTTP/1.1 requests, instead of...whatever `extract_chunked_http_body` was doing.
- Adds structure for handling different C2N methods/paths in the future, and consistently returns HTTP 400 for paths that we don't implement (yet).

Additionally:
- Implements `Debug` manually on `PingRequest` so the `url` field doesn't take up half the logs.
- Cleans up some logging in `ts_control` crates to reduce warn/error spew and align words we're using (netmap/mapresponse).
- Adds a "netmap stream started" log message at info level to indicate we've reconnected/restarted the map stream after a disconnect. Before, we'd get the warnings/errors but no indication we'd actually reconnected.
- Prunes `cargo vet` deps in `supply-chain`.

Updates #cleanup