### PR TITLE
ffi: convert `isize` returns to `ffi::c_int`

### DIFF
--- a/ts_ffi/src/lib.rs
+++ b/ts_ffi/src/lib.rs
@@ -18,7 +18,7 @@
 //! synchronization.
 
 use std::{
-    ffi::{CStr, c_char},
+    ffi::{self, CStr, c_char},
     sync::{LazyLock, Once},
 };
 
@@ -124,7 +124,7 @@ pub extern "C" fn ts_deinit(dev: Box<device>) {
 ///
 /// Returns a negative number on error.
 #[unsafe(no_mangle)]
-pub extern "C" fn ts_ipv4(dev: &device, dst: &mut in_addr_t) -> isize {
+pub extern "C" fn ts_ipv4(dev: &device, dst: &mut in_addr_t) -> ffi::c_int {
     let addr = match TOKIO_RUNTIME.block_on(dev.0.ipv4()) {
         Ok(addr) => addr,
         Err(e) => {
@@ -142,7 +142,7 @@ pub extern "C" fn ts_ipv4(dev: &device, dst: &mut in_addr_t) -> isize {
 ///
 /// Returns a negative number on error.
 #[unsafe(no_mangle)]
-pub extern "C" fn ts_ipv6(dev: &device, dst: &mut in6_addr_t) -> isize {
+pub extern "C" fn ts_ipv6(dev: &device, dst: &mut in6_addr_t) -> ffi::c_int {
     let addr = match TOKIO_RUNTIME.block_on(dev.0.ipv6()) {
         Ok(addr) => addr,
         Err(e) => {

--- a/ts_ffi/src/net_types.rs
+++ b/ts_ffi/src/net_types.rs
@@ -9,7 +9,7 @@
 //! if things diverge.
 
 use std::{
-    ffi::{CStr, c_char},
+    ffi::{self, CStr, c_char},
     fmt::{Debug, Formatter},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
 };
@@ -300,7 +300,7 @@ impl From<sockaddr_in6> for SocketAddrV6 {
 /// `s` must be able to be read according to [`CStr`] rules, i.e.
 /// it must be NUL-terminated and valid for reading up to and including the NUL.
 #[unsafe(no_mangle)]
-pub extern "C" fn ts_parse_sockaddr(s: *const c_char, addr: &mut sockaddr) -> isize {
+pub extern "C" fn ts_parse_sockaddr(s: *const c_char, addr: &mut sockaddr) -> ffi::c_int {
     // SAFETY: ensured by function precondition
     let Ok(s) = (unsafe { CStr::from_ptr(s) }).to_str() else {
         tracing::error!("bad utf8");
@@ -331,7 +331,7 @@ pub extern "C" fn ts_parse_sockaddr(s: *const c_char, addr: &mut sockaddr) -> is
 /// `s` must be able to be read according to [`CStr`] rules, i.e.
 /// it must be NUL-terminated and valid for reading up to and including the NUL.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn ts_parse_ip(s: *const c_char, addr: &mut sockaddr) -> isize {
+pub unsafe extern "C" fn ts_parse_ip(s: *const c_char, addr: &mut sockaddr) -> ffi::c_int {
     // SAFETY: ensured by function precondition
     let Ok(s) = (unsafe { CStr::from_ptr(s) }).to_str() else {
         tracing::error!("bad utf8");
@@ -355,7 +355,7 @@ pub unsafe extern "C" fn ts_parse_ip(s: *const c_char, addr: &mut sockaddr) -> i
 ///
 /// Returns a negative number if `sa_family` is invalid.
 #[unsafe(no_mangle)]
-pub extern "C" fn ts_sockaddr_set_port(addr: &mut sockaddr, port: u16) -> isize {
+pub extern "C" fn ts_sockaddr_set_port(addr: &mut sockaddr, port: u16) -> ffi::c_int {
     match addr.sa_family {
         AF_INET => {
             unsafe { addr.sa_data.sockaddr_in }.sin_port = port;

--- a/ts_ffi/src/tcp.rs
+++ b/ts_ffi/src/tcp.rs
@@ -1,3 +1,5 @@
+use std::ffi;
+
 use crate::TOKIO_RUNTIME;
 
 /// A Tailscale TCP listener handle.
@@ -78,7 +80,11 @@ pub extern "C" fn ts_tcp_connect(
 /// `buf` must be safe to convert into a Rust slice of length `len` (see
 /// [`core::slice::from_raw_parts`]).
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn ts_tcp_send(stream: &tcp_stream, buf: *const u8, len: usize) -> isize {
+pub unsafe extern "C" fn ts_tcp_send(
+    stream: &tcp_stream,
+    buf: *const u8,
+    len: usize,
+) -> ffi::c_int {
     // SAFETY: ensured by function precondition
     let b = unsafe { core::slice::from_raw_parts(buf, len) };
 
@@ -101,7 +107,7 @@ pub unsafe extern "C" fn ts_tcp_send(stream: &tcp_stream, buf: *const u8, len: u
 /// `buf` must be safe to convert into a mutable Rust slice of length `len` (see
 /// [`core::slice::from_raw_parts_mut`]).
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn ts_tcp_recv(stream: &tcp_stream, buf: *mut u8, len: usize) -> isize {
+pub unsafe extern "C" fn ts_tcp_recv(stream: &tcp_stream, buf: *mut u8, len: usize) -> ffi::c_int {
     // SAFETY: ensured by function precondition
     let b = unsafe { core::slice::from_raw_parts_mut(buf, len) };
 
@@ -110,7 +116,7 @@ pub unsafe extern "C" fn ts_tcp_recv(stream: &tcp_stream, buf: *mut u8, len: usi
             tracing::error!(err = %e, "tcp accept");
             -1
         }
-        Ok(read) => read as isize,
+        Ok(read) => read as _,
     }
 }
 

--- a/ts_ffi/src/udp.rs
+++ b/ts_ffi/src/udp.rs
@@ -1,3 +1,5 @@
+use std::ffi;
+
 use crate::TOKIO_RUNTIME;
 
 /// A Tailscale UDP socket handle.
@@ -42,7 +44,7 @@ pub unsafe extern "C" fn ts_udp_sendto(
     addr: &crate::sockaddr,
     msg: *const u8,
     len: usize,
-) -> isize {
+) -> ffi::c_int {
     // SAFETY: ensured by function precondition
     let msg = unsafe { core::slice::from_raw_parts(msg, len) };
 
@@ -75,7 +77,7 @@ pub unsafe extern "C" fn ts_udp_recvfrom(
     addr: Option<&mut crate::sockaddr>,
     buf: *mut u8,
     len: usize,
-) -> isize {
+) -> ffi::c_int {
     // SAFETY: ensured by function precondition
     let buf = unsafe { core::slice::from_raw_parts_mut(buf, len) };
 

--- a/ts_python/src/lib.rs
+++ b/ts_python/src/lib.rs
@@ -2,7 +2,7 @@
 
 use core::str::FromStr;
 use std::{
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     sync::{Arc, Once},
 };
 
@@ -16,20 +16,16 @@ type PyFut<'p> = PyResult<Bound<'p, PyAny>>;
 mod tcp;
 mod udp;
 
-// NOTE(npry): we want to declare our types inside the `tailscale` module so that printing them or
-// calling python's `help` reports that their types are `tailscale.*`, rather than `builtin.*`,
-// which is what they show if declared outside a `pymodule`, even if reexported from one.
-//
-// The module organization is awkward because proc-macro annotation on file modules is
-// currently unstable: https://github.com/rust-lang/rust/issues/54727. Ideally we'd put `tailscale`
-// in `tailscale.rs` and make `udp` and `tcp` submodules of it, but that currently doesn't work.
-
 /// Tailscale API.
 #[pymodule]
 pub mod tailscale {
-    use std::net::IpAddr;
-
     use super::*;
+    #[pymodule_export]
+    use crate::{
+        Device,
+        tcp::{TcpListener, TcpStream},
+        udp::UdpSocket,
+    };
 
     /// Connect to tailscale using the specified config file and optional auth key.
     #[pyfunction]
@@ -54,115 +50,97 @@ pub mod tailscale {
             Ok(Device { dev: Arc::new(dev) })
         })
     }
+}
 
-    /// Tailscale client.
-    #[pyclass(frozen)]
-    pub struct Device {
-        dev: Arc<ts::Device>,
+/// Tailscale client.
+#[pyclass(frozen, module = "tailscale")]
+pub struct Device {
+    dev: Arc<ts::Device>,
+}
+
+#[pymethods]
+impl Device {
+    /// Bind a new UDP socket on the given `addr`.
+    ///
+    /// `addr` must be given as (host, port). Presently, `host` must be an IP.
+    pub fn udp_bind<'p>(&self, py: Python<'p>, addr: (&str, u16)) -> PyFut<'p> {
+        let dev = self.dev.clone();
+        let ip = IpAddr::from_str(addr.0);
+
+        future_into_py(py, async move {
+            let ip = ip.map_err(py_value_err)?;
+
+            let sock = dev
+                .udp_bind((ip, addr.1).into())
+                .await
+                .map_err(py_value_err)?;
+
+            Ok(udp::UdpSocket {
+                sock: Arc::new(sock),
+            })
+        })
     }
 
-    /// A TCP listen socket.
-    #[pyclass(frozen)]
-    pub struct TcpListener {
-        pub(crate) listener: Arc<ts::TcpListener>,
+    /// Bind a new TCP listen socket on the given `addr` and `port`.
+    ///
+    /// `addr` must be given as (host, port). Presently, `host` must be an IP.
+    pub fn tcp_listen<'p>(&self, py: Python<'p>, addr: (&str, u16)) -> PyFut<'p> {
+        let dev = self.dev.clone();
+        let ip = IpAddr::from_str(addr.0);
+
+        future_into_py(py, async move {
+            let ip = ip.map_err(py_value_err)?;
+
+            let listener = dev
+                .tcp_listen((ip, addr.1).into())
+                .await
+                .map_err(py_value_err)?;
+
+            Ok(tcp::TcpListener {
+                listener: Arc::new(listener),
+            })
+        })
     }
 
-    /// An established TCP stream.
-    #[pyclass(frozen)]
-    pub struct TcpStream {
-        pub(crate) sock: Arc<ts::TcpStream>,
+    /// Create a new TCP connection to the given `addr`.
+    ///
+    /// `addr` must be given as (host, port). Presently, `host` must be an IP.
+    pub fn tcp_connect<'p>(&self, py: Python<'p>, addr: (&str, u16)) -> PyFut<'p> {
+        let dev = self.dev.clone();
+        let ip = IpAddr::from_str(addr.0);
+
+        future_into_py(py, async move {
+            let ip = ip.map_err(py_value_err)?;
+
+            let sock = dev
+                .tcp_connect((ip, addr.1).into())
+                .await
+                .map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+            Ok(tcp::TcpStream {
+                sock: Arc::new(sock),
+            })
+        })
     }
 
-    /// A tailscale UDP socket.
-    #[pyclass(frozen)]
-    pub struct UdpSocket {
-        pub(crate) sock: Arc<ts::UdpSocket>,
+    /// Get the device's IPv4 tailnet address.
+    pub fn ipv4<'p>(&self, py: Python<'p>) -> PyFut<'p> {
+        let dev = self.dev.clone();
+
+        future_into_py(py, async move {
+            let ip = dev.ipv4().await.map_err(py_value_err)?;
+            Ok(ip.to_string())
+        })
     }
 
-    #[pymethods]
-    impl Device {
-        /// Bind a new UDP socket on the given `addr`.
-        ///
-        /// `addr` must be given as (host, port). Presently, `host` must be an IP.
-        pub fn udp_bind<'p>(&self, py: Python<'p>, addr: (&str, u16)) -> PyFut<'p> {
-            let dev = self.dev.clone();
-            let ip = IpAddr::from_str(addr.0);
+    /// Get the device's IPv6 tailnet address.
+    pub fn ipv6<'p>(&self, py: Python<'p>) -> PyFut<'p> {
+        let dev = self.dev.clone();
 
-            future_into_py(py, async move {
-                let ip = ip.map_err(py_value_err)?;
-
-                let sock = dev
-                    .udp_bind((ip, addr.1).into())
-                    .await
-                    .map_err(py_value_err)?;
-
-                Ok(UdpSocket {
-                    sock: Arc::new(sock),
-                })
-            })
-        }
-
-        /// Bind a new TCP listen socket on the given `addr` and `port`.
-        ///
-        /// `addr` must be given as (host, port). Presently, `host` must be an IP.
-        pub fn tcp_listen<'p>(&self, py: Python<'p>, addr: (&str, u16)) -> PyFut<'p> {
-            let dev = self.dev.clone();
-            let ip = IpAddr::from_str(addr.0);
-
-            future_into_py(py, async move {
-                let ip = ip.map_err(py_value_err)?;
-
-                let listener = dev
-                    .tcp_listen((ip, addr.1).into())
-                    .await
-                    .map_err(py_value_err)?;
-
-                Ok(TcpListener {
-                    listener: Arc::new(listener),
-                })
-            })
-        }
-
-        /// Create a new TCP connection to the given `addr`.
-        ///
-        /// `addr` must be given as (host, port). Presently, `host` must be an IP.
-        pub fn tcp_connect<'p>(&self, py: Python<'p>, addr: (&str, u16)) -> PyFut<'p> {
-            let dev = self.dev.clone();
-            let ip = IpAddr::from_str(addr.0);
-
-            future_into_py(py, async move {
-                let ip = ip.map_err(py_value_err)?;
-
-                let sock = dev
-                    .tcp_connect((ip, addr.1).into())
-                    .await
-                    .map_err(|e| PyValueError::new_err(e.to_string()))?;
-
-                Ok(TcpStream {
-                    sock: Arc::new(sock),
-                })
-            })
-        }
-
-        /// Get the device's IPv4 tailnet address.
-        pub fn ipv4<'p>(&self, py: Python<'p>) -> PyFut<'p> {
-            let dev = self.dev.clone();
-
-            future_into_py(py, async move {
-                let ip = dev.ipv4().await.map_err(py_value_err)?;
-                Ok(ip.to_string())
-            })
-        }
-
-        /// Get the device's IPv6 tailnet address.
-        pub fn ipv6<'p>(&self, py: Python<'p>) -> PyFut<'p> {
-            let dev = self.dev.clone();
-
-            future_into_py(py, async move {
-                let ip = dev.ipv6().await.map_err(py_value_err)?;
-                Ok(ip.to_string())
-            })
-        }
+        future_into_py(py, async move {
+            let ip = dev.ipv6().await.map_err(py_value_err)?;
+            Ok(ip.to_string())
+        })
     }
 }
 

--- a/ts_python/src/tcp.rs
+++ b/ts_python/src/tcp.rs
@@ -1,12 +1,24 @@
 use std::sync::Arc;
 
-use pyo3::{PyResult, Python, exceptions::PyOSError, pymethods};
+use pyo3::{PyResult, Python, exceptions::PyOSError, pyclass, pymethods};
 use pyo3_async_runtimes::tokio::future_into_py;
 
 use crate::{PyFut, py_value_err, sockaddr_as_tuple};
 
+/// A TCP listen socket.
+#[pyclass(frozen, module = "tailscale")]
+pub struct TcpListener {
+    pub(crate) listener: Arc<ts::TcpListener>,
+}
+
+/// An established TCP stream.
+#[pyclass(frozen, module = "tailscale")]
+pub struct TcpStream {
+    pub(crate) sock: Arc<ts::TcpStream>,
+}
+
 #[pymethods]
-impl crate::tailscale::TcpListener {
+impl TcpListener {
     /// Accept a new incoming connection.
     ///
     /// Blocks indefinitely until a connection is ready to be accepted.
@@ -16,7 +28,7 @@ impl crate::tailscale::TcpListener {
         future_into_py(py, async move {
             let stream = sock.accept().await.map_err(py_value_err)?;
 
-            Ok(crate::tailscale::TcpStream {
+            Ok(TcpStream {
                 sock: Arc::new(stream),
             })
         })
@@ -33,7 +45,7 @@ impl crate::tailscale::TcpListener {
 }
 
 #[pymethods]
-impl crate::tailscale::TcpStream {
+impl TcpStream {
     /// Send bytes to the stream, returning the number of bytes transmitted.
     ///
     /// Always sends at least one byte if not an error.

--- a/ts_python/src/udp.rs
+++ b/ts_python/src/udp.rs
@@ -2,14 +2,21 @@ use core::{
     net::{IpAddr, SocketAddr},
     str::FromStr,
 };
+use std::sync::Arc;
 
-use pyo3::{Python, pymethods};
+use pyo3::{Python, pyclass, pymethods};
 use pyo3_async_runtimes::tokio::future_into_py;
 
 use crate::{PyFut, py_value_err, sockaddr_as_tuple};
 
+/// A tailscale UDP socket.
+#[pyclass(frozen)]
+pub struct UdpSocket {
+    pub(crate) sock: Arc<ts::UdpSocket>,
+}
+
 #[pymethods]
-impl crate::tailscale::UdpSocket {
+impl UdpSocket {
     /// Send a datagram to the given address.
     ///
     /// The address argument is currently expected to adopt the 2-tuple form (host, port),


### PR DESCRIPTION
`isize` renders as `intptr_t` on the C side, which isn't the idiomatic type I was hoping it might use. `ffi::c_int` results in plain `int`.