### PR TITLE
ts_elixir: simplify async calls

### DIFF
--- a/ts_elixir/native/ts_elixir/src/lib.rs
+++ b/ts_elixir/native/ts_elixir/src/lib.rs
@@ -3,11 +3,10 @@
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     str::FromStr,
-    sync::{Arc, RwLock},
+    sync::{Arc, LazyLock},
 };
 
 use rustler::{Encoder, ResourceArc, Term};
-use tokio::task::JoinHandle;
 
 mod tcp;
 mod udp;
@@ -34,7 +33,16 @@ type Result<T> = core::result::Result<T, Box<dyn core::error::Error + Send + Syn
 #[rustler::resource_impl]
 impl rustler::Resource for Device {}
 
-static TOKIO_RUNTIME: RwLock<Option<tokio::runtime::Runtime>> = RwLock::new(None);
+static TOKIO_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    tracing::debug!("started tokio runtime");
+
+    rt
+});
 
 fn erl_result(env: rustler::Env, r: Result<impl Encoder>) -> Term {
     match r {
@@ -52,7 +60,7 @@ where
 
 #[rustler::nif(schedule = "DirtyIo")]
 fn connect(env: rustler::Env, config_path: String, auth_key: Option<String>) -> impl Encoder {
-    let dev = block_on(async move {
+    let dev = TOKIO_RUNTIME.block_on(async move {
         let config = tailscale::Config {
             key_state: tailscale::load_key_file(config_path, Default::default()).await?,
             client_name: Some("ts_elixir".to_owned()),
@@ -80,7 +88,7 @@ fn start_tracing() -> impl Encoder {
 #[rustler::nif(schedule = "DirtyIo")]
 fn ipv4(env: rustler::Env, dev: ResourceArc<Device>) -> impl Encoder {
     let dev = dev.inner.clone();
-    let addr = block_on(async move { dev.ipv4().await });
+    let addr = TOKIO_RUNTIME.block_on(dev.ipv4());
 
     erl_result(env, addr.map(|ip| ip_to_erl(env, ip)).map_err(Into::into))
 }
@@ -89,7 +97,7 @@ fn ipv4(env: rustler::Env, dev: ResourceArc<Device>) -> impl Encoder {
 fn ipv6(env: rustler::Env<'_>, dev: ResourceArc<Device>) -> impl Encoder {
     let dev = dev.inner.clone();
 
-    match block_on(async move { dev.ipv6().await }) {
+    match TOKIO_RUNTIME.block_on(dev.ipv6()) {
         Err(e) => (atoms::error(), e.to_string()).encode(env),
         Ok(ip) => (atoms::ok(), ip_to_erl(env, ip)).encode(env),
     }
@@ -175,17 +183,6 @@ fn ip_from_erl(ip: Term) -> Option<IpAddr> {
 }
 
 fn load(env: rustler::Env, _term: Term) -> bool {
-    {
-        let mut rt = TOKIO_RUNTIME.write().unwrap();
-        let _present = rt.insert(
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .unwrap(),
-        );
-    }
-    tracing::debug!("started tokio runtime");
-
     let ret = env.register::<UdpSocket>().is_ok()
         && env.register::<Device>().is_ok()
         && env.register::<TcpStream>().is_ok()
@@ -195,32 +192,6 @@ fn load(env: rustler::Env, _term: Term) -> bool {
     }
 
     ret
-}
-
-fn block_on<F>(f: F) -> F::Output
-where
-    F: Future + Send + 'static,
-    F::Output: Send,
-{
-    let (tx, rx) = tokio::sync::oneshot::channel();
-
-    spawn(async move {
-        let ret = f.await;
-        let _result = tx.send(ret);
-    });
-
-    rx.blocking_recv().unwrap()
-}
-
-fn spawn<F>(f: F) -> JoinHandle<F::Output>
-where
-    F: Future + Send + 'static,
-    F::Output: Send,
-{
-    let runtime = TOKIO_RUNTIME.read().unwrap();
-    let rt = runtime.as_ref().unwrap();
-
-    rt.spawn(f)
 }
 
 rustler::init!("Elixir.Tailscale.Native", load = load);

--- a/ts_elixir/native/ts_elixir/src/tcp.rs
+++ b/ts_elixir/native/ts_elixir/src/tcp.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use rustler::{Encoder, ResourceArc};
 
-use crate::{IpOrSelf, Result, atoms, erl_result, ip_from_erl, ok_arc};
+use crate::{IpOrSelf, Result, TOKIO_RUNTIME, atoms, erl_result, ip_from_erl, ok_arc};
 
 pub(crate) struct TcpListener {
     inner: Arc<tailscale::TcpListener>,
@@ -28,7 +28,7 @@ fn tcp_listen(
     let dev = dev.inner.clone();
     let ip = IpOrSelf::new(addr);
 
-    let sock = crate::block_on(async move {
+    let sock = TOKIO_RUNTIME.block_on(async move {
         let addr = ip.ok_or("invalid ip addr")?.resolve(&dev).await?;
         let sock = dev.tcp_listen((addr, port).into()).await?;
 
@@ -50,7 +50,7 @@ fn tcp_connect(
     let addr = ip_from_erl(addr);
     let dev = dev.inner.clone();
 
-    let sock = crate::block_on(async move {
+    let sock = TOKIO_RUNTIME.block_on(async move {
         let addr = addr.ok_or("invalid ip addr")?;
         let sock = dev.tcp_connect((addr, port).into()).await?;
 
@@ -66,7 +66,7 @@ fn tcp_connect(
 fn tcp_accept(env: rustler::Env<'_>, sock: ResourceArc<TcpListener>) -> impl Encoder {
     let inner = sock.inner.clone();
 
-    let sock = crate::block_on(async move {
+    let sock = TOKIO_RUNTIME.block_on(async move {
         let stream = inner.accept().await?;
 
         ok_arc(TcpStream {
@@ -81,7 +81,7 @@ fn tcp_accept(env: rustler::Env<'_>, sock: ResourceArc<TcpListener>) -> impl Enc
 fn tcp_send(env: rustler::Env, sock: ResourceArc<TcpStream>, msg: Vec<u8>) -> rustler::Term {
     let inner = sock.inner.clone();
 
-    match crate::block_on(async move { inner.send(&msg).await }) {
+    match TOKIO_RUNTIME.block_on(async move { inner.send(&msg).await }) {
         Ok(n) => (atoms::ok(), n).encode(env),
         Err(e) => (atoms::error(), e.to_string()).encode(env),
     }
@@ -91,7 +91,7 @@ fn tcp_send(env: rustler::Env, sock: ResourceArc<TcpStream>, msg: Vec<u8>) -> ru
 fn tcp_recv(env: rustler::Env, sock: ResourceArc<TcpStream>) -> impl Encoder {
     let inner = sock.inner.clone();
 
-    let buf = crate::block_on(async move {
+    let buf = TOKIO_RUNTIME.block_on(async move {
         let buf = inner.recv_bytes().await?;
         Result::<_>::Ok(buf.to_vec())
     });

--- a/ts_elixir/native/ts_elixir/src/udp.rs
+++ b/ts_elixir/native/ts_elixir/src/udp.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use rustler::{Binary, Encoder, ResourceArc, Term};
 
-use crate::{Device, IpOrSelf, Result, atoms, erl_result, ip_from_erl, ip_to_erl, ok_arc};
+use crate::{
+    Device, IpOrSelf, Result, TOKIO_RUNTIME, atoms, erl_result, ip_from_erl, ip_to_erl, ok_arc,
+};
 
 pub struct UdpSocket {
     inner: Arc<tailscale::UdpSocket>,
@@ -16,7 +18,7 @@ fn udp_bind(env: rustler::Env, dev: ResourceArc<Device>, ip: Term, port: u16) ->
     let dev = dev.inner.clone();
     let ip = IpOrSelf::new(ip);
 
-    let sock = crate::block_on(async move {
+    let sock = TOKIO_RUNTIME.block_on(async move {
         let addr = ip.ok_or("invalid ip addr")?.resolve(&dev).await?;
         let sock = dev.udp_bind((addr, port).into()).await?;
 
@@ -40,7 +42,7 @@ fn udp_send<'env>(
     let msg = msg.to_vec();
     let sock = sock.inner.clone();
 
-    match crate::block_on(async move {
+    match TOKIO_RUNTIME.block_on(async move {
         let addr = addr.ok_or("invalid ip addr")?;
 
         sock.send_to((addr, port).into(), &msg).await?;


### PR DESCRIPTION
Remove old cruft: switch to `LazyLock<tokio::Runtime>` and just call `Runtime::block_on` rather than custom impl.
