### PR TITLE
python: support peer lookup

### DIFF
--- a/ts_control/src/node.rs
+++ b/ts_control/src/node.rs
@@ -8,7 +8,7 @@ pub type Id = i64;
 
 /// The stable ID of a node.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct StableId(String);
+pub struct StableId(pub String);
 
 /// A node in a tailnet.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/ts_python/examples/udp/recv.py
+++ b/ts_python/examples/udp/recv.py
@@ -13,7 +13,7 @@ async def main(auth_key: str, bind_port: int) -> None:
     # Bind a UDP socket on this device's IPv4 address:
     tailnet_ipv4 = await dev.ipv4_addr()
     udp_sock = await dev.udp_bind((tailnet_ipv4, bind_port))
-    print(f"[{tailnet_ipv4}:{bind_port}] udp bound, local endpoint: {udp_sock.local_endpoint_addr()}")
+    print(f"[{tailnet_ipv4}:{bind_port}] udp bound, local endpoint: {udp_sock.local_addr()}")
 
     # Wait for a message and print it, then repeat.
     count = 0

--- a/ts_python/examples/udp/send.py
+++ b/ts_python/examples/udp/send.py
@@ -16,7 +16,7 @@ async def main(auth_key: str, peer_ip: str, peer_port: int) -> None:
     # Bind a UDP socket on this device's IPv4 address:
     tailnet_ipv4 = await dev.ipv4_addr()
     udp_sock = await dev.udp_bind((tailnet_ipv4, BIND_PORT))
-    print(f"[{tailnet_ipv4}:{BIND_PORT}] udp bound, local endpoint: {udp_sock.local_endpoint_addr()}")
+    print(f"[{tailnet_ipv4}:{BIND_PORT}] udp bound, local endpoint: {udp_sock.local_addr()}")
 
     # Send a message to the peer every second.
     count = 0

--- a/ts_python/src/ip_or_str.rs
+++ b/ts_python/src/ip_or_str.rs
@@ -1,0 +1,19 @@
+use std::net::IpAddr;
+
+/// IP address in python `ipaddress.IpAddress` form, or as a string.
+#[derive(pyo3::FromPyObject)]
+pub enum IpRepr {
+    String(String),
+    Ip(IpAddr),
+}
+
+impl TryFrom<IpRepr> for IpAddr {
+    type Error = pyo3::PyErr;
+
+    fn try_from(value: IpRepr) -> Result<Self, Self::Error> {
+        match value {
+            IpRepr::Ip(ip) => Ok(ip),
+            IpRepr::String(s) => s.parse::<IpAddr>().map_err(crate::py_value_err),
+        }
+    }
+}

--- a/ts_python/src/lib.rs
+++ b/ts_python/src/lib.rs
@@ -15,8 +15,11 @@ extern crate tailscale as ts;
 type PyFut<'p> = PyResult<Bound<'p, PyAny>>;
 
 mod ip_or_str;
+mod node_info;
 mod tcp;
 mod udp;
+
+use node_info::NodeInfo;
 
 /// Tailscale API.
 #[pymodule]
@@ -142,6 +145,19 @@ impl Device {
         future_into_py(py, async move {
             let ip = dev.ipv6_addr().await.map_err(py_value_err)?;
             Ok(ip)
+        })
+    }
+
+    /// Look up info about a peer by its name.
+    ///
+    /// `name` may be an unqualified hostname or a fully-qualified name.
+    pub fn peer_by_name<'p>(&self, py: Python<'p>, name: String) -> PyFut<'p> {
+        let dev = self.dev.clone();
+
+        future_into_py(py, async move {
+            let node = dev.peer_by_name(&name).await.map_err(py_value_err)?;
+
+            Ok(node.map(|node| NodeInfo::from(&node)))
         })
     }
 }

--- a/ts_python/src/lib.rs
+++ b/ts_python/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!("../README.md")]
 
