### PR TITLE
flake, ts_python: fix macOS build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,8 @@
 
         cargoArtifacts = deps;
         cargoExtraArgs = "--workspace --all-targets --all-features";
+        env.PYO3_NO_PYTHON = 1;
+        env.PYO3_BUILD_EXTENSION_MODULE = 1;
 
         # don't run benches as part of check
         checkPhaseCargoCommand = "cargo test --profile release --all-features --workspace --examples --bins --lib --tests";
@@ -192,6 +194,9 @@
           pname = "tailscale-rs-wksp";
           version = "dev";
           src = rustsrc;
+
+          env.PYO3_NO_PYTHON = 1;
+          env.PYO3_BUILD_EXTENSION_MODULE = 1;
         };
 
       in {

--- a/ts_python/Cargo.toml
+++ b/ts_python/Cargo.toml
@@ -7,10 +7,10 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
-tailscale = { workspace = true }
-ts_cli_util = { workspace = true }
+tailscale.workspace = true
+ts_cli_util.workspace = true
 
-pyo3 = { version = "0.28", features = ["extension-module", "bytes", "abi3-py312"] }
+pyo3 = { version = "0.28", features = ["bytes", "abi3-py312"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime", "attributes"] }
 
 [lib]


### PR DESCRIPTION
Fixes the broken nightly macOS 26 jobs in GitHub Actions.

`ts_python`: Removes the deprecated pyo3 "extension-module" feature, which is deprecated/problematic and the source of our macOS build issues.

`flake.nix`: Adds the `PYO3_NO_PYTHON` and `PYO3_BUILD_EXTENSION_MODULE` env vars to the `checks.common` attrset and to the args to `craneLib.buildPackage()`. Required to check/build `ts_python` in Nix without a Python interpreter after removing PyO3's deprecated "extension-module" feature.

Closes #9.