### PR TITLE
workspace, ts_netstack_smoltcp_core: update smoltcp to 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,16 +1413,6 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heapless"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
@@ -3453,15 +3443,15 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smoltcp"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad095989c1533c1c266d9b1e8d70a1329dd3723c3edac6d03bbd67e7bf6f4bb"
+checksum = "ac729b0a77bd092a3f06ddaddc59fe0d67f48ba0de45a9abe707c2842c7f8767"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
  "defmt 0.3.100",
- "heapless 0.8.0",
+ "heapless",
  "log",
  "managed",
 ]
@@ -4082,7 +4072,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 name = "ts_array256"
 version = "0.1.0"
 dependencies = [
- "heapless 0.9.2",
+ "heapless",
  "lazy_static",
  "proptest",
  "smallvec",
@@ -4097,7 +4087,7 @@ dependencies = [
  "cfg-if",
  "divan",
  "flate2",
- "heapless 0.9.2",
+ "heapless",
  "ipnet",
  "itertools",
  "lazy_static",
@@ -4308,7 +4298,7 @@ dependencies = [
 name = "ts_hexdump"
 version = "0.1.0"
 dependencies = [
- "heapless 0.9.2",
+ "heapless",
 ]
 
 [[package]]
@@ -4391,7 +4381,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "flume",
- "heapless 0.8.0",
+ "heapless",
  "smoltcp",
  "thiserror 2.0.18",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ serde_json = "1"
 serde_with = "3"
 smallvec = "1.15"
 static_assertions = "1.1"
-smoltcp = { version = "0.12", default-features = false }
+smoltcp = { version = "0.13", default-features = false }
 tap = "1.0"
 thiserror = { version = "2", default-features = false }
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros"] }

--- a/ts_netstack_smoltcp_core/Cargo.toml
+++ b/ts_netstack_smoltcp_core/Cargo.toml
@@ -10,11 +10,11 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-flume = { workspace = true }
-tracing = { workspace = true }
 bytes.workspace = true
-heapless_0_8 = { package = "heapless", version = "0.8" }
-thiserror = { workspace = true }
+flume.workspace = true
+heapless.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 
 [dependencies.smoltcp]
 workspace = true
@@ -33,11 +33,11 @@ features = [
 ]
 
 [dev-dependencies]
-ts_cli_util.workspace = true
 tracing-panic = { version = "0.1", features = ["capture-backtrace"] }
+ts_cli_util.workspace = true
 
 [dev-dependencies.smoltcp]
-version = "0.12"
+version = "0.13"
 default-features = false
 features = [
     "alloc",

--- a/ts_netstack_smoltcp_core/src/lib.rs
+++ b/ts_netstack_smoltcp_core/src/lib.rs
@@ -716,7 +716,7 @@ where
     }
 }
 
-fn set_loopback<const N: usize>(ips: &mut heapless_0_8::Vec<smoltcp::wire::IpCidr, N>) -> bool {
+fn set_loopback<const N: usize>(ips: &mut heapless::Vec<smoltcp::wire::IpCidr, N>) -> bool {
     if ips.capacity() < 2 {
         return false;
     }

--- a/ts_netstack_smoltcp_core/src/socket_impl/raw.rs
+++ b/ts_netstack_smoltcp_core/src/socket_impl/raw.rs
@@ -22,8 +22,12 @@ impl Netstack {
                 ip_version,
                 protocol,
             } => {
-                let sock =
-                    raw::Socket::new(ip_version, protocol, self.raw_buffer(), self.raw_buffer());
+                let sock = raw::Socket::new(
+                    Some(ip_version),
+                    Some(protocol),
+                    self.raw_buffer(),
+                    self.raw_buffer(),
+                );
                 let handle = self.socket_set.add(sock);
 
                 RawSocketResponse::Opened { handle }.into()


### PR DESCRIPTION
Updates `smoltcp` to 0.13, replaces the `heapless_0_8` dependency with `heapless` used by the rest of the workspace, and updates raw socket creation in `ts_netstack_smoltcp_core::socket_impl::raw::Netstack::process_raw()` to wrap the IP version/protocol in an `Option<>`, per the new raw socket API.

Updates #28
Closes #49