### PR TITLE
netsock/tcp: correct eos detection

### DIFF
--- a/ts_netstack_smoltcp_socket/src/tcp/stream.rs
+++ b/ts_netstack_smoltcp_socket/src/tcp/stream.rs
@@ -155,6 +155,10 @@ impl TcpStream {
     }
 
     fn _recv_bytes(&self, resp: Response) -> Result<Bytes, netcore::Error> {
+        if matches!(resp, Response::TcpStream(tcp::stream::Response::Finished)) {
+            return Ok(Bytes::new());
+        }
+
         netcore::try_response_as!(resp, tcp::stream::Response::Recv { buf });
         Ok(buf)
     }


### PR DESCRIPTION
The signal for end-of-stream is a specific message type sent over the response channel. We weren't checking for it in netstack_socket, so the TCP stream ending was always an unexpected type error. Now check first and return a zero-length buffer to indicate to the caller that the remote has hung up.
