### PR TITLE
ts_control: support plain HTTP control servers and optional early payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4209,7 +4209,6 @@ dependencies = [
  "ts_control_noise",
  "ts_control_serde",
  "ts_dynbitset",
- "ts_hexdump",
  "ts_http_util",
  "ts_keys",
  "ts_packet",
@@ -4218,7 +4217,6 @@ dependencies = [
  "ts_tls_util",
  "ts_transport_derp",
  "url",
- "zerocopy",
 ]
 
 [[package]]

--- a/ts_control/Cargo.toml
+++ b/ts_control/Cargo.toml
@@ -18,7 +18,6 @@ ts_capabilityversion = { workspace = true, features = ["serde"] }
 ts_control_noise.workspace = true
 ts_control_serde.workspace = true
 ts_dynbitset.workspace = true
-ts_hexdump.workspace = true
 ts_http_util.workspace = true
 ts_keys.workspace = true
 ts_packet.workspace = true
@@ -38,7 +37,6 @@ thiserror.workspace = true
 tokio-util = { workspace = true, features = ["time"] }
 tracing.workspace = true
 url = { workspace = true, features = ["serde", "std"] }
-zerocopy.workspace = true
 
 # Required dependencies for the async_tokio feature.
 futures-util = { workspace = true, optional = true }

--- a/ts_control/src/control_dialer.rs
+++ b/ts_control/src/control_dialer.rs
@@ -255,8 +255,8 @@ where
         CapabilityVersion::CURRENT,
     );
 
-    let mut conn = crate::tokio::upgrade_ts2021(url, &init_msg, handshake, h1_client).await?;
-    let _challenge_packet = crate::tokio::read_challenge_packet(&mut conn).await?;
+    let conn = crate::tokio::upgrade_ts2021(url, &init_msg, handshake, h1_client).await?;
+    let conn = crate::tokio::read_challenge_packet(conn).await?;
 
     let h2_conn = ts_http_util::http2::connect(conn).await?;
     tracing::debug!("http2 connection to control established");

--- a/ts_control/src/tokio/connect.rs
+++ b/ts_control/src/tokio/connect.rs
@@ -1,14 +1,11 @@
 use alloc::string::String;
-use core::{fmt, str::FromStr};
+use core::{fmt, pin::Pin, str::FromStr, task::Poll};
 
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
 use ts_capabilityversion::CapabilityVersion;
-use ts_hexdump::{AsHexExt, Case};
 use ts_http_util::{BytesBody, ClientExt, EmptyBody, HeaderName, HeaderValue, Http2, ResponseExt};
-use ts_keys::{ChallengePublicKey, MachineKeyPair, MachinePublicKey};
-use ts_packet::PacketMut;
+use ts_keys::{MachineKeyPair, MachinePublicKey};
 use url::Url;
-use zerocopy::network_endian::U32;
 
 use crate::tokio::{MapStreamError, RegistrationError};
 
@@ -72,7 +69,7 @@ pub async fn connect(
     control_url: &Url,
     machine_keys: &MachineKeyPair,
 ) -> Result<Http2<BytesBody>, ConnectionError> {
-    let h1_client = ts_http_util::http1::connect_tls(control_url).await?;
+    let h1_client = connect_h1_empty(control_url).await?;
 
     let control_public_key = fetch_control_key(control_url).await?;
 
@@ -83,23 +80,40 @@ pub async fn connect(
         CapabilityVersion::CURRENT,
     );
 
-    let mut conn = upgrade_ts2021(control_url, &init_msg, handshake, h1_client).await?;
-    let _challenge_packet = read_challenge_packet(&mut conn).await?;
+    let conn = upgrade_ts2021(control_url, &init_msg, handshake, h1_client).await?;
+
+    // The early payload (challenge packet) is optional. The server may send
+    // the magic prefix [FF FF FF 'T' 'S'] followed by a JSON challenge, or it
+    // may go straight to HTTP/2 (whose first frame starts with different bytes).
+    // Read the first 9 bytes (same size as an HTTP/2 frame header) and check.
+    let conn = read_challenge_packet(conn).await?;
 
     let h2_conn = ts_http_util::http2::connect(conn).await?;
     Ok(h2_conn)
 }
 
