### PR TITLE
tailscale: env fallback for control URL and auth key

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,22 @@
 use std::path::Path;
 
+use url::Url;
+
+/// Environment variable consulted for [`Config::control_server_url`] when that
+/// field is `None`.
+pub const ENV_CONTROL_URL: &str = "TS_CONTROL_URL";
+/// Environment variable consulted for [`Config::requested_hostname`] when that
+/// field is `None`.
+pub const ENV_HOSTNAME: &str = "TS_HOSTNAME";
+/// Environment variable consulted for [`Config::client_name`] when that field
+/// is `None`.
+pub const ENV_CLIENT_NAME: &str = "TS_CLIENT_NAME";
+/// Environment variable consulted for the auth key passed to
+/// [`crate::Device::new`] when the `auth_key` parameter is `None`.
+pub const ENV_AUTH_KEY: &str = "TS_AUTH_KEY";
+
 /// Config for connecting to Tailscale.
+#[derive(Default)]
 pub struct Config {
     /// The path of the file used to store cryptographic keys.
     ///
@@ -17,11 +33,17 @@ pub struct Config {
     pub client_name: Option<String>,
 
     /// The URL of the control server to connect to.
-    pub control_server_url: url::Url,
+    ///
+    /// When `None`, [`crate::Device::new`] reads [`ENV_CONTROL_URL`] from the
+    /// environment. If that is also unset, the built-in Tailscale default
+    /// ([`ts_control::DEFAULT_CONTROL_SERVER`]) is used.
+    pub control_server_url: Option<Url>,
 
     /// The hostname this node will request.
     ///
-    /// If left blank, uses the hostname reported by the OS.
+    /// If `None`, [`crate::Device::new`] reads [`ENV_HOSTNAME`] from the
+    /// environment. If that is also unset, the hostname reported by the OS is
+    /// used.
     pub requested_hostname: Option<String>,
 
     /// Tags this node will request.
@@ -55,21 +77,37 @@ impl From<&Config> for ts_control::Config {
         ts_control::Config {
             client_name: value.client_name.clone(),
             hostname: value.requested_hostname.clone(),
-            server_url: value.control_server_url.clone(),
+            server_url: value
+                .control_server_url
+                .clone()
+                .unwrap_or_else(|| ts_control::DEFAULT_CONTROL_SERVER.clone()),
         }
     }
 }
 
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            key_state: Default::default(),
-            client_name: None,
-            control_server_url: ts_control::DEFAULT_CONTROL_SERVER.clone(),
-            requested_hostname: None,
-            requested_tags: vec![],
-        }
+/// Resolve the control server URL.
+///
+/// Precedence: `configured.is_some()` > [`ENV_CONTROL_URL`] >
+/// [`ts_control::DEFAULT_CONTROL_SERVER`]. A malformed env value returns
+/// [`crate::Error::InvalidConfigEnv`].
+pub(crate) fn resolve_control_url(
+    configured: &Option<Url>,
+    get: impl Fn(&str) -> Option<String>,
+) -> Result<Url, crate::Error> {
+    if let Some(url) = configured {
+        return Ok(url.clone());
     }
+    let Some(raw) = get(ENV_CONTROL_URL) else {
+        return Ok(ts_control::DEFAULT_CONTROL_SERVER.clone());
+    };
+    Url::parse(&raw).map_err(|e| {
+        tracing::error!(
+            error = %e,
+            var = ENV_CONTROL_URL,
+            "parsing control server URL from environment",
+        );
+        crate::Error::InvalidConfigEnv(ENV_CONTROL_URL)
+    })
 }
 
 /// What to do if the key file can't be parsed.