-use core::str::FromStr;
 use std::{
     net::{IpAddr, SocketAddr},
     sync::{Arc, Once},
@@ -9,10 +8,13 @@ use std::{
 use pyo3::{exceptions::PyValueError, prelude::*};
 use pyo3_async_runtimes::tokio::future_into_py;
 
+use crate::ip_or_str::IpRepr;
+
 extern crate tailscale as ts;
 
 type PyFut<'p> = PyResult<Bound<'p, PyAny>>;
 
+mod ip_or_str;
 mod tcp;
 mod udp;
 
@@ -63,12 +65,12 @@ impl Device {
     /// Bind a new UDP socket on the given `addr`.
     ///
     /// `addr` must be given as (host, port). Presently, `host` must be an IP.
-    pub fn udp_bind<'p>(&self, py: Python<'p>, addr: (&str, u16)) -> PyFut<'p> {
+    pub fn udp_bind<'p>(&self, py: Python<'p>, addr: (IpRepr, u16)) -> PyFut<'p> {
         let dev = self.dev.clone();
-        let ip = IpAddr::from_str(addr.0);
+        let ip: Result<IpAddr, _> = addr.0.try_into();
 
         future_into_py(py, async move {
-            let ip = ip.map_err(py_value_err)?;
+            let ip = ip?;
 
             let sock = dev
                 .udp_bind((ip, addr.1).into())
@@ -84,12 +86,12 @@ impl Device {
     /// Bind a new TCP listen socket on the given `addr` and `port`.
     ///
     /// `addr` must be given as (host, port). Presently, `host` must be an IP.
-    pub fn tcp_listen<'p>(&self, py: Python<'p>, addr: (&str, u16)) -> PyFut<'p> {
+    pub fn tcp_listen<'p>(&self, py: Python<'p>, addr: (IpRepr, u16)) -> PyFut<'p> {
         let dev = self.dev.clone();
-        let ip = IpAddr::from_str(addr.0);
+        let ip: Result<IpAddr, _> = addr.0.try_into();
 
         future_into_py(py, async move {
-            let ip = ip.map_err(py_value_err)?;
+            let ip = ip?;
 
             let listener = dev
                 .tcp_listen((ip, addr.1).into())
@@ -105,12 +107,12 @@ impl Device {
     /// Create a new TCP connection to the given `addr`.
     ///
     /// `addr` must be given as (host, port). Presently, `host` must be an IP.
-    pub fn tcp_connect<'p>(&self, py: Python<'p>, addr: (&str, u16)) -> PyFut<'p> {
+    pub fn tcp_connect<'p>(&self, py: Python<'p>, addr: (IpRepr, u16)) -> PyFut<'p> {
         let dev = self.dev.clone();
-        let ip = IpAddr::from_str(addr.0);
+        let ip: Result<IpAddr, _> = addr.0.try_into();
 
         future_into_py(py, async move {
-            let ip = ip.map_err(py_value_err)?;
+            let ip = ip?;
 
             let sock = dev
                 .tcp_connect((ip, addr.1).into())
@@ -129,7 +131,7 @@ impl Device {
 
         future_into_py(py, async move {
             let ip = dev.ipv4_addr().await.map_err(py_value_err)?;
-            Ok(ip.to_string())
+            Ok(ip)
         })
     }
 
@@ -139,13 +141,13 @@ impl Device {
 
         future_into_py(py, async move {
             let ip = dev.ipv6_addr().await.map_err(py_value_err)?;
-            Ok(ip.to_string())
+            Ok(ip)
         })
     }
 }
 
-fn sockaddr_as_tuple(s: SocketAddr) -> (String, u16) {
-    (s.ip().to_string(), s.port())
+fn sockaddr_as_tuple(s: SocketAddr) -> (IpAddr, u16) {
+    (s.ip(), s.port())
 }
 
 fn py_value_err(e: impl ToString) -> PyErr {

--- a/ts_python/src/node_info.rs
+++ b/ts_python/src/node_info.rs
@@ -1,0 +1,57 @@
+use std::net::IpAddr;
+
+/// Info about a tailscale node.
+///
+/// Turned into a `dict` on the Python side via `IntoPyObject`.
+#[derive(Debug, PartialEq, Eq, pyo3::IntoPyObject)]
+pub struct NodeInfo {
+    /// Node's id.
+    pub id: i64,
+    /// Stable id.
+    pub stable_id: String,
+    /// The node's hostname.
+    pub hostname: String,
+    /// The tailnet to which this node belongs.
+    pub tailnet: Option<String>,
+    /// This node's tags.
+    pub tags: Vec<String>,
+    /// The tailnet addresses this device has.
+    pub tailnet_addresses: Vec<IpAddr>,
+    /// This node's home derp region.
+    pub derp_region: Option<u32>,
+    /// This node's node key.
+    pub node_key: Vec<u8>,
+    /// This node's disco key.
+    pub disco_key: Option<Vec<u8>>,
+    /// This node's machine key.
+    pub machine_key: Option<Vec<u8>>,
+    /// The underlay addresses on which this node is reachable.
+    pub underlay_addresses: Vec<(IpAddr, u16)>,
+}
+
+impl From<&tailscale::NodeInfo> for NodeInfo {
+    fn from(value: &tailscale::NodeInfo) -> Self {
+        Self {
+            id: value.id,
+            stable_id: value.stable_id.0.clone(),
+            tags: value.tags.clone(),
+            node_key: value.node_key.to_bytes().to_vec(),
+
+            hostname: value.hostname.clone(),
+            tailnet: value.tailnet.clone(),
+            tailnet_addresses: vec![
+                value.tailnet_address.ipv4.addr().into(),
+                value.tailnet_address.ipv6.addr().into(),
+            ],
+            derp_region: value.derp_region.map(|x| x.0.get()),
+
+            machine_key: value.machine_key.as_ref().map(|x| x.to_bytes().to_vec()),
+            disco_key: value.disco_key.as_ref().map(|x| x.to_bytes().to_vec()),
+            underlay_addresses: value
+                .underlay_addresses
+                .iter()
+                .map(|addr| (addr.ip(), addr.port()))
+                .collect(),
+        }
+    }
+}

--- a/ts_python/src/tcp.rs
+++ b/ts_python/src/tcp.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{net::IpAddr, sync::Arc};
 
 use pyo3::{PyResult, Python, exceptions::PyOSError, pyclass, pymethods};
 use pyo3_async_runtimes::tokio::future_into_py;
@@ -35,7 +35,7 @@ impl TcpListener {
     }
 
     /// Get the local endpoint this TCP listener is listening on.
-    pub fn local_endpoint_addr(&self) -> (String, u16) {
+    pub fn local_addr(&self) -> (IpAddr, u16) {
         sockaddr_as_tuple(self.listener.local_addr())
     }
 
@@ -74,12 +74,12 @@ impl TcpStream {
     }
 
     /// Get the local endpoint this socket is bound to.
-    pub fn local_endpoint_addr(&self) -> (String, u16) {
+    pub fn local_addr(&self) -> (IpAddr, u16) {
         sockaddr_as_tuple(self.sock.local_addr())
     }
 
     /// Get the remote endpoint this socket is connected to.
-    pub fn remote_endpoint_addr(&self) -> (String, u16) {
+    pub fn remote_addr(&self) -> (IpAddr, u16) {
         sockaddr_as_tuple(self.sock.remote_addr())
     }
 

--- a/ts_python/src/udp.rs
+++ b/ts_python/src/udp.rs
@@ -1,13 +1,10 @@
-use core::{
-    net::{IpAddr, SocketAddr},
-    str::FromStr,
-};
+use core::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
 use pyo3::{Python, pyclass, pymethods};
 use pyo3_async_runtimes::tokio::future_into_py;
 
-use crate::{PyFut, py_value_err, sockaddr_as_tuple};
+use crate::{PyFut, ip_or_str::IpRepr, py_value_err, sockaddr_as_tuple};
 
 /// A tailscale UDP socket.
 #[pyclass(frozen, module = "_internal")]
@@ -21,10 +18,10 @@ impl UdpSocket {
     ///
     /// The address argument is currently expected to adopt the 2-tuple form (host, port),
     /// where host is strictly an IP address -- DNS lookup is not yet supported.
-    pub fn sendto<'p>(&self, py: Python<'p>, addr: (&str, u16), msg: &[u8]) -> PyFut<'p> {
+    pub fn sendto<'p>(&self, py: Python<'p>, addr: (IpRepr, u16), msg: &[u8]) -> PyFut<'p> {
         let (ip, port) = addr;
 
-        let addr = IpAddr::from_str(ip)?;
+        let addr = ip.try_into()?;
         let socket_addr = SocketAddr::new(addr, port);
         let msg = msg.to_vec();
 
@@ -54,7 +51,7 @@ impl UdpSocket {
     }
 
     /// Get the local endpoint this socket is bound to.
-    pub fn local_endpoint_addr(&self) -> (String, u16) {
+    pub fn local_addr(&self) -> (IpAddr, u16) {
         sockaddr_as_tuple(self.sock.local_addr())
     }
 


### PR DESCRIPTION
Ditto with #73 &mdash; need a new type to capture `NodeInfo`. Currently the `IntoPyObject` means it turns into a dict, though I think it'd be better if it were a native-python dataclass. I don't think that has to block this landing.