+/// Connect an HTTP/1.1 client (EmptyBody) to the control server, using TLS for https://
+/// URLs and plain TCP for http:// URLs.
+async fn connect_h1_empty(url: &Url) -> Result<ts_http_util::Http1<EmptyBody>, ConnectionError> {
+    if url.scheme() == "http" {
+        Ok(ts_http_util::http1::connect_tcp(url).await?)
+    } else {
+        Ok(ts_http_util::http1::connect_tls(url).await?)
+    }
+}
+
 #[tracing::instrument(skip_all, fields(%control_url), ret, err, level = "trace")]
 pub async fn fetch_control_key(control_url: &Url) -> Result<MachinePublicKey, ConnectionError> {
     let mut key_url = control_url.join("/key")?;
-    key_url.set_scheme("https").unwrap();
+    if control_url.scheme() == "https" {
+        key_url.set_scheme("https").unwrap();
+    }
 
     key_url
         .query_pairs_mut()
         .extend_pairs([("v", CapabilityVersion::CURRENT.to_string())]);
 
-    let client = ts_http_util::http1::connect_tls::<EmptyBody>(&key_url).await?;
+    let client = connect_h1_empty(&key_url).await?;
     let response = client.get(&key_url, None).await?;
     if !response.status().is_success() {
         let status = response.status();
@@ -153,59 +167,160 @@ pub async fn upgrade_ts2021(
     Ok(conn)
 }
 
-#[tracing::instrument(skip_all, ret, err, level = "trace")]
+/// A connection that may have leftover bytes prepended from the early payload check.
+struct ChainedConn<T: Unpin> {
+    prefix: Vec<u8>,
+    prefix_pos: usize,
+    inner: T,
+}
+
+impl<T: AsyncRead + Unpin> AsyncRead for ChainedConn<T> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let me = self.get_mut();
+        if me.prefix_pos < me.prefix.len() {
+            let remaining = &me.prefix[me.prefix_pos..];
+            let to_copy = remaining.len().min(buf.remaining());
+            buf.put_slice(&remaining[..to_copy]);
+            me.prefix_pos += to_copy;
+            return Poll::Ready(Ok(()));
+        }
+        Pin::new(&mut me.inner).poll_read(cx, buf)
+    }
+}
+
+impl<T: AsyncWrite + Unpin> AsyncWrite for ChainedConn<T> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.get_mut().inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+}
+
+/// Read the optional early payload (challenge packet) from the server.
+///
+/// The server may send a challenge packet with magic prefix [FF FF FF 'T' 'S'] followed
+/// by a JSON payload, or it may go straight to HTTP/2. This function reads the first
+/// 9 bytes (same size as an HTTP/2 frame header) and checks for the magic. If no magic,
+/// the bytes are chained back for the HTTP/2 parser.
 pub async fn read_challenge_packet(
-    conn: &mut (impl AsyncRead + Unpin),
-) -> Result<ChallengePublicKey, ConnectionError> {
-    let mut magic = [0u8; CHALLENGE_MAGIC.len()];
+    mut conn: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
+) -> Result<impl AsyncRead + AsyncWrite + Unpin + Send + 'static, ConnectionError> {
+    const HDR_LEN: usize = 9; // 5 magic + 4 length, same as HTTP/2 frame header
 
-    conn.read_exact(&mut magic)
+    let mut hdr = [0u8; HDR_LEN];
+    conn.read_exact(&mut hdr)
         .await
         .map_err(|err| ConnectionError::Io {
-            field: Some("magic"),
-            stage: "challenge",
-            err,
-        })?;
-    if magic != CHALLENGE_MAGIC {
-        return Err(ConnectionError::InvalidChallengeMagic(magic));
-    }
-
-    let mut challenge_len: U32 = 0.into();
-    conn.read_exact(challenge_len.as_mut())
-        .await
-        .map_err(|err| ConnectionError::Io {
-            field: Some("length"),
-            stage: "challenge",
-            err,
-        })?;
-    let challenge_len = challenge_len.get() as usize;
-    if challenge_len > MAX_CHALLENGE_LENGTH {
-        return Err(ConnectionError::InvalidChallengeLength(challenge_len));
-    }
-
-    let mut json = PacketMut::new(challenge_len);
-    conn.read_exact(json.as_mut())
-        .await
-        .map_err(|err| ConnectionError::Io {
-            field: Some("body"),
-            stage: "challenge",
+            field: Some("header"),
+            stage: "early_payload",
             err,
         })?;
 