@@ -146,4 +184,46 @@ where
     })?;
 
     Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn one(var: &'static str, value: &'static str) -> impl Fn(&str) -> Option<String> {
+        move |name| (name == var).then(|| value.to_owned())
+    }
+
+    #[test]
+    fn control_url_default_when_nothing_set() {
+        let url = resolve_control_url(&None, |_| None).unwrap();
+        assert_eq!(url, *ts_control::DEFAULT_CONTROL_SERVER);
+    }
+
+    #[test]
+    fn control_url_env_wins_when_config_is_none() {
+        let url =
+            resolve_control_url(&None, one(ENV_CONTROL_URL, "https://env.example.com/")).unwrap();
+        assert_eq!(url.as_str(), "https://env.example.com/");
+    }
+
+    #[test]
+    fn control_url_explicit_wins_over_env() {
+        let explicit: Url = "https://explicit.example.com/".parse().unwrap();
+        let url = resolve_control_url(
+            &Some(explicit.clone()),
+            one(ENV_CONTROL_URL, "https://env.example.com/"),
+        )
+        .unwrap();
+        assert_eq!(url, explicit);
+    }
+
+    #[test]
+    fn control_url_malformed_env_returns_typed_error() {
+        let result = resolve_control_url(&None, one(ENV_CONTROL_URL, "not a url"));
+        assert!(
+            matches!(result, Err(crate::Error::InvalidConfigEnv(ENV_CONTROL_URL))),
+            "expected InvalidConfigEnv(TS_CONTROL_URL)",
+        );
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,13 @@ pub enum Error {
     /// A connection was reset.
     #[error("connection reset")]
     ConnectionReset,
+
+    /// A configuration environment variable held an unparseable or non-UTF-8 value.
+    ///
+    /// The wrapped `&'static str` names the offending variable (e.g. `"TS_CONTROL_URL"`).
+    /// The underlying parse error is logged at the call site via `tracing::error!`.
+    #[error("invalid value for config env var {0}")]
+    InvalidConfigEnv(&'static str),
 }
 
 impl From<ts_runtime::Error> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,21 @@
 //! [Tokio docs](https://docs.rs/tokio) for more information. In the future, we would like to limit
 //! our reliance on Tokio so that there are alternatives for users of other async runtimes.
 //!
+//! ## Environment variables
+//!
+//! [`Device::new`] consults a small set of environment variables when the
+//! corresponding [`Config`] field (or `auth_key` parameter) is left unset, so
+//! applications can point at a self-hosted control server or supply an auth
+//! key without code changes. Precedence is *explicit value > environment
+//! variable > built-in default*:
+//!
+//! | Variable | Configures | Default |
+//! | --- | --- | --- |
+//! | `TS_CONTROL_URL` | [`Config::control_server_url`] | `https://controlplane.tailscale.com/` |
+//! | `TS_HOSTNAME` | [`Config::requested_hostname`] | OS hostname |
+//! | `TS_CLIENT_NAME` | [`Config::client_name`] | unset |
+//! | `TS_AUTH_KEY` | `auth_key` parameter of [`Device::new`] | unset |
+//!
 //! ## Caveats
 //!
 //! This software is still a work-in-progress! We are providing it in the open at this stage out of
@@ -135,7 +150,10 @@ use std::{
 };
 
 #[doc(inline)]
-pub use config::{BadFormatBehavior, Config, load_key_file};
+pub use config::{
+    BadFormatBehavior, Config, ENV_AUTH_KEY, ENV_CLIENT_NAME, ENV_CONTROL_URL, ENV_HOSTNAME,
+    load_key_file,
+};
 #[doc(inline)]
 pub use error::Error;
 #[doc(inline)]
@@ -183,8 +201,18 @@ impl Device {
     pub async fn new(config: &Config, auth_key: Option<String>) -> Result<Self, Error> {
         check_magic_env()?;
 
-        let rt =
-            ts_runtime::Runtime::spawn(config.into(), auth_key, config.key_state.clone()).await?;
+        let get = |name: &str| std::env::var(name).ok();
+        let ts_cfg = ts_control::Config {
+            server_url: config::resolve_control_url(&config.control_server_url, get)?,
+            hostname: config
+                .requested_hostname
+                .clone()
+                .or_else(|| get(ENV_HOSTNAME)),
+            client_name: config.client_name.clone().or_else(|| get(ENV_CLIENT_NAME)),
+        };
+        let auth_key = auth_key.or_else(|| get(ENV_AUTH_KEY));
+
+        let rt = ts_runtime::Runtime::spawn(ts_cfg, auth_key, config.key_state.clone()).await?;
         let channel = rt.channel().await?;
 
         Ok(Self {


### PR DESCRIPTION
Not familiar with Rust, but tried a bit with Claude. Ran into a couple of things as I was working up an integration test for Headscale. 

Mirror the env fallback tsnet implemented in tailscale/tailscale#18975.

When a Config field or the auth_key parameter is unset, Device::new now
consults `TS_CONTROL_URL`, `TS_HOSTNAME`, `TS_CLIENT_NAME`, and `TS_AUTH_KEY` as a
fallback before the built-in default. Every consumer of the tailscale
crate

All the examples, ts_python, ts_elixir, and downstream
applications gets env-driven config with no wiring change at the call
site.

Created with help of Claude.