### PR TITLE
ts_python: fix PyPI project links

### DIFF
--- a/ts_python/pyproject.toml
+++ b/ts_python/pyproject.toml
@@ -5,9 +5,6 @@ description = "Work-in-progress Tailscale library written in Rust."
 license = "BSD-3-Clause"
 readme = "README.md"
 keywords = ["tailscale-py", "tailscale-rs", "tailscale", "vpn", "wireguard"]
-documentation = "https://github.com/tailscale/tailscale-rs/tree/main/ts_python"
-homepage = "https://github.com/tailscale/tailscale-rs"
-repository = "https://github.com/tailscale/tailscale-rs"
 requires-python = ">=3.12"
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -26,6 +23,11 @@ classifiers = [
 dependencies = [
     "maturin>=1.13.1",
 ]
+
+[project.urls]
+Documentation = "https://github.com/tailscale/tailscale-rs/tree/main/ts_python"
+Homepage = "https://github.com/tailscale/tailscale-rs"
+Repository = "https://github.com/tailscale/tailscale-rs"
 
 [build-system]
 requires = ["maturin>=1.13.1,<2.0"]


### PR DESCRIPTION
The PyPI project doesn't have homepage/docs/repo links appearing in the sidebar, because they're in the wrong part of the `pyproject.toml`.

They should be under `[project.urls]`, not `[project]`. See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls