### PR TITLE
tailscale, runtime: support peer lookup by name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,8 @@ mod error;
 pub use config::{BadFormatBehavior, Config, load_key_file};
 #[doc(inline)]
 pub use error::Error;
+#[doc(inline)]
+pub use ts_control::Node as NodeInfo;
 
 /// A tailscale device.
 pub struct Device {
@@ -154,6 +156,22 @@ impl Device {
             .tcp_connect((ip, ephemeral_port).into(), remote)
             .await
             .map_err(Into::into)
+    }
+
+    /// Look up a peer by name.
+    pub async fn peer_by_name(&self, name: &str) -> Result<Option<NodeInfo>, Error> {
+        let pt = self
+            .runtime
+            .peer_tracker
+            .upgrade()
+            .ok_or(Error::RuntimeDegraded)?;
+
+        pt.ask(ts_runtime::peer_tracker::PeerByName {
+            name: name.to_string(),
+        })
+        .await
+        .map_err(ts_runtime::Error::from)
+        .map_err(Into::into)
     }
 
     /// Attempt to gracefully shut down this device's runtime.

--- a/ts_control/src/node.rs
+++ b/ts_control/src/node.rs
@@ -56,7 +56,9 @@ impl Node {
     /// Tailscale's control plane, this usually means `$HOST.tail1234.ts.net.`
     ///
     /// The `trailing_dot` parameter specifies whether to include the trailing dot in the
-    /// fqdn. This is the way the Go codebase formats this field.
+    /// fqdn. This is included by the definition of FQDN, and is the way the Go codebase
+    /// formats this field, but the parameter is included to allow turning it off for use
+    /// in contexts that expect it to be absent.
     pub fn fqdn(&self, trailing_dot: bool) -> String {
         let dot = if trailing_dot { "." } else { "" };
         match &self.tailnet {

--- a/ts_control/src/node.rs
+++ b/ts_control/src/node.rs
@@ -17,8 +17,13 @@ pub struct Node {
     pub id: Id,
     /// The node's stable id.
     pub stable_id: StableId,
-    /// The name of the node.
-    pub name: String,
+
+    /// This node's hostname.
+    pub hostname: String,
+
+    /// The tailnet this node belongs to.
+    pub tailnet: Option<String>,
+
     /// The tags assigned to this node.
     pub tags: Vec<String>,
 
@@ -44,6 +49,48 @@ pub struct Node {
     pub derp_region: Option<ts_transport_derp::RegionId>,
 }
 
+impl Node {
+    /// The fully-qualified domain name of the node.
+    ///
+    /// This is a string of the form `$HOST.$TAILNET_DOMAIN.`. For tailnets controlled by
+    /// Tailscale's control plane, this usually means `$HOST.tail1234.ts.net.`
+    ///
+    /// The `trailing_dot` parameter specifies whether to include the trailing dot in the
+    /// fqdn. This is the way the Go codebase formats this field.
+    pub fn fqdn(&self, trailing_dot: bool) -> String {
+        let dot = if trailing_dot { "." } else { "" };
+        match &self.tailnet {
+            Some(tailnet) => format!("{}.{tailnet}{dot}", self.hostname),
+            None => format!("{}{dot}", self.hostname),
+        }
+    }
+
+    /// Report whether this node matches the given `name`.
+    ///
+    /// `name` is checked for equality with both this node's bare hostname and its fqdn. A
+    /// trailing `.` may be present.
+    pub fn matches_name(&self, name: &str) -> bool {
+        // This approach is taken to avoid allocating a buffer just for the sake of making this
+        // comparison: try to chop `.tailnet.` off of the end of `name` and compare the
+        // remainder to our hostname. If `.tailnet.` doesn't match `name`, we'll end up comparing
+        // our hostname to `hostname.other_tailnet.`, which won't succeed. If `name` was just the
+        // hostname, nothing will have been chopped, so the comparison will still be hostname-to-
+        // hostname.
+
+        let name = name.strip_suffix('.').unwrap_or(name);
+
+        let name = if let Some(tailnet) = &self.tailnet {
+            name.strip_suffix(tailnet.as_str())
+                .and_then(|name| name.strip_suffix('.'))
+                .unwrap_or(name)
+        } else {
+            name
+        };
+
+        name == self.hostname
+    }
+}
+
 /// Addresses for a node within a tailnet.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TailnetAddress {
@@ -65,10 +112,20 @@ impl TailnetAddress {
 
 impl From<&ts_control_serde::Node<'_>> for Node {
     fn from(value: &ts_control_serde::Node) -> Self {
+        let fqdn_without_trailing_dot = value.name.strip_suffix('.').unwrap_or(value.name);
+
+        let (hostname, tailnet) = match fqdn_without_trailing_dot.split_once('.') {
+            Some((hostname, tailnet)) => (hostname, Some(tailnet.to_owned())),
+            None => (fqdn_without_trailing_dot, None),
+        };
+
         Self {
             id: value.id,
             stable_id: StableId(value.stable_id.0.to_string()),
-            name: value.name.to_string(),
+
+            hostname: hostname.to_owned(),
+            tailnet,
+
             tags: value
                 .tags
                 .as_ref()

--- a/ts_runtime/src/lib.rs
+++ b/ts_runtime/src/lib.rs
@@ -25,12 +25,14 @@ mod error;
 mod multiderp;
 mod netstack_actor;
 mod packetfilter;
-mod peer_tracker;
+pub mod peer_tracker;
 mod route_updater;
 mod src_filter;
 
 pub(crate) use env::Env;
 pub use error::{Error, ErrorKind};
+
+use crate::peer_tracker::PeerTracker;
 
 /// The runtime for a tailscale device.
 pub struct Runtime {
@@ -38,6 +40,8 @@ pub struct Runtime {
     pub control: ActorRef<ControlRunner>,
     dataplane: ActorRef<DataplaneActor>,
     netstack: WeakActorRef<NetstackActor>,
+    /// Reference to the peer state tracker actor, used for lookup.
+    pub peer_tracker: WeakActorRef<PeerTracker>,
     env: Env,
     shutdown: watch::Sender<bool>,
 }
@@ -62,7 +66,7 @@ impl Runtime {
         route_updater::RouteUpdater::spawn((multiderp.clone(), env.clone(), netstack_id));
         packetfilter::PacketfilterUpdater::spawn(env.clone());
         src_filter::SourceFilterUpdater::spawn(env.clone());
-        peer_tracker::PeerTracker::spawn(env.clone());
+        let peer_tracker = PeerTracker::spawn(env.clone()).downgrade();
 
         let netstack =
             NetstackActor::spawn((env.clone(), Default::default(), netstack_up, netstack_down));
@@ -76,6 +80,7 @@ impl Runtime {
         Ok(Self {
             control,
             dataplane,
+            peer_tracker,
             netstack: netstack.downgrade(),
             env,
             shutdown: shutdown_tx,

--- a/ts_runtime/src/peer_tracker.rs
+++ b/ts_runtime/src/peer_tracker.rs
@@ -1,3 +1,5 @@
+//! Peer delta update tracking.
+
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -12,6 +14,7 @@ use ts_keys::NodePublicKey;
 
 use crate::{Error, env::Env};
 
+/// Actor that tracks peer delta updates and emits new states.
 pub struct PeerTracker {
     peers: HashMap<NodePublicKey, Node>,
     id_to_nodekey: HashMap<NodeId, NodePublicKey>,
@@ -33,8 +36,30 @@ impl kameo::Actor for PeerTracker {
     }
 }
 
+// For messages with arguments, a struct is generated with the args as fields. They aren't
+// documented, and we can't apply attributes directly to the fields. Hence, wrap in a module where
+// docs are turned off everywhere.
+#[allow(missing_docs)]
+mod msg_impl {
+    use super::*;
+
+    #[kameo::messages]
+    impl PeerTracker {
+        /// Lookup a peer by name.
+        #[message]
+        pub fn peer_by_name(&self, name: String) -> Option<Node> {
+            self.peers
+                .values()
+                .find(|&peer| peer.matches_name(&name))
+                .cloned()
+        }
+    }
+}
+
+pub use msg_impl::*;
+
 #[derive(Debug, Clone)]
-pub struct PeerState {
+pub(crate) struct PeerState {
     #[allow(unused)]
     pub deletions: HashSet<NodePublicKey>,
     #[allow(unused)]


### PR DESCRIPTION
This is the minimal version of peer lookup without a trait or any fanciness: just quasi-dns functionality via a dedicated function.
