### PR TITLE
ts_python: prep for publishing, add UDP example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,11 @@ perf.data
 perf.data.old
 heaptrack.*
 config.json
+key_file*.json
 priv/
 _build/
 ts_elixir/deps/
+ts_python/python/tailscale/*.so
 *.exe
 *.dll
 *.lib

--- a/ts_python/README.md
+++ b/ts_python/README.md
@@ -5,7 +5,7 @@ Python bindings for `tailscale-rs`.
 At the moment, this exposes facilities for connecting to a tailnet and binding network sockets that
 have access to the tailnet.
 
-## example
+## Code Sample
 
 ```python
 import asyncio
@@ -38,7 +38,7 @@ To run this demo:
 $ TS_RS_EXPERIMENT=this_is_unstable_software python demo.py
 ```
 
-## building/usage
+## Building and Usage
 
 We're not up on pypi, so you can't `pip install tailscale` yet. To use the module, you'll
 need to build it. The best way to do that is with [`maturin`](https://www.maturin.rs/):

--- a/ts_python/examples/README.md
+++ b/ts_python/examples/README.md
@@ -1,0 +1,24 @@
+# Examples
+
+This directory contains Python examples that use `tailscale-py`.
+
+## Requirements
+
+For all the examples, you'll need:
+- A working Python 3.12+ installation you can install packages into
+- A [tailnet set up](https://tailscale.com/docs/how-to/quickstart) and Tailscale (the Go client)
+  installed on your local machine
+- Two [auth keys](https://tailscale.com/docs/features/access-control/auth-keys) registered for the
+  tailnet, referred to as `$AUTH_KEY_1` and `$AUTH_KEY_2` in the examples 
+    - For one-off keys, **do not** follow the "Register a node with the auth key" section! The
+      examples take care of that for you
+    - If you prefer, you can use a reusable auth key rather than two auth keys
+- A tailnet policy configured to allow access between your local machine and the example code, and
+between the examples themselves
+
+Also note the `TS_RS_EXPERIMENT=this_is_unstable_software` environment variable is required for all
+the examples below; for an explanation, see [the Caveats section of the README](../../README.md#caveats).
+
+## [UDP](udp)
+
+A UDP sender and receiver. The sender sends UDP datagrams to the receiver over the tailnet.

--- a/ts_python/examples/udp/README.md
+++ b/ts_python/examples/udp/README.md
@@ -1,0 +1,41 @@
+# Example: UDP
+
+> [!NOTE]
+> See the top-level [Requirements section](../README.md#requirements) for pre-requisites.
+
+A UDP sender and receiver. The [sender](send.py) binds to a port and sends datagrams to the [receiver](recv.py) over the
+tailnet; the receiver binds to a port and prints any messages it receives.
+
+First, start the receiver:
+
+```sh
+# Terminal 1
+$ TS_RS_EXPERIMENT=this_is_unstable_software ./recv.py $AUTH_KEY_1 5678
+...
+[<recv IPv4>:5678] udp bound, local endpoint: ('<recv IPv4>', 5678)
+...
+```
+
+Then, in another terminal, start the sender:
+
+```sh
+# Terminal 2
+$ TS_RS_EXPERIMENT=this_is_unstable_software ./send.py $AUTH_KEY_2 <recv IPv4> 5678 
+...
+[<send IPv4>:1234] udp bound, local endpoint: ('<send IPv4>', 1234)
+[<send IPv4>:1234-><recv IPv4>:5678|0001] sent message: b'HELLO'
+[<send IPv4>:1234-><recv IPv4>:5678|0002] sent message: b'HELLO'
+...
+```
+
+After a short period of time, you should start seeing the following messages in the receiver terminal:
+
+```sh
+# Terminal 1
+...
+[<recv IPv4>:5678<-<send IPv4>:1234|0082] received message: b'HELLO'
+[<recv IPv4>:5678<-<send IPv4>:1234|0083] received message: b'HELLO'
+```
+
+If you can't get the sender and receiver to communicate, verify the tailnet policy allows the sender
+access to the receiver's tailnet IP address on UDP port 5678.

--- a/ts_python/examples/udp/recv.py
+++ b/ts_python/examples/udp/recv.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+A UDP receiver built with `tailscale-py`. Receives datagrams from peers and prints their contents.
+"""
+import argparse
+import asyncio
+import tailscale
+
+async def main(auth_key: str, bind_port: int) -> None:
+    # Connect to the tailnet:
+    dev = await tailscale.connect('key_file_recv.json', auth_key)
+
+    # Bind a UDP socket on this device's IPv4 address:
+    tailnet_ipv4 = await dev.ipv4_addr()
+    udp_sock = await dev.udp_bind((tailnet_ipv4, bind_port))
+    print(f"[{tailnet_ipv4}:{bind_port}] udp bound, local endpoint: {udp_sock.local_endpoint_addr()}")
+
+    # Wait for a message and print it, then repeat.
+    count = 0
+    while True:
+        (msg, remote) = await udp_sock.recvfrom()
+        count += 1
+        (peer_ip, peer_port) = (f"{remote[0]}", remote[1])
+        print(f"[{tailnet_ipv4}:{bind_port}<-{peer_ip}:{peer_port}|{count:04}] received message: {msg}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="UDP receiver built with `tailscale-py`",
+        usage="TS_RS_EXPERIMENT=this_is_unstable_software %(prog)s [options]"
+    )
+    parser.add_argument("auth_key", help="auth key to register with tailnet")
+    parser.add_argument("bind_port", help="local UDP port to bind", type=int)
+    args = parser.parse_args()
+
+    asyncio.run(main(args.auth_key, args.bind_port))

--- a/ts_python/examples/udp/send.py
+++ b/ts_python/examples/udp/send.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+A UDP sender built with `tailscale-py`. Sends a datagram to the given peer every second.
+"""
+import argparse
+import asyncio
+import tailscale
+
+BIND_PORT = 1234
+MESSAGE = b'HELLO'
+
+async def main(auth_key: str, peer_ip: str, peer_port: int) -> None:
+    # Connect to the tailnet:
+    dev = await tailscale.connect('key_file_send.json', auth_key)
+
+    # Bind a UDP socket on this device's IPv4 address:
+    tailnet_ipv4 = await dev.ipv4_addr()
+    udp_sock = await dev.udp_bind((tailnet_ipv4, BIND_PORT))
+    print(f"[{tailnet_ipv4}:{BIND_PORT}] udp bound, local endpoint: {udp_sock.local_endpoint_addr()}")
+
+    # Send a message to the peer every second.
+    count = 0
+    while True:
+        await udp_sock.sendto((peer_ip, peer_port), msg=MESSAGE)
+        count += 1
+        print(f"[{tailnet_ipv4}:{BIND_PORT}->{peer_ip}:{peer_port}|{count:04}] sent message: {MESSAGE}")
+        await asyncio.sleep(1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="UDP sender built with `tailscale-py`",
+        usage="TS_RS_EXPERIMENT=this_is_unstable_software %(prog)s [options]"
+    )
+    parser.add_argument("auth_key", help="auth key to register with tailnet")
+    parser.add_argument("peer_ip", help="peer's tailnet IP address")
+    parser.add_argument("peer_port", help="peer's UDP port", type=int)
+    args = parser.parse_args()
+
+    asyncio.run(main(args.auth_key, args.peer_ip, args.peer_port))

--- a/ts_python/pyproject.toml
+++ b/ts_python/pyproject.toml
@@ -1,0 +1,36 @@
+[project]
+name = "tailscale-py"
+version = "0.2.0"
+description = "Work-in-progress Tailscale library written in Rust."
+license = "BSD-3-Clause"
+readme = "README.md"
+keywords = ["tailscale-py", "tailscale-rs", "tailscale", "vpn", "wireguard"]
+documentation = "https://github.com/tailscale/tailscale-rs/tree/main/ts_python"
+homepage = "https://github.com/tailscale/tailscale-rs"
+repository = "https://github.com/tailscale/tailscale-rs"
+requires-python = ">=3.12"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: System :: Networking",
+]
+
+dependencies = [
+    "maturin>=1.13.1",
+]
+
+[build-system]
+requires = ["maturin>=1.13.1,<2.0"]
+build-backend = "maturin"
+
+[tool.maturin]
+python-source = "python"
+module-name = "tailscale._internal"

--- a/ts_python/python/tailscale/__init__.py
+++ b/ts_python/python/tailscale/__init__.py
@@ -1,0 +1,1 @@
+from tailscale._internal import *

--- a/ts_python/src/lib.rs
+++ b/ts_python/src/lib.rs
@@ -18,7 +18,7 @@ mod udp;
 
 /// Tailscale API.
 #[pymodule]
-pub mod tailscale {
+pub mod _internal {
     use super::*;
     #[pymodule_export]
     use crate::{

--- a/ts_python/src/tcp.rs
+++ b/ts_python/src/tcp.rs
@@ -6,13 +6,13 @@ use pyo3_async_runtimes::tokio::future_into_py;
 use crate::{PyFut, py_value_err, sockaddr_as_tuple};
 
 /// A TCP listen socket.
-#[pyclass(frozen, module = "tailscale")]
+#[pyclass(frozen, module = "_internal")]
 pub struct TcpListener {
     pub(crate) listener: Arc<ts::TcpListener>,
 }
 
 /// An established TCP stream.
-#[pyclass(frozen, module = "tailscale")]
+#[pyclass(frozen, module = "_internal")]
 pub struct TcpStream {
     pub(crate) sock: Arc<ts::TcpStream>,
 }

--- a/ts_python/src/udp.rs
+++ b/ts_python/src/udp.rs
@@ -10,7 +10,7 @@ use pyo3_async_runtimes::tokio::future_into_py;
 use crate::{PyFut, py_value_err, sockaddr_as_tuple};
 
 /// A tailscale UDP socket.
-#[pyclass(frozen)]
+#[pyclass(frozen, module = "_internal")]
 pub struct UdpSocket {
     pub(crate) sock: Arc<ts::UdpSocket>,
 }

--- a/ts_python/uv.lock
+++ b/ts_python/uv.lock
@@ -1,0 +1,35 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "maturin"
+version = "1.13.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/16/b284a7bc4af3dd87717c784278c1b8cb18606ad1f6f7a671c47bfd9c3df0/maturin-1.13.1.tar.gz", hash = "sha256:9a87ff3b8e4d1c6eac33ebfe8e261e8236516d98d45c0323550621819b5a1a2f", size = 340369, upload-time = "2026-04-09T15:14:07.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/4d/a23fc95be881aa8c7a6ea353410417872e4d7065df03d7f3db8f0dbed4a7/maturin-1.13.1-py3-none-linux_armv6l.whl", hash = "sha256:416e4e01cb88b798e606ee43929df897e42c1647b722ef68283816cca99a8742", size = 10102444, upload-time = "2026-04-09T15:13:48.393Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/1e/65c385d65bae95cf04895d52f39dbed8b1453ae55da2903d252ade40a774/maturin-1.13.1-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:72888e87819ce546d0d2df900e4b385e4ef299077d92ee37b48923a5602dae94", size = 19576043, upload-time = "2026-04-09T15:14:08.685Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/13/f6bc868d0bfecd9314870b97f530a167e31f7878ac4945c78245c6eef69c/maturin-1.13.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:98b5fcf1a186c217830a8295ecc2989c6b1cf50945417adfc15252107b9475b7", size = 10117339, upload-time = "2026-04-09T15:13:40.559Z" },
+    { url = "https://files.pythonhosted.org/packages/51/58/279e081305c11c1c1c4fccacf77df8959646c5d4de7a57ec7e787653e270/maturin-1.13.1-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:3da18cccf2f683c0977bff9146a0908d6ffce836d600665736ac01679f588cb9", size = 10139689, upload-time = "2026-04-09T15:13:38.291Z" },
+    { url = "https://files.pythonhosted.org/packages/00/94/69391af5396c6aab723932240803f49e5f3de3dd7c57d32f02d237a0ce32/maturin-1.13.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:6b1e5916a253243e8f5f9e847b62bbc98420eec48c9ce2e2e8724c6da89d359b", size = 10551141, upload-time = "2026-04-09T15:13:42.887Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/bf/4edac2667b49e3733438062ae416413b8fc8d42e1bd499ba15e1fb02fc55/maturin-1.13.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:dc91031e0619c1e28730279ef9ee5f106c9b9ec806b013f888676b242f892eb7", size = 9983094, upload-time = "2026-04-09T15:13:56.868Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/a6d651cfe8fc6bf2e892c90e3cdbb25c06d81c9115140d03ea1a68a97575/maturin-1.13.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:001741c6cff56aa8ea59a0d78ae990c0550d0e3e82b00b683eedb4158a8ef7e6", size = 9949980, upload-time = "2026-04-09T15:13:59.185Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d1/82c067464f848e38af9910bce55eb54302b1c1284a279d515dbfcf5994f5/maturin-1.13.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:01c845825c917c07c1d0b2c9032c59c16a7d383d1e649a46481d3e5693c2750f", size = 13186276, upload-time = "2026-04-09T15:13:45.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f4/25367baf1025580f047f9b37598bb3fadc416e24536afd4f28e190335c73/maturin-1.13.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f69093ed4a0e6464e52a7fc26d714f859ce15630ec8070743398c6bf41f38a9e", size = 10891837, upload-time = "2026-04-09T15:13:35.68Z" },
+    { url = "https://files.pythonhosted.org/packages/af/be/caafad8ce74974b7deafdf144d12f758993dfea4c66c9905b138f51a7792/maturin-1.13.1-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:c1490584f3c70af45466ee99065b49e6657ebdccac6b10571bb44681309c9396", size = 10351032, upload-time = "2026-04-09T15:14:01.632Z" },
+    { url = "https://files.pythonhosted.org/packages/66/0e/970a721d27cfa410e8bfa0a1e32e6ef52cb8169692110a5fdabe1af3f570/maturin-1.13.1-py3-none-win32.whl", hash = "sha256:c6a720b252c99de072922dbe4432ab19662b6f80045b0355fec23bdfccb450da", size = 8855465, upload-time = "2026-04-09T15:13:51.122Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/7c1e0d65fa147d5479055a171541c82b8cdfc1c825d85a82240470f14176/maturin-1.13.1-py3-none-win_amd64.whl", hash = "sha256:a2017d2281203d0c6570240e7d746564d766d756105823b7de68bda6ae722711", size = 10230471, upload-time = "2026-04-09T15:13:53.89Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/2a/afe0193b673a79ffd2e01ad999511b7e9e6b49af02bb3759d82a78c3043d/maturin-1.13.1-py3-none-win_arm64.whl", hash = "sha256:2839024dcd65776abb4759e5bca29941971e095574162a4d335191da4be9ff24", size = 8905575, upload-time = "2026-04-09T15:14:03.891Z" },
+]
+
+[[package]]
+name = "tailscale-py"
+version = "0.2.0"
+source = { editable = "." }
+dependencies = [
+    { name = "maturin" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "maturin", specifier = ">=1.13.1" }]


### PR DESCRIPTION
This is a base PR; over the coming weeks, more examples and Python-specific wrappers, typing, and comments will be added.

- Adds `pyproject.toml` with metadata for publishing
- Creates the root `python/tailscale` package for `uv publish`
- Adds a `uv` lockfile
- Adds an examples directory with a UDP sender/receiver example
- Gitignores `key_file*.json` files and `*.so` files generated by the `uv` build

Planning on leaving `ts_python/README.md` as-is until we publish on PyPI successfully, then will update it with `uv` instructions when we do a `0.2.1` release.