### PR TITLE
ffi: support peer ip lookup

### DIFF
--- a/ts_ffi/.gitignore
+++ b/ts_ffi/.gitignore
@@ -1,3 +1,4 @@
 /tailscale.h
 tcp_echo
 udp_ping
+lookup_peer

--- a/ts_ffi/examples/Makefile
+++ b/ts_ffi/examples/Makefile
@@ -33,7 +33,7 @@ ifneq ($(RUST_TARGET),)
 endif
 
 CFLAGS += -L../../target/$(RUST_TARGET_PATH)$(RUST_PROFILE_DIR)/
-TARGET_NAMES := udp_ping tcp_echo
+TARGET_NAMES := udp_ping tcp_echo lookup_peer
 TARGETS := $(patsubst %,%$(TARGET_SUFFIX),$(TARGET_NAMES))
 
 # libtailscalers: let cargo handle build incrementality

--- a/ts_ffi/examples/default.nix
+++ b/ts_ffi/examples/default.nix
@@ -18,6 +18,7 @@
 
         cc -o udp_ping_ udp_ping/*.c $CFLAGS
         cc -o tcp_echo_ tcp_echo/*.c $CFLAGS
+        cc -o lookup_peer_ lookup_peer/*.c $CFLAGS
 
         runHook postBuild
     '';
@@ -28,6 +29,7 @@
         mkdir -p "$out/bin"
         cp udp_ping_ "$out/bin/udp_ping"
         cp tcp_echo_ "$out/bin/tcp_echo"
+        cp lookup_peer_ "$out/bin/lookup_peer"
 
         runHook postInstall
     '';

--- a/ts_ffi/examples/lookup_peer/lookup_peer.c
+++ b/ts_ffi/examples/lookup_peer/lookup_peer.c
@@ -1,0 +1,56 @@
+/*
+ * Command-line utility to look up IP addresses for a peer on your tailnet.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+
+#ifdef WIN32
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+#include "tailscale.h"
+
+#define USAGE \
+    "usage: lookup_peer CONFIG_PATH AUTH_TOKEN PEER_NAME\n" \
+    "  e.g. lookup_peer test.json tskey-auth-XXX mynode"
+
+int main(int argc, char** argv) {
+    if (argc != 4) {
+        puts(USAGE);
+        exit(EXIT_FAILURE);
+    }
+
+    const struct ts_device* dev = ts_init(
+        argv[1],
+        argv[2]
+    );
+    assert(dev);
+
+    // Wait for device to receive its IP: first netmap has been received.
+    ts_in_addr_t addrv4;
+    ts_in6_addr_t addrv6;
+    char addr_str[INET6_ADDRSTRLEN];
+
+    assert(!ts_ipv4(dev, &addrv4));
+
+    if (ts_peer_ipv4_addr(dev, argv[3], &addrv4) <= 0) {
+        return EXIT_FAILURE;
+    }
+    assert(inet_ntop(AF_INET, &addrv4, addr_str, INET6_ADDRSTRLEN));
+    puts(addr_str);
+
+    if (ts_peer_ipv6_addr(dev, argv[3], &addrv6) <= 0) {
+        return EXIT_FAILURE;
+    }
+    assert(inet_ntop(AF_INET6, &addrv6, addr_str, INET6_ADDRSTRLEN));
+    puts(addr_str);
+
+    return EXIT_SUCCESS;
+}

--- a/ts_ffi/src/lib.rs
+++ b/ts_ffi/src/lib.rs
@@ -155,3 +155,89 @@ pub extern "C" fn ts_ipv6_addr(dev: &device, dst: &mut in6_addr_t) -> ffi::c_int
 
     0
 }
+
+/// Get the IPv4 address of a specified peer by name.
+///
+/// `peer_name` can be a fully-qualified name (`$HOST.tail1234.ts.net`) or an unqualified
+/// hostname (`$HOST`). The first match is returned: shared-in nodes may cause ambiguity
+/// when unqualified hostnames are used.
+///
+/// Returns a negative number if there was an error, zero if no match was found, and a
+/// positive number if `addr` has been populated with the address for the requested peer.
+///
+/// # Safety
+///
+/// `peer_name` must be able to be read according to [`CStr`] rules, i.e.
+/// it must be NUL-terminated and valid for reading up to and including the NUL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ts_peer_ipv4_addr(
+    dev: &device,
+    peer_name: *const c_char,
+    addr: &mut in_addr_t,
+) -> ffi::c_int {
+    // SAFETY: ensured by function precondition
+    unsafe {
+        _peer_by_addr(dev, peer_name, |n| {
+            *addr = n.tailnet_address.ipv4.addr().into();
+        })
+    }
+}
+
+/// Get the IPv6 address of a specified peer by name.
+///
+/// `peer_name` can be a fully-qualified name (`$HOST.tail1234.ts.net`) or an unqualified
+/// hostname (`$HOST`). The first match is returned: shared-in nodes may cause ambiguity
+/// when unqualified hostnames are used.
+///
+/// Returns a negative number if there was an error, zero if no match was found, and a
+/// positive number if `addr` has been populated with the address for the requested peer.
+///
+/// # Safety
+///
+/// `peer_name` must be able to be read according to [`CStr`] rules, i.e.
+/// it must be NUL-terminated and valid for reading up to and including the NUL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ts_peer_ipv6_addr(
+    dev: &device,
+    peer_name: *const c_char,
+    addr: &mut in6_addr_t,
+) -> ffi::c_int {
+    // SAFETY: ensured by function precondition
+    unsafe {
+        _peer_by_addr(dev, peer_name, |n| {
+            *addr = n.tailnet_address.ipv6.addr().into();
+        })
+    }
+}
+
+/// # Safety
+///
+/// `peer_name` must be able to be read according to [`CStr`] rules, i.e.
+/// it must be NUL-terminated and valid for reading up to and including the NUL.
+unsafe fn _peer_by_addr(
+    dev: &device,
+    peer_name: *const c_char,
+    on_node_info: impl FnOnce(&tailscale::NodeInfo),
+) -> ffi::c_int {
+    // SAFETY: ensured by function precondition
+    let name = unsafe { CStr::from_ptr(peer_name) };
+
+    let Ok(name) = name.to_str() else {
+        tracing::error!("peer name: invalid utf-8");
+        return -1;
+    };
+
+    match TOKIO_RUNTIME.block_on(dev.0.peer_by_name(name)) {
+        Ok(Some(node)) => {
+            on_node_info(&node);
+            1
+        }
+
+        Ok(None) => 0,
+
+        Err(e) => {
+            tracing::error!(error = %e, "looking up peer");
+            -1
+        }
+    }
+}


### PR DESCRIPTION
This only does IP lookup (rather than handing back a `NodeInfo`) because defining a struct with a bunch of internal allocations and vecs in C seems more trouble than it's worth right now.

Also provides a nice little example cli util to verify with:

```shell
$ ./lookup_peer $CONFIG $TOKEN $MY_PEER
100.64.0.1
7afd:5c11:e0a1::1234:5678
```