### PR TITLE
deny: turn off multiple versions of dep warning

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -22,7 +22,7 @@ allow = [
 private = { ignore = true }
 
 [bans]
-multiple-versions = "warn"
+multiple-versions = "allow"
 wildcards = "allow"
 
 [graph]


### PR DESCRIPTION
We had `deny.toml` configured to warn on multiple versions of the same crate (seems like also default behavior?). This is a common and normal occurrence due to conflicting requirements in our dependency tree: at my last count, we had 37 warnings, which take up most of the output of the `cargo deny` CI check. I don't believe there's any operational way we can resolve these, and they're functionally benign, so just to denoise, remove the warning.