-    #[derive(serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct ChallengePacket {
-        node_key_challenge: ChallengePublicKey,
+    if &hdr[..CHALLENGE_MAGIC.len()] == &CHALLENGE_MAGIC {
+        // Early payload present -- read and discard the challenge JSON.
+        let len = u32::from_be_bytes(hdr[5..9].try_into().unwrap()) as usize;
+        if len > 1 << 20 {
+            return Err(ConnectionError::InvalidChallengeLength(len));
+        }
+        let mut body = vec![0u8; len];
+        conn.read_exact(&mut body)
+            .await
+            .map_err(|err| ConnectionError::Io {
+                field: Some("body"),
+                stage: "challenge",
+                err,
+            })?;
+        tracing::debug!("read early challenge payload ({} bytes)", len);
+        // Return the connection as-is (challenge consumed).
+        Ok(ChainedConn {
+            prefix: vec![],
+            prefix_pos: 0,
+            inner: conn,
+        })
+    } else {
+        // No early payload -- the 9 bytes are the start of HTTP/2.
+        // Chain them back so the HTTP/2 parser sees them.
+        tracing::debug!("no early challenge payload, proceeding to HTTP/2");
+        Ok(ChainedConn {
+            prefix: hdr.to_vec(),
+            prefix_pos: 0,
+            inner: conn,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt, duplex};
+
+    use super::*;
+
+    /// Build a challenge packet: magic + big-endian length + JSON body.
+    fn make_challenge(json: &[u8]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&CHALLENGE_MAGIC);
+        buf.extend_from_slice(&(json.len() as u32).to_be_bytes());
+        buf.extend_from_slice(json);
+        buf
     }
 
-    tracing::trace!(
-        "challenge packet:\n{}",
-        json.iter()
-            .hexdump(Case::Lower)
-            .flatten()
-            .collect::<String>()
-    );
+    /// Test that when the server sends an early challenge packet (production control
+    /// server behavior), the magic+length+JSON is consumed and subsequent HTTP/2 data
+    /// is passed through unmodified.
+    #[tokio::test]
+    async fn challenge_present() {
+        let json = b"{\"nodeKeyChallenge\":\"test\"}";
+        let payload = b"HTTP/2 data after challenge";
 
-    let packet = serde_json::from_slice::<ChallengePacket>(&json[..])?;
-    Ok(packet.node_key_challenge)
+        let mut data = make_challenge(json);
+        data.extend_from_slice(payload);
+
+        let (mut writer, reader) = duplex(1024);
+        writer.write_all(&data).await.unwrap();
+        drop(writer);
+
+        let mut conn = read_challenge_packet(reader).await.unwrap();
+
+        let mut out = Vec::new();
+        conn.read_to_end(&mut out).await.unwrap();
+        assert_eq!(out, payload);
+    }
+
+    /// Test that when the server skips the early challenge and goes straight to HTTP/2
+    /// (testcontrol behavior), all bytes are preserved -- the 9-byte peek that didn't
+    /// match the magic is chained back so the HTTP/2 parser sees the full stream.
+    #[tokio::test]
+    async fn challenge_absent() {
+        let payload = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+
+        let (mut writer, reader) = duplex(1024);
+        writer.write_all(payload).await.unwrap();
+        drop(writer);
+
+        let mut conn = read_challenge_packet(reader).await.unwrap();
+
+        let mut out = Vec::new();
+        conn.read_to_end(&mut out).await.unwrap();
+        assert_eq!(out, payload);
+    }
 }

--- a/ts_http_util/src/lib.rs
+++ b/ts_http_util/src/lib.rs
@@ -97,7 +97,10 @@ pub fn make_upgrade_req(
     protocol: &str,
     extra_headers: impl IntoIterator<Item = (HeaderName, HeaderValue)>,
 ) -> Result<Request<EmptyBody>, Error> {
-    let mut req = Request::get(u.as_str())
+    // Use POST for the upgrade request. Some server implementations accept both
+    // GET and POST, but others (e.g. Go's testcontrol) only accept POST. POST
+    // is what Go's controlhttp client sends, so use it for widest compatibility.
+    let mut req = Request::post(u.as_str())
         .header(HOST, u.host_str().ok_or(Error::InvalidParam)?)
         .header(UPGRADE, protocol)
         .header(CONNECTION, "Upgrade")


### PR DESCRIPTION
The control client previously required TLS for all control server
connections and assumed the server always sends an early challenge
packet after the Noise handshake. Both assumptions break when using
Go's testcontrol server, which serves plain HTTP and skips the early
payload.

Changes:

- ts_control/connect: select HTTP/1.1 over TCP or TLS based on URL
  scheme, making http:// control URLs work
- ts_control/connect: make the post-handshake early payload (challenge
  packet) optional by peeking at the first 9 bytes and chaining them
  back if they aren't the magic prefix
- ts_control/control_dialer: use the same optional challenge logic for
  reconnections
- ts_http_util: change upgrade request from GET to POST to match Go's
  controlhttpserver which requires POST for /ts2021
