### PR TITLE
tailscale: polish API

### DIFF
--- a/examples/axum/main.rs
+++ b/examples/axum/main.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
         .with_state(Arc::new(AtomicUsize::new(0)))
         .route("/{*path}", get(assets));
 
-    let url = format!("http://{}/index.html", listener.local_endpoint_addr());
+    let url = format!("http://{}/index.html", listener.local_addr());
     tracing::info!(%url, "http server listening");
 
     axum::serve(tailscale::axum::Listener::from(listener), router).await?;

--- a/examples/axum/main.rs
+++ b/examples/axum/main.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
     .await?;
 
     let listener = dev
-        .tcp_listen((dev.ipv4().await?, args.port).into())
+        .tcp_listen((dev.ipv4_addr().await?, args.port).into())
         .await?;
 
     let router = Router::new()
@@ -90,7 +90,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
         .with_state(Arc::new(AtomicUsize::new(0)))
         .route("/{*path}", get(assets));
 
-    let url = format!("http://{}/index.html", listener.local_endpoint());
+    let url = format!("http://{}/index.html", listener.local_endpoint_addr());
     tracing::info!(%url, "http server listening");
 
     axum::serve(tailscale::axum::Listener::from(listener), router).await?;

--- a/examples/peer_ping/main.rs
+++ b/examples/peer_ping/main.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
     )
     .await?;
 
-    let sock = dev.udp_bind((dev.ipv4().await?, 1234).into()).await?;
+    let sock = dev.udp_bind((dev.ipv4_addr().await?, 1234).into()).await?;
     let mut ticker = tokio::time::interval(Duration::from_secs_f64(args.ping_interval_secs));
 
     loop {

--- a/examples/tcp_echo/main.rs
+++ b/examples/tcp_echo/main.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
     )
     .await?;
 
-    let sockaddr = (dev.ipv4().await?, args.listen_port).into();
+    let sockaddr = (dev.ipv4_addr().await?, args.listen_port).into();
     let listener = dev.tcp_listen(sockaddr).await?;
 
     tracing::info!(listening_addr = %sockaddr);
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
         let conn = listener.accept().await?;
 
         tokio::task::spawn(async move {
-            let remote_ep = conn.remote_endpoint();
+            let remote_ep = conn.remote_endpoint_addr();
             tracing::info!(%remote_ep, "accepted connection");
 
             let (mut reader, mut writer) = tokio::io::split(conn);

--- a/examples/tcp_echo/main.rs
+++ b/examples/tcp_echo/main.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
         let conn = listener.accept().await?;
 
         tokio::task::spawn(async move {
-            let remote_ep = conn.remote_endpoint_addr();
+            let remote_ep = conn.remote_addr();
             tracing::info!(%remote_ep, "accepted connection");
 
             let (mut reader, mut writer) = tokio::io::split(conn);

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -62,12 +62,12 @@ impl axum::serve::Listener for Listener {
             }
         };
 
-        let addr = stream.remote_endpoint_addr();
+        let addr = stream.remote_addr();
 
         (stream, addr)
     }
 
     fn local_addr(&self) -> std::io::Result<Self::Addr> {
-        Ok(self.0.local_endpoint_addr())
+        Ok(self.0.local_addr())
     }
 }

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -13,7 +13,7 @@
 //!     Some("YOUR_AUTH_KEY".to_owned()),
 //! ).await?;
 //!
-//! let listener = dev.tcp_listen((dev.ipv4().await?, 80).into()).await?;
+//! let listener = dev.tcp_listen((dev.ipv4_addr().await?, 80).into()).await?;
 //!
 //! async fn index() -> &'static str { "Hello world!" }
 //! let router = axum::Router::new().route("/", axum::routing::get(index));
@@ -49,12 +49,12 @@ impl axum::serve::Listener for Listener {
             }
         };
 
-        let addr = stream.remote_endpoint();
+        let addr = stream.remote_endpoint_addr();
 
         (stream, addr)
     }
 
     fn local_addr(&self) -> std::io::Result<Self::Addr> {
-        Ok(self.0.local_endpoint())
+        Ok(self.0.local_endpoint_addr())
     }
 }

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -14,11 +14,12 @@
 //! ).await?;
 //!
 //! let listener = dev.tcp_listen((dev.ipv4_addr().await?, 80).into()).await?;
+//! let listener: tailscale::axum::Listener = listener.into();
 //!
 //! async fn index() -> &'static str { "Hello world!" }
 //! let router = axum::Router::new().route("/", axum::routing::get(index));
 //!
-//! axum::serve(tailscale::axum::Listener(listener), router).await?;
+//! axum::serve(listener, router).await?;
 //! #   Ok(())
 //! # }
 //! ```
@@ -29,11 +30,23 @@ use crate::{TcpListener, TcpStream};
 
 /// Wrapper type implementing [`axum::serve::Listener`] on [`TcpListener`].
 #[derive(Debug)]
