### PR TITLE
repo: bump rand -> 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2843,9 +2843,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -3603,7 +3603,7 @@ dependencies = [
  "clap",
  "include_dir",
  "mime_guess",
- "rand 0.10.0",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3633,7 +3633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4102,7 +4102,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "smallvec",
  "static_assertions",
  "ts_array256",
@@ -4278,7 +4278,7 @@ dependencies = [
  "crypto_box",
  "num-derive",
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "ts_keys",
  "zerocopy",
@@ -4375,7 +4375,7 @@ dependencies = [
  "futures-util",
  "include_dir",
  "mime_guess",
- "rand 0.10.0",
+ "rand 0.10.1",
  "tokio",
  "tracing",
  "tracing-panic",
@@ -4603,7 +4603,7 @@ dependencies = [
  "hex",
  "hkdf",
  "itertools",
- "rand 0.10.0",
+ "rand 0.10.1",
  "tokio",
  "tracing",
  "ts_cli_util",


### PR DESCRIPTION
There's a recently-reported [rustsec advisory](https://rustsec.org/advisories/RUSTSEC-2026-0097) causing CI to fail. We're not triggering the relevant conditions (minimally: the `log` feature is off), but the easiest resolution is just to bump the dep.