-pub struct Listener(pub TcpListener);
+pub struct Listener(TcpListener);
 
 impl From<TcpListener> for Listener {
     fn from(listener: TcpListener) -> Self {
         Self(listener)
+    }
+}
+
+impl From<Listener> for TcpListener {
+    fn from(listener: Listener) -> Self {
+        listener.0
+    }
+}
+
+impl AsRef<TcpListener> for Listener {
+    fn as_ref(&self) -> &TcpListener {
+        &self.0
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,13 +50,12 @@ struct KeyFile {
     key_state: ts_keys::NodeState,
 }
 
-impl Config {
-    /// Construct a [`ts_control::Config`] from this config.
-    pub fn control_config(&self) -> ts_control::Config {
+impl From<&Config> for ts_control::Config {
+    fn from(value: &Config) -> ts_control::Config {
         ts_control::Config {
-            client_name: self.client_name.clone(),
-            hostname: self.requested_hostname.clone(),
-            server_url: self.control_server_url.clone(),
+            client_name: value.client_name.clone(),
+            hostname: value.requested_hostname.clone(),
+            server_url: value.control_server_url.clone(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ pub struct Config {
     /// This file represents this node's identity. The key file format is specific to
     /// tailscale-rs; key files are not interchangeable with those produced by other
     /// implementations of Tailscale, e.g. `tailscaled` or `tsnet`.
-    pub key_state: ts_keys::NodeState,
+    pub key_state: crate::NodeState,
 
     // TODO(npry): let clients also define an app name once the sdk-level name moves
     //  to a dedicated field
@@ -36,7 +36,7 @@ pub struct Config {
 pub async fn load_key_file(
     p: impl AsRef<Path>,
     bad_format: BadFormatBehavior,
-) -> Result<ts_keys::NodeState, crate::Error> {
+) -> Result<crate::NodeState, crate::Error> {
     let p = p.as_ref();
 
     tracing::trace!(key_file = %p.display(), "loading key file");
@@ -47,7 +47,7 @@ pub async fn load_key_file(
 
 #[derive(serde::Serialize, serde::Deserialize, Default)]
 struct KeyFile {
-    key_state: ts_keys::NodeState,
+    key_state: crate::NodeState,
 }
 
 impl From<&Config> for ts_control::Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,9 @@ pub struct Device {
 }
 
 impl Device {
-    /// Spawn a device from the given [`Config`] and auth key.
+    /// Create a device from the given [`Config`] and auth key.
+    ///
+    /// Internally, this will spawn mutltiple asynchronous actors onto a Tokio runtime.
     ///
     /// # Example
     ///
@@ -131,12 +133,12 @@ impl Device {
             .ok_or(Error::InternalFailure)
     }
 
-    /// Bind a UDP socket to `port` on the specified [`SocketAddr`].
+    /// Bind a UDP socket to the specified [`SocketAddr`].
     pub async fn udp_bind(&self, socket_addr: SocketAddr) -> Result<UdpSocket, Error> {
         self.channel.udp_bind(socket_addr).await.map_err(Into::into)
     }
 
-    /// Bind a TCP listener to `port` on the specified [`SocketAddr`].
+    /// Bind a TCP listener to the specified [`SocketAddr`].
     pub async fn tcp_listen(&self, socket_addr: SocketAddr) -> Result<TcpListener, Error> {
         self.channel
             .tcp_listen(socket_addr)
@@ -180,6 +182,8 @@ impl Device {
     ///
     /// Reports whether the device was fully shut down before the timeout. It is still shut
     /// down if it timed out, just more violently and with potential resource leaks.
+    ///
+    /// If `timeout` is `None`, then shutdown will never time-out.
     pub async fn shutdown(self, timeout: Option<Duration>) -> bool {
         self.runtime.graceful_shutdown(timeout).await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,8 +103,7 @@ impl Device {
         check_magic_env()?;
 
         let rt =
-            ts_runtime::Runtime::spawn(config.control_config(), auth_key, config.key_state.clone())
-                .await?;
+            ts_runtime::Runtime::spawn(config.into(), auth_key, config.key_state.clone()).await?;
         let channel = rt.channel().await?;
 
         Ok(Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,25 +52,27 @@
 
 extern crate ts_netstack_smoltcp as netstack;
 
-use core::{
+use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     time::Duration,
 };
 
 #[doc(inline)]
+pub use config::{BadFormatBehavior, Config, load_key_file};
+#[doc(inline)]
+pub use error::Error;
+#[doc(inline)]
 pub use netstack::netsock::{TcpListener, TcpStream, UdpSocket};
 use netstack::{CreateSocket, netcore::Channel};
+#[doc(inline)]
+pub use ts_keys::NodeState;
+#[doc(inline)]
+pub use ts_control::Node as NodeInfo;
 
 #[cfg(feature = "axum")]
 pub mod axum;
 mod config;
 mod error;
-
-pub use config::{BadFormatBehavior, Config, load_key_file};
-#[doc(inline)]
-pub use error::Error;
-#[doc(inline)]
-pub use ts_control::Node as NodeInfo;
 
 /// A tailscale device.
 pub struct Device {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! ).await?;
 //!
 //! // Bind a UDP socket on our tailnet IP, port 1234
-//! let sock = dev.udp_bind((dev.ipv4().await?, 1234).into()).await?;
+//! let sock = dev.udp_bind((dev.ipv4_addr().await?, 1234).into()).await?;
 //!
 //! // Send a packet containing "ping" to 100.64.0.1:5678 once per second
 //! loop {
@@ -112,7 +112,7 @@ impl Device {
     }
 
     /// Get this node's IPv4 tailnet address.
-    pub async fn ipv4(&self) -> Result<Ipv4Addr, Error> {
+    pub async fn ipv4_addr(&self) -> Result<Ipv4Addr, Error> {
         self.runtime
             .control
             .ask(ts_runtime::control_runner::Ipv4)
@@ -122,7 +122,7 @@ impl Device {
     }
 
     /// Get this node's IPv6 tailnet address.
-    pub async fn ipv6(&self) -> Result<Ipv6Addr, Error> {
+    pub async fn ipv6_addr(&self) -> Result<Ipv6Addr, Error> {
         self.runtime
             .control
             .ask(ts_runtime::control_runner::Ipv6)
@@ -147,8 +147,8 @@ impl Device {
     /// Connect to a TCP socket at the remote address.
     pub async fn tcp_connect(&self, remote: SocketAddr) -> Result<TcpStream, Error> {
         let ip: IpAddr = match remote.is_ipv4() {
-            true => self.ipv4().await?.into(),
-            false => self.ipv6().await?.into(),
+            true => self.ipv4_addr().await?.into(),
+            false => self.ipv6_addr().await?.into(),
         };
 
         // TODO(npry): collision checking
@@ -180,7 +180,7 @@ impl Device {
     ///
     /// Reports whether the device was fully shut down before the timeout. It is still shut
     /// down if it timed out, just more violently and with potential resource leaks.
-    pub async fn graceful_shutdown(self, timeout: Option<Duration>) -> bool {
+    pub async fn shutdown(self, timeout: Option<Duration>) -> bool {
         self.runtime.graceful_shutdown(timeout).await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,9 +65,9 @@ pub use error::Error;
 pub use netstack::netsock::{TcpListener, TcpStream, UdpSocket};
 use netstack::{CreateSocket, netcore::Channel};
 #[doc(inline)]
-pub use ts_keys::NodeState;
-#[doc(inline)]
 pub use ts_control::Node as NodeInfo;
+#[doc(inline)]
+pub use ts_keys::NodeState;
 
 #[cfg(feature = "axum")]
 pub mod axum;

--- a/ts_cli_util/src/lib.rs
+++ b/ts_cli_util/src/lib.rs
@@ -59,7 +59,7 @@ impl CommonArgs {
         let config: tailscale::Config = self.config().await?;
 
         let (client, stream) = ts_control::AsyncControlClient::connect(
-            &config.control_config(),
+            &(&config).into(),
             &config.key_state,
             self.auth_key.as_deref(),
         )

--- a/ts_elixir/lib/tailscale.ex
+++ b/ts_elixir/lib/tailscale.ex
@@ -8,14 +8,14 @@ defmodule Tailscale do
     
   `tailscale` is capable of interpreting either the `inet` format or a `String`.
   """
-  @type ip4() :: :inet.ip4_address() | String.t()
+  @type ip4_addr() :: :inet.ip4_address() | String.t()
   
   @typedoc """
   An IPv6 address.
     
   `tailscale` is capable of interpreting either the `inet` format or a `String`.
   """
-  @type ip6() :: :inet.ip6_address() | String.t()
+  @type ip6_addr() :: :inet.ip6_address() | String.t()
 
   @typedoc """
   An IP address (v4 or v6).
@@ -56,15 +56,15 @@ defmodule Tailscale do
     Tailscale.Native.connect(config_path, auth_key)
   end
 
-  @spec ipv4(t()) :: {:ok, :inet.ip4_address()} | {:error, any()}
+  @spec ipv4_addr(t()) :: {:ok, :inet.ip4_address()} | {:error, any()}
   @doc """
   Get the current IPv4 address of this Tailscale node.
     
   Blocks until the address is available.
   """
-  def ipv4(dev), do: Tailscale.Native.ipv4(dev)
+  def ipv4_addr(dev), do: Tailscale.Native.ipv4_addr(dev)
   
-  @spec ipv6(t()) :: {:ok, :inet.ip6_address()} | {:error, any()}
+  @spec ipv6_addr(t()) :: {:ok, :inet.ip6_address()} | {:error, any()}
   @doc """
   Get the current IPv6 address of this Tailscale node.
     
@@ -73,5 +73,5 @@ defmodule Tailscale do
   Note that this address is in `:inet` format (16-bit segments), which may be difficult to read. 
   See `:inet.ntoa` to format to a string.
   """
-  def ipv6(dev), do: Tailscale.Native.ipv6(dev)
+  def ipv6_addr(dev), do: Tailscale.Native.ipv6_addr(dev)
 end

--- a/ts_elixir/lib/tailscale/native.ex
+++ b/ts_elixir/lib/tailscale/native.ex
@@ -118,14 +118,14 @@ defmodule Tailscale.Native do
   
   Blocks until the device is connected and gets its address from control.
   """
-  @spec ipv4(device()) :: {:ok, :inet.ip4_address()} | {:error, any()}
-  def ipv4(_dev), do: err()
+  @spec ipv4_addr(device()) :: {:ok, :inet.ip4_address()} | {:error, any()}
+  def ipv4_addr(_dev), do: err()
   
   @doc """
   Retrieve the IPv6 address for the given tailscale device.
   
   Blocks until the device is connected and gets its address from control.
   """
-  @spec ipv6(device()) :: {:ok, :inet.ip6_address()} | {:error, any()}
-  def ipv6(_dev), do: err()
+  @spec ipv6_addr(device()) :: {:ok, :inet.ip6_address()} | {:error, any()}
+  def ipv6_addr(_dev), do: err()
 end

--- a/ts_elixir/native/ts_elixir/src/lib.rs
+++ b/ts_elixir/native/ts_elixir/src/lib.rs
@@ -86,18 +86,18 @@ fn start_tracing() -> impl Encoder {
 }
 
 #[rustler::nif(schedule = "DirtyIo")]
-fn ipv4(env: rustler::Env, dev: ResourceArc<Device>) -> impl Encoder {
+fn ipv4_addr(env: rustler::Env, dev: ResourceArc<Device>) -> impl Encoder {
     let dev = dev.inner.clone();
-    let addr = TOKIO_RUNTIME.block_on(dev.ipv4());
+    let addr = TOKIO_RUNTIME.block_on(dev.ipv4_addr());
 
     erl_result(env, addr.map(|ip| ip_to_erl(env, ip)).map_err(Into::into))
 }
 
 #[rustler::nif(schedule = "DirtyIo")]
-fn ipv6(env: rustler::Env<'_>, dev: ResourceArc<Device>) -> impl Encoder {
+fn ipv6_addr(env: rustler::Env<'_>, dev: ResourceArc<Device>) -> impl Encoder {
     let dev = dev.inner.clone();
 
-    match TOKIO_RUNTIME.block_on(dev.ipv6()) {
+    match TOKIO_RUNTIME.block_on(dev.ipv6_addr()) {
         Err(e) => (atoms::error(), e.to_string()).encode(env),
         Ok(ip) => (atoms::ok(), ip_to_erl(env, ip)).encode(env),
     }
@@ -146,8 +146,8 @@ impl IpOrSelf {
     pub async fn resolve(&self, dev: &tailscale::Device) -> Result<IpAddr> {
         match self {
             IpOrSelf::Ip(ip) => Ok(*ip),
-            IpOrSelf::SelfV4 => dev.ipv4().await.map(Into::into).map_err(Into::into),
-            IpOrSelf::SelfV6 => dev.ipv6().await.map(Into::into).map_err(Into::into),
+            IpOrSelf::SelfV4 => dev.ipv4_addr().await.map(Into::into).map_err(Into::into),
+            IpOrSelf::SelfV6 => dev.ipv6_addr().await.map(Into::into).map_err(Into::into),
         }
     }
 }

--- a/ts_ffi/examples/tcp_echo/tcp_echo.c
+++ b/ts_ffi/examples/tcp_echo/tcp_echo.c
@@ -28,7 +28,7 @@ static void* run_conn_echo(void* arg) {
     ts_tcp_stream* stream = arg;
     pthread_t id = pthread_self();
 
-    struct ts_sockaddr remote_addr = ts_tcp_remote(stream);
+    struct ts_sockaddr remote_addr = ts_tcp_remote_addr(stream);
     struct ts_sockaddr_in remote_addr_in = remote_addr.sa_data.sockaddr_in;
 
     char* addr_str = inet_ntoa(*(struct in_addr*)&remote_addr_in.sin_addr);
@@ -79,7 +79,7 @@ int main(int argc, char** argv) {
             },
         },
     };
-    assert(!ts_ipv4(dev, &addr.sa_data.sockaddr_in.sin_addr));
+    assert(!ts_ipv4_addr(dev, &addr.sa_data.sockaddr_in.sin_addr));
 
     char* addr_str = inet_ntoa(*(struct in_addr*)&addr.sa_data.sockaddr_in.sin_addr);
     printf("listening on %s:%u\n", addr_str, 1234);

--- a/ts_ffi/examples/udp_ping/udp_ping.c
+++ b/ts_ffi/examples/udp_ping/udp_ping.c
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
             },
         },
     };
-    assert(!ts_ipv4(dev, &addr.sa_data.sockaddr_in.sin_addr));
+    assert(!ts_ipv4_addr(dev, &addr.sa_data.sockaddr_in.sin_addr));
 
     char* addr_str = inet_ntoa(*(struct in_addr*)&addr.sa_data.sockaddr_in.sin_addr);
     printf("bound to %s:%u\n", addr_str, 1234);

--- a/ts_ffi/src/lib.rs
+++ b/ts_ffi/src/lib.rs
@@ -32,7 +32,7 @@ pub use net_types::{
 };
 pub use tcp::{
     tcp_listener, tcp_stream, ts_tcp_close, ts_tcp_close_listener, ts_tcp_connect, ts_tcp_listen,
-    ts_tcp_listener_local, ts_tcp_local, ts_tcp_recv, ts_tcp_remote, ts_tcp_send,
+    ts_tcp_listener_local_addr, ts_tcp_local_addr, ts_tcp_recv, ts_tcp_remote_addr, ts_tcp_send,
 };
 pub use udp::{ts_udp_bind, ts_udp_close, ts_udp_recvfrom, ts_udp_sendto, udp_socket};
 
@@ -124,7 +124,7 @@ pub extern "C" fn ts_deinit(dev: Box<device>) {
 ///
 /// Returns a negative number on error.
 #[unsafe(no_mangle)]
-pub extern "C" fn ts_ipv4(dev: &device, dst: &mut in_addr_t) -> ffi::c_int {
+pub extern "C" fn ts_ipv4_addr(dev: &device, dst: &mut in_addr_t) -> ffi::c_int {
     let addr = match TOKIO_RUNTIME.block_on(dev.0.ipv4_addr()) {
         Ok(addr) => addr,
         Err(e) => {
@@ -142,7 +142,7 @@ pub extern "C" fn ts_ipv4(dev: &device, dst: &mut in_addr_t) -> ffi::c_int {
 ///
 /// Returns a negative number on error.
 #[unsafe(no_mangle)]
-pub extern "C" fn ts_ipv6(dev: &device, dst: &mut in6_addr_t) -> ffi::c_int {
+pub extern "C" fn ts_ipv6_addr(dev: &device, dst: &mut in6_addr_t) -> ffi::c_int {
     let addr = match TOKIO_RUNTIME.block_on(dev.0.ipv6_addr()) {
         Ok(addr) => addr,
         Err(e) => {

--- a/ts_ffi/src/lib.rs
+++ b/ts_ffi/src/lib.rs
@@ -125,7 +125,7 @@ pub extern "C" fn ts_deinit(dev: Box<device>) {
 /// Returns a negative number on error.
 #[unsafe(no_mangle)]
 pub extern "C" fn ts_ipv4(dev: &device, dst: &mut in_addr_t) -> ffi::c_int {
-    let addr = match TOKIO_RUNTIME.block_on(dev.0.ipv4()) {
+    let addr = match TOKIO_RUNTIME.block_on(dev.0.ipv4_addr()) {
         Ok(addr) => addr,
         Err(e) => {
             tracing::error!(error = %e, "getting ipv4");
@@ -143,7 +143,7 @@ pub extern "C" fn ts_ipv4(dev: &device, dst: &mut in_addr_t) -> ffi::c_int {
 /// Returns a negative number on error.
 #[unsafe(no_mangle)]
 pub extern "C" fn ts_ipv6(dev: &device, dst: &mut in6_addr_t) -> ffi::c_int {
-    let addr = match TOKIO_RUNTIME.block_on(dev.0.ipv6()) {
+    let addr = match TOKIO_RUNTIME.block_on(dev.0.ipv6_addr()) {
         Ok(addr) => addr,
         Err(e) => {
             tracing::error!(error = %e, "getting ipv6");

--- a/ts_ffi/src/tcp.rs
+++ b/ts_ffi/src/tcp.rs
@@ -44,7 +44,7 @@ pub extern "C" fn ts_tcp_accept(listener: &tcp_listener) -> Option<Box<tcp_strea
 /// Get the local endpoint `listener` is listening on.
 #[unsafe(no_mangle)]
 pub extern "C" fn ts_tcp_listener_local(listener: &tcp_listener) -> crate::sockaddr {
-    listener.0.local_endpoint().into()
+    listener.0.local_endpoint_addr().into()
 }
 
 /// Close the specified socket.
@@ -123,13 +123,13 @@ pub unsafe extern "C" fn ts_tcp_recv(stream: &tcp_stream, buf: *mut u8, len: usi
 /// Get the local endpoint for this TCP stream.
 #[unsafe(no_mangle)]
 pub extern "C" fn ts_tcp_local(stream: &tcp_stream) -> crate::sockaddr {
-    stream.0.local_endpoint().into()
+    stream.0.local_endpoint_addr().into()
 }
 
 /// Get the remote endpoint this TCP stream is connected to.
 #[unsafe(no_mangle)]
 pub extern "C" fn ts_tcp_remote(stream: &tcp_stream) -> crate::sockaddr {
-    stream.0.remote_endpoint().into()
+    stream.0.remote_endpoint_addr().into()
 }
 
 /// Close the specified socket.

--- a/ts_ffi/src/tcp.rs
+++ b/ts_ffi/src/tcp.rs
@@ -43,8 +43,8 @@ pub extern "C" fn ts_tcp_accept(listener: &tcp_listener) -> Option<Box<tcp_strea
 
 /// Get the local endpoint `listener` is listening on.
 #[unsafe(no_mangle)]
-pub extern "C" fn ts_tcp_listener_local(listener: &tcp_listener) -> crate::sockaddr {
-    listener.0.local_endpoint_addr().into()
+pub extern "C" fn ts_tcp_listener_local_addr(listener: &tcp_listener) -> crate::sockaddr {
+    listener.0.local_addr().into()
 }
 
 /// Close the specified socket.
@@ -122,14 +122,14 @@ pub unsafe extern "C" fn ts_tcp_recv(stream: &tcp_stream, buf: *mut u8, len: usi
 
 /// Get the local endpoint for this TCP stream.
 #[unsafe(no_mangle)]
-pub extern "C" fn ts_tcp_local(stream: &tcp_stream) -> crate::sockaddr {
-    stream.0.local_endpoint_addr().into()
+pub extern "C" fn ts_tcp_local_addr(stream: &tcp_stream) -> crate::sockaddr {
+    stream.0.local_addr().into()
 }
 
 /// Get the remote endpoint this TCP stream is connected to.
 #[unsafe(no_mangle)]
-pub extern "C" fn ts_tcp_remote(stream: &tcp_stream) -> crate::sockaddr {
-    stream.0.remote_endpoint_addr().into()
+pub extern "C" fn ts_tcp_remote_addr(stream: &tcp_stream) -> crate::sockaddr {
+    stream.0.remote_addr().into()
 }
 
 /// Close the specified socket.

--- a/ts_ffi/src/udp.rs
+++ b/ts_ffi/src/udp.rs
@@ -101,5 +101,5 @@ pub unsafe extern "C" fn ts_udp_recvfrom(
 /// Get the local endpoint to which the socket is bound.
 #[unsafe(no_mangle)]
 pub extern "C" fn ts_udp_local(sock: &udp_socket) -> crate::sockaddr {
-    sock.0.local_endpoint().into()
+    sock.0.local_endpoint_addr().into()
 }

--- a/ts_ffi/src/udp.rs
+++ b/ts_ffi/src/udp.rs
@@ -100,6 +100,6 @@ pub unsafe extern "C" fn ts_udp_recvfrom(
 
 /// Get the local endpoint to which the socket is bound.
 #[unsafe(no_mangle)]
-pub extern "C" fn ts_udp_local(sock: &udp_socket) -> crate::sockaddr {
-    sock.0.local_endpoint_addr().into()
+pub extern "C" fn ts_udp_local_addr(sock: &udp_socket) -> crate::sockaddr {
+    sock.0.local_addr().into()
 }

--- a/ts_netstack_smoltcp/examples/axum_tun/main.rs
+++ b/ts_netstack_smoltcp/examples/axum_tun/main.rs
@@ -92,12 +92,12 @@ impl axum::serve::Listener for Listener {
             }
         };
 
-        let addr = stream.remote_endpoint();
+        let addr = stream.remote_endpoint_addr();
 
         (stream, addr)
     }
 
     fn local_addr(&self) -> std::io::Result<Self::Addr> {
-        Ok(self.0.local_endpoint())
+        Ok(self.0.local_endpoint_addr())
     }
 }

--- a/ts_netstack_smoltcp/examples/axum_tun/main.rs
+++ b/ts_netstack_smoltcp/examples/axum_tun/main.rs
@@ -92,12 +92,12 @@ impl axum::serve::Listener for Listener {
             }
         };
 
-        let addr = stream.remote_endpoint_addr();
+        let addr = stream.remote_addr();
 
         (stream, addr)
     }
 
     fn local_addr(&self) -> std::io::Result<Self::Addr> {
-        Ok(self.0.local_endpoint_addr())
+        Ok(self.0.local_addr())
     }
 }

--- a/ts_netstack_smoltcp/examples/common/mod.rs
+++ b/ts_netstack_smoltcp/examples/common/mod.rs
@@ -250,7 +250,7 @@ where
 pub fn netstack_listen_blocking(listener: netsock::TcpListener) {
     loop {
         let sock = listener.accept_blocking().unwrap();
-        tracing::debug!(remote = %sock.remote_endpoint(), "connection accepted");
+        tracing::debug!(remote = %sock.remote_endpoint_addr(), "connection accepted");
 
         std::thread::spawn(move || socket_pingpong_blocking(sock));
     }
@@ -261,7 +261,7 @@ pub fn netstack_listen_blocking(listener: netsock::TcpListener) {
 pub async fn netstack_listen(listener: netsock::TcpListener) {
     loop {
         let sock = listener.accept().await.unwrap();
-        tracing::debug!(remote = %sock.remote_endpoint(), "connection accepted");
+        tracing::debug!(remote = %sock.remote_endpoint_addr(), "connection accepted");
 
         tokio::task::spawn(socket_pingpong(sock));
     }

--- a/ts_netstack_smoltcp/examples/common/mod.rs
+++ b/ts_netstack_smoltcp/examples/common/mod.rs
@@ -250,7 +250,7 @@ where
 pub fn netstack_listen_blocking(listener: netsock::TcpListener) {
     loop {
         let sock = listener.accept_blocking().unwrap();
-        tracing::debug!(remote = %sock.remote_endpoint_addr(), "connection accepted");
+        tracing::debug!(remote = %sock.remote_addr(), "connection accepted");
 
         std::thread::spawn(move || socket_pingpong_blocking(sock));
     }
@@ -261,7 +261,7 @@ pub fn netstack_listen_blocking(listener: netsock::TcpListener) {
 pub async fn netstack_listen(listener: netsock::TcpListener) {
     loop {
         let sock = listener.accept().await.unwrap();
-        tracing::debug!(remote = %sock.remote_endpoint_addr(), "connection accepted");
+        tracing::debug!(remote = %sock.remote_addr(), "connection accepted");
 
         tokio::task::spawn(socket_pingpong(sock));
     }

--- a/ts_netstack_smoltcp/examples/tcp_connect_tun.rs
+++ b/ts_netstack_smoltcp/examples/tcp_connect_tun.rs
@@ -24,8 +24,8 @@ fn main() -> common::Result<()> {
         stack_handle.tcp_connect_blocking(common::netstack_endpoint(), common::tun_endpoint())?;
     tracing::debug!(?sock, "netstack stream connected");
 
-    assert_eq!(sock.local_endpoint(), common::netstack_endpoint());
-    assert_eq!(sock.remote_endpoint(), common::tun_endpoint());
+    assert_eq!(sock.local_endpoint_addr(), common::netstack_endpoint());
+    assert_eq!(sock.remote_endpoint_addr(), common::tun_endpoint());
 
     common::socket_pingpong_blocking(sock);
 

--- a/ts_netstack_smoltcp/examples/tcp_connect_tun.rs
+++ b/ts_netstack_smoltcp/examples/tcp_connect_tun.rs
@@ -24,8 +24,8 @@ fn main() -> common::Result<()> {
         stack_handle.tcp_connect_blocking(common::netstack_endpoint(), common::tun_endpoint())?;
     tracing::debug!(?sock, "netstack stream connected");
 
-    assert_eq!(sock.local_endpoint_addr(), common::netstack_endpoint());
-    assert_eq!(sock.remote_endpoint_addr(), common::tun_endpoint());
+    assert_eq!(sock.local_addr(), common::netstack_endpoint());
+    assert_eq!(sock.remote_addr(), common::tun_endpoint());
 
     common::socket_pingpong_blocking(sock);
 

--- a/ts_netstack_smoltcp/examples/tcp_connect_tun_async.rs
+++ b/ts_netstack_smoltcp/examples/tcp_connect_tun_async.rs
@@ -27,8 +27,8 @@ async fn main() -> common::Result<()> {
         .await?;
     tracing::debug!(?sock, "netstack stream connected");
 
-    assert_eq!(sock.local_endpoint(), common::netstack_endpoint());
-    assert_eq!(sock.remote_endpoint(), common::tun_endpoint());
+    assert_eq!(sock.local_endpoint_addr(), common::netstack_endpoint());
+    assert_eq!(sock.remote_endpoint_addr(), common::tun_endpoint());
 
     common::socket_pingpong(sock).await;
 

--- a/ts_netstack_smoltcp/examples/tcp_connect_tun_async.rs
+++ b/ts_netstack_smoltcp/examples/tcp_connect_tun_async.rs
@@ -27,8 +27,8 @@ async fn main() -> common::Result<()> {
         .await?;
     tracing::debug!(?sock, "netstack stream connected");
 
-    assert_eq!(sock.local_endpoint_addr(), common::netstack_endpoint());
-    assert_eq!(sock.remote_endpoint_addr(), common::tun_endpoint());
+    assert_eq!(sock.local_addr(), common::netstack_endpoint());
+    assert_eq!(sock.remote_addr(), common::tun_endpoint());
 
     common::socket_pingpong(sock).await;
 

--- a/ts_netstack_smoltcp/examples/tcp_pingpong_pipe.rs
+++ b/ts_netstack_smoltcp/examples/tcp_pingpong_pipe.rs
@@ -18,8 +18,8 @@ fn main() -> common::Result<()> {
 
     tracing::debug!(?sock, "netstack stream connected");
 
-    assert_eq!(sock.local_endpoint(), common::netstack_endpoint());
-    assert_eq!(sock.remote_endpoint(), common::netstack2_endpoint());
+    assert_eq!(sock.local_endpoint_addr(), common::netstack_endpoint());
+    assert_eq!(sock.remote_endpoint_addr(), common::netstack2_endpoint());
 
     common::socket_pingpong_blocking(sock);
 

--- a/ts_netstack_smoltcp/examples/tcp_pingpong_pipe.rs
+++ b/ts_netstack_smoltcp/examples/tcp_pingpong_pipe.rs
@@ -18,8 +18,8 @@ fn main() -> common::Result<()> {
 
     tracing::debug!(?sock, "netstack stream connected");
 
-    assert_eq!(sock.local_endpoint_addr(), common::netstack_endpoint());
-    assert_eq!(sock.remote_endpoint_addr(), common::netstack2_endpoint());
+    assert_eq!(sock.local_addr(), common::netstack_endpoint());
+    assert_eq!(sock.remote_addr(), common::netstack2_endpoint());
 
     common::socket_pingpong_blocking(sock);
 

--- a/ts_netstack_smoltcp/examples/tcp_pingpong_pipe_async.rs
+++ b/ts_netstack_smoltcp/examples/tcp_pingpong_pipe_async.rs
@@ -21,8 +21,8 @@ async fn main() -> common::Result<()> {
 
     tracing::debug!(?sock, "netstack stream connected");
 
-    assert_eq!(sock.local_endpoint(), common::netstack_endpoint());
-    assert_eq!(sock.remote_endpoint(), common::netstack2_endpoint());
+    assert_eq!(sock.local_endpoint_addr(), common::netstack_endpoint());
+    assert_eq!(sock.remote_endpoint_addr(), common::netstack2_endpoint());
 
     common::socket_pingpong(sock).await;
 

--- a/ts_netstack_smoltcp/examples/tcp_pingpong_pipe_async.rs
+++ b/ts_netstack_smoltcp/examples/tcp_pingpong_pipe_async.rs
@@ -21,8 +21,8 @@ async fn main() -> common::Result<()> {
 
     tracing::debug!(?sock, "netstack stream connected");
 
-    assert_eq!(sock.local_endpoint_addr(), common::netstack_endpoint());
-    assert_eq!(sock.remote_endpoint_addr(), common::netstack2_endpoint());
+    assert_eq!(sock.local_addr(), common::netstack_endpoint());
+    assert_eq!(sock.remote_addr(), common::netstack2_endpoint());
 
     common::socket_pingpong(sock).await;
 

--- a/ts_netstack_smoltcp/examples/udp_tun.rs
+++ b/ts_netstack_smoltcp/examples/udp_tun.rs
@@ -22,7 +22,7 @@ fn main() -> common::Result<()> {
     let sock = stack_handle.udp_bind_blocking(common::netstack_endpoint())?;
     tracing::debug!(?sock, "netstack socket bound");
 
-    assert_eq!(sock.local_endpoint_addr(), common::netstack_endpoint());
+    assert_eq!(sock.local_addr(), common::netstack_endpoint());
 
     let sock = Arc::new(sock);
 

--- a/ts_netstack_smoltcp/examples/udp_tun.rs
+++ b/ts_netstack_smoltcp/examples/udp_tun.rs
@@ -22,7 +22,7 @@ fn main() -> common::Result<()> {
     let sock = stack_handle.udp_bind_blocking(common::netstack_endpoint())?;
     tracing::debug!(?sock, "netstack socket bound");
 
-    assert_eq!(sock.local_endpoint(), common::netstack_endpoint());
+    assert_eq!(sock.local_endpoint_addr(), common::netstack_endpoint());
 
     let sock = Arc::new(sock);
 

--- a/ts_netstack_smoltcp/examples/udp_tun_async.rs
+++ b/ts_netstack_smoltcp/examples/udp_tun_async.rs
@@ -24,7 +24,7 @@ async fn main() -> common::Result<()> {
     let sock = stack_handle.udp_bind(common::netstack_endpoint()).await?;
     tracing::debug!(?sock, "netstack socket bound");
 
-    assert_eq!(sock.local_endpoint(), common::netstack_endpoint());
+    assert_eq!(sock.local_endpoint_addr(), common::netstack_endpoint());
 
     let sock = Arc::new(sock);
 

--- a/ts_netstack_smoltcp/examples/udp_tun_async.rs
+++ b/ts_netstack_smoltcp/examples/udp_tun_async.rs
@@ -24,7 +24,7 @@ async fn main() -> common::Result<()> {
     let sock = stack_handle.udp_bind(common::netstack_endpoint()).await?;
     tracing::debug!(?sock, "netstack socket bound");
 
-    assert_eq!(sock.local_endpoint_addr(), common::netstack_endpoint());
+    assert_eq!(sock.local_addr(), common::netstack_endpoint());
 
     let sock = Arc::new(sock);
 

--- a/ts_netstack_smoltcp_socket/src/tcp/listener.rs
+++ b/ts_netstack_smoltcp_socket/src/tcp/listener.rs
@@ -67,7 +67,7 @@ impl TcpListener {
     }
 
     /// Report the local endpoint on which this is listening.
-    pub const fn local_endpoint(&self) -> SocketAddr {
+    pub const fn local_endpoint_addr(&self) -> SocketAddr {
         self.endpoint
     }
 }

--- a/ts_netstack_smoltcp_socket/src/tcp/listener.rs
+++ b/ts_netstack_smoltcp_socket/src/tcp/listener.rs
@@ -67,7 +67,7 @@ impl TcpListener {
     }
 
     /// Report the local endpoint on which this is listening.
-    pub const fn local_endpoint_addr(&self) -> SocketAddr {
+    pub const fn local_addr(&self) -> SocketAddr {
         self.endpoint
     }
 }

--- a/ts_netstack_smoltcp_socket/src/tcp/stream.rs
+++ b/ts_netstack_smoltcp_socket/src/tcp/stream.rs
@@ -63,12 +63,12 @@ impl Debug for TcpStream {
 
 impl TcpStream {
     /// Report the local endpoint to which this stream is connected.
-    pub const fn local_endpoint(&self) -> SocketAddr {
+    pub const fn local_endpoint_addr(&self) -> SocketAddr {
         self.local
     }
 
     /// Report the remote endpoint to which this stream is connected.
-    pub const fn remote_endpoint(&self) -> SocketAddr {
+    pub const fn remote_endpoint_addr(&self) -> SocketAddr {
         self.remote
     }
 

--- a/ts_netstack_smoltcp_socket/src/tcp/stream.rs
+++ b/ts_netstack_smoltcp_socket/src/tcp/stream.rs
@@ -63,12 +63,12 @@ impl Debug for TcpStream {
 
 impl TcpStream {
     /// Report the local endpoint to which this stream is connected.
-    pub const fn local_endpoint_addr(&self) -> SocketAddr {
+    pub const fn local_addr(&self) -> SocketAddr {
         self.local
     }
 
     /// Report the remote endpoint to which this stream is connected.
-    pub const fn remote_endpoint_addr(&self) -> SocketAddr {
+    pub const fn remote_addr(&self) -> SocketAddr {
         self.remote
     }
 

--- a/ts_netstack_smoltcp_socket/src/udp.rs
+++ b/ts_netstack_smoltcp_socket/src/udp.rs
@@ -119,7 +119,7 @@ impl UdpSocket {
     }
 
     /// Report the local endpoint to which this socket is bound.
-    pub const fn local_endpoint_addr(&self) -> SocketAddr {
+    pub const fn local_addr(&self) -> SocketAddr {
         self.local
     }
 

--- a/ts_netstack_smoltcp_socket/src/udp.rs
+++ b/ts_netstack_smoltcp_socket/src/udp.rs
@@ -119,7 +119,7 @@ impl UdpSocket {
     }
 
     /// Report the local endpoint to which this socket is bound.
-    pub const fn local_endpoint(&self) -> SocketAddr {
+    pub const fn local_endpoint_addr(&self) -> SocketAddr {
         self.local
     }
 

--- a/ts_python/README.md
+++ b/ts_python/README.md
@@ -17,9 +17,9 @@ async def main():
     dev = await tailscale.connect('tsrs_state.json', "tskey-auth-$MY_AUTH_KEY")
 
     # bind a udp socket on this node's ipv4 address:
-    tailnet_ipv4 = await dev.ipv4()
+    tailnet_ipv4 = await dev.ipv4_addr()
     udp_sock = await dev.udp_bind((tailnet_ipv4, 1234))
-    print(f'udp bound, local endpoint: {udp_sock.local_endpoint()}')
+    print(f'udp bound, local endpoint: {udp_sock.local_endpoint_addr()}')
 
     # send a message to a peer once per second
     while True:

--- a/ts_python/src/lib.rs
+++ b/ts_python/src/lib.rs
@@ -124,21 +124,21 @@ impl Device {
     }
 
     /// Get the device's IPv4 tailnet address.
-    pub fn ipv4<'p>(&self, py: Python<'p>) -> PyFut<'p> {
+    pub fn ipv4_addr<'p>(&self, py: Python<'p>) -> PyFut<'p> {
         let dev = self.dev.clone();
 
         future_into_py(py, async move {
-            let ip = dev.ipv4().await.map_err(py_value_err)?;
+            let ip = dev.ipv4_addr().await.map_err(py_value_err)?;
             Ok(ip.to_string())
         })
     }
 
     /// Get the device's IPv6 tailnet address.
-    pub fn ipv6<'p>(&self, py: Python<'p>) -> PyFut<'p> {
+    pub fn ipv6_addr<'p>(&self, py: Python<'p>) -> PyFut<'p> {
         let dev = self.dev.clone();
 
         future_into_py(py, async move {
-            let ip = dev.ipv6().await.map_err(py_value_err)?;
+            let ip = dev.ipv6_addr().await.map_err(py_value_err)?;
             Ok(ip.to_string())
         })
     }

--- a/ts_python/src/tcp.rs
+++ b/ts_python/src/tcp.rs
@@ -35,12 +35,15 @@ impl TcpListener {
     }
 
     /// Get the local endpoint this TCP listener is listening on.
-    pub fn local_endpoint(&self) -> (String, u16) {
-        sockaddr_as_tuple(self.listener.local_endpoint())
+    pub fn local_endpoint_addr(&self) -> (String, u16) {
+        sockaddr_as_tuple(self.listener.local_endpoint_addr())
     }
 
     fn __repr__(&self) -> String {
-        format!("tailscale.TcpListener({})", self.listener.local_endpoint(),)
+        format!(
+            "tailscale.TcpListener({})",
+            self.listener.local_endpoint_addr(),
+        )
     }
 }
 
@@ -74,20 +77,20 @@ impl TcpStream {
     }
 
     /// Get the local endpoint this socket is bound to.
-    pub fn local_endpoint(&self) -> (String, u16) {
-        sockaddr_as_tuple(self.sock.local_endpoint())
+    pub fn local_endpoint_addr(&self) -> (String, u16) {
+        sockaddr_as_tuple(self.sock.local_endpoint_addr())
     }
 
     /// Get the remote endpoint this socket is connected to.
-    pub fn remote_endpoint(&self) -> (String, u16) {
-        sockaddr_as_tuple(self.sock.remote_endpoint())
+    pub fn remote_endpoint_addr(&self) -> (String, u16) {
+        sockaddr_as_tuple(self.sock.remote_endpoint_addr())
     }
 
     fn __repr__(&self) -> String {
         format!(
             "tailscale.TcpStream({} -> {})",
-            self.sock.local_endpoint(),
-            self.sock.remote_endpoint()
+            self.sock.local_endpoint_addr(),
+            self.sock.remote_endpoint_addr()
         )
     }
 

--- a/ts_python/src/tcp.rs
+++ b/ts_python/src/tcp.rs
@@ -36,14 +36,11 @@ impl TcpListener {
 
     /// Get the local endpoint this TCP listener is listening on.
     pub fn local_endpoint_addr(&self) -> (String, u16) {
-        sockaddr_as_tuple(self.listener.local_endpoint_addr())
+        sockaddr_as_tuple(self.listener.local_addr())
     }
 
     fn __repr__(&self) -> String {
-        format!(
-            "tailscale.TcpListener({})",
-            self.listener.local_endpoint_addr(),
-        )
+        format!("tailscale.TcpListener({})", self.listener.local_addr(),)
     }
 }
 
@@ -78,19 +75,19 @@ impl TcpStream {
 
     /// Get the local endpoint this socket is bound to.
     pub fn local_endpoint_addr(&self) -> (String, u16) {
-        sockaddr_as_tuple(self.sock.local_endpoint_addr())
+        sockaddr_as_tuple(self.sock.local_addr())
     }
 
     /// Get the remote endpoint this socket is connected to.
     pub fn remote_endpoint_addr(&self) -> (String, u16) {
-        sockaddr_as_tuple(self.sock.remote_endpoint_addr())
+        sockaddr_as_tuple(self.sock.remote_addr())
     }
 
     fn __repr__(&self) -> String {
         format!(
             "tailscale.TcpStream({} -> {})",
-            self.sock.local_endpoint_addr(),
-            self.sock.remote_endpoint_addr()
+            self.sock.local_addr(),
+            self.sock.remote_addr()
         )
     }
 

--- a/ts_python/src/udp.rs
+++ b/ts_python/src/udp.rs
@@ -55,10 +55,10 @@ impl UdpSocket {
 
     /// Get the local endpoint this socket is bound to.
     pub fn local_endpoint_addr(&self) -> (String, u16) {
-        sockaddr_as_tuple(self.sock.local_endpoint_addr())
+        sockaddr_as_tuple(self.sock.local_addr())
     }
 
     fn __repr__(&self) -> String {
-        format!("tailscale.UdpSocket({})", self.sock.local_endpoint_addr())
+        format!("tailscale.UdpSocket({})", self.sock.local_addr())
     }
 }

--- a/ts_python/src/udp.rs
+++ b/ts_python/src/udp.rs
@@ -54,11 +54,11 @@ impl UdpSocket {
     }
 
     /// Get the local endpoint this socket is bound to.
-    pub fn local_endpoint(&self) -> (String, u16) {
-        sockaddr_as_tuple(self.sock.local_endpoint())
+    pub fn local_endpoint_addr(&self) -> (String, u16) {
+        sockaddr_as_tuple(self.sock.local_endpoint_addr())
     }
 
     fn __repr__(&self) -> String {
-        format!("tailscale.UdpSocket({})", self.sock.local_endpoint())
+        format!("tailscale.UdpSocket({})", self.sock.local_endpoint_addr())
     }
 }

--- a/ts_runtime/src/lib.rs
+++ b/ts_runtime/src/lib.rs
@@ -73,7 +73,7 @@ impl Runtime {
 
         let control = ControlRunner::spawn(control_runner::Params {
             config,
-            auth_key: auth_key.map(|x| x.to_owned()),
+            auth_key,
             env: env.clone(),
         });
 


### PR DESCRIPTION
This PR re-exports a few types so that users shouldn't need to use any crate except the main one (which includes renaming Config to ControlConfig, partly in advance of Nathan's config PR which introduces another kind of Config). One thing I wasn't sure about was netstack::Error, which is returned by some socket methods. I didn't re-export since the user can just use `into` to get a tailscale::Error, but it's a bit unsatisfactory that we have these two similar error types. I think I would prefer to have just one API error and to use that in both places, but that's a bigger refactoring so have left that for now. I'm interested in thoughts though.

The final commit is a somewhat speculative renaming. I think graceful_shutdown -> shutdown is good, but not sure about the _addr suffixes. I added them because without it felt to me like it was doing something more than just getting an address (maybe converting into an upgraded device or something). If we like this change then we should probably change the language bindings and the endpoint methods on the sockets. Or we could just not do this change if you think it is clear as is.