### PR TITLE
derp, tls, control: feature-gate insecure tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4571,6 +4571,7 @@ version = "0.2.0"
 dependencies = [
  "tokio",
  "tokio-rustls",
+ "tracing",
  "url",
  "webpki-roots",
 ]

--- a/ts_control/Cargo.toml
+++ b/ts_control/Cargo.toml
@@ -49,5 +49,8 @@ tokio-stream = { version = "0.1", optional = true, default-features = false, fea
 default = ["async_tokio"]
 async_tokio = ["dep:futures-util", "dep:tokio", "dep:tokio-stream"]
 
+# Allow derp connections to be made without verifying TLS certs. Only for use in tests.
+insecure-derp = ["ts_transport_derp/insecure-for-tests"]
+
 [lints]
 workspace = true

--- a/ts_control/src/derp.rs
+++ b/ts_control/src/derp.rs
@@ -53,10 +53,13 @@ fn server(server: &ts_control_serde::DerpServer) -> ts_transport_derp::ServerCon
         port => port,
     };
 
-    let tls_config = if server.insecure_for_tests {
-        TlsValidationConfig::InsecureForTests
-    } else {
-        TlsValidationConfig::from_str(server.cert_name.unwrap_or_default(), server.hostname)
+    #[cfg_attr(not(feature = "insecure-derp"), allow(unused_mut))]
+    let mut tls_config =
+        TlsValidationConfig::from_str(server.cert_name.unwrap_or_default(), server.hostname);
+
+    #[cfg(feature = "insecure-derp")]
+    if server.insecure_for_tests {
+        tls_config = TlsValidationConfig::InsecureForTests;
     };
 
     ts_transport_derp::ServerConnInfo {

--- a/ts_tls_util/Cargo.toml
+++ b/ts_tls_util/Cargo.toml
@@ -15,8 +15,13 @@ rust-version.workspace = true
 # Unconditionally required dependencies.
 tokio.workspace = true
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
+tracing.workspace = true
 url.workspace = true
 webpki-roots = { version = "1.0" }
+
+[features]
+# enable the connect_insecure function, which doesn't validate tls certs
+insecure = []
 
 [lints]
 workspace = true

--- a/ts_tls_util/src/insecure.rs
+++ b/ts_tls_util/src/insecure.rs
@@ -1,0 +1,79 @@
+use std::sync::Arc;
+
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerifier};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_rustls::{
+    TlsConnector,
+    client::TlsStream,
+    rustls,
+    rustls::{
+        ClientConfig,
+        client::danger::ServerCertVerified,
+        pki_types::{CertificateDer, UnixTime},
+    },
+};
+
+use crate::ServerName;
+
+/// Establishes a TLS stream with a server over an existing connection, skipping certificate
+/// verification entirely. Only for use in tests with self-signed certificates.
+pub async fn connect_insecure<Io>(
+    server_name: ServerName<'_>,
+    io: Io,
+) -> tokio::io::Result<TlsStream<Io>>
+where
+    Io: AsyncRead + AsyncWrite + Unpin,
+{
+    tracing::warn!(server_name = %server_name.to_str(), "connecting insecure TLS");
+
+    let rustls_config = ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(InsecureCertVerifier))
+        .with_no_client_auth();
+
+    let connector = TlsConnector::from(Arc::new(rustls_config));
+    let stream = connector.connect(server_name.to_owned(), io).await?;
+
+    Ok(stream)
+}
+
+/// A TLS certificate verifier that accepts any certificate. Only for use in tests.
+#[derive(Debug)]
+struct InsecureCertVerifier;
+
+impl ServerCertVerifier for InsecureCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _: &CertificateDer<'_>,
+        _: &[CertificateDer<'_>],
+        _: &ServerName<'_>,
+        _: &[u8],
+        _: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _: &[u8],
+        _: &CertificateDer<'_>,
+        _: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _: &[u8],
+        _: &CertificateDer<'_>,
+        _: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}

--- a/ts_tls_util/src/lib.rs
+++ b/ts_tls_util/src/lib.rs
@@ -10,53 +10,11 @@ use tokio_rustls::{
 pub use tokio_rustls::{client::TlsStream, rustls::pki_types::ServerName};
 use url::Url;
 
-/// A TLS certificate verifier that accepts any certificate. Only for use in tests.
-#[derive(Debug)]
-struct InsecureCertVerifier;
+#[cfg(feature = "insecure")]
+mod insecure;
 
-impl tokio_rustls::rustls::client::danger::ServerCertVerifier for InsecureCertVerifier {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &tokio_rustls::rustls::pki_types::CertificateDer<'_>,
-        _intermediates: &[tokio_rustls::rustls::pki_types::CertificateDer<'_>],
-        _server_name: &ServerName<'_>,
-        _ocsp_response: &[u8],
-        _now: tokio_rustls::rustls::pki_types::UnixTime,
-    ) -> Result<tokio_rustls::rustls::client::danger::ServerCertVerified, tokio_rustls::rustls::Error>
-    {
-        Ok(tokio_rustls::rustls::client::danger::ServerCertVerified::assertion())
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        _message: &[u8],
-        _cert: &tokio_rustls::rustls::pki_types::CertificateDer<'_>,
-        _dss: &tokio_rustls::rustls::DigitallySignedStruct,
-    ) -> Result<
-        tokio_rustls::rustls::client::danger::HandshakeSignatureValid,
-        tokio_rustls::rustls::Error,
-    > {
-        Ok(tokio_rustls::rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        _message: &[u8],
-        _cert: &tokio_rustls::rustls::pki_types::CertificateDer<'_>,
-        _dss: &tokio_rustls::rustls::DigitallySignedStruct,
-    ) -> Result<
-        tokio_rustls::rustls::client::danger::HandshakeSignatureValid,
-        tokio_rustls::rustls::Error,
-    > {
-        Ok(tokio_rustls::rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<tokio_rustls::rustls::SignatureScheme> {
-        tokio_rustls::rustls::crypto::aws_lc_rs::default_provider()
-            .signature_verification_algorithms
-            .supported_schemes()
-    }
-}
+#[cfg(feature = "insecure")]
+pub use insecure::connect_insecure;
 
 static ROOT_CERT_STORE: LazyLock<Arc<RootCertStore>> = LazyLock::new(|| {
     Arc::new(RootCertStore {
@@ -97,26 +55,6 @@ where
 
     let connector = TlsConnector::from(Arc::new(rustls_config));
 
-    let stream = connector.connect(server_name.to_owned(), io).await?;
-
-    Ok(stream)
-}
-
-/// Establishes a TLS stream with a server over an existing connection, skipping certificate
-/// verification entirely. Only for use in tests with self-signed certificates.
-pub async fn connect_insecure<Io>(
-    server_name: ServerName<'_>,
-    io: Io,
-) -> tokio::io::Result<TlsStream<Io>>
-where
-    Io: AsyncRead + AsyncWrite + Unpin,
-{
-    let rustls_config = ClientConfig::builder()
-        .dangerous()
-        .with_custom_certificate_verifier(Arc::new(InsecureCertVerifier))
-        .with_no_client_auth();
-
-    let connector = TlsConnector::from(Arc::new(rustls_config));
     let stream = connector.connect(server_name.to_owned(), io).await?;
 
     Ok(stream)

--- a/ts_transport_derp/Cargo.toml
+++ b/ts_transport_derp/Cargo.toml
@@ -40,5 +40,11 @@ tokio = { workspace = true, features = ["full"] }
 ts_cli_util.workspace = true
 ts_control_serde.workspace = true
 
+[features]
+# Enable insecure TLS connections for running in test configurations
+insecure-for-tests = [
+    "ts_tls_util/insecure"
+]
+
 [lints]
 workspace = true

--- a/ts_transport_derp/src/dial.rs
+++ b/ts_transport_derp/src/dial.rs
@@ -65,8 +65,10 @@ pub async fn dial_region_tls<'c>(
             )
             .await?
         }
+        #[cfg(feature = "insecure-for-tests")]
         TlsValidationConfig::InsecureForTests => {
             tracing::warn!(%server.hostname, "using insecure TLS for tests");
+
             ts_tls_util::connect_insecure(
                 ServerName::try_from(server.hostname.clone()).map_err(|e| {
                     tracing::error!(error = %e, "derp hostname");
@@ -77,7 +79,7 @@ pub async fn dial_region_tls<'c>(
             .await?
         }
         TlsValidationConfig::SelfSigned { .. } => {
-            // SelfSigned should be filtered out in `dial_region_tcp`.
+            // These should be filtered out in `dial_region_tcp`, so we want this to panic.
             unimplemented!("self-signed derp server certs are currently unsupported");
         }
     };

--- a/ts_transport_derp/src/lib.rs
+++ b/ts_transport_derp/src/lib.rs
@@ -185,6 +185,7 @@ pub enum TlsValidationConfig {
         /// The common name the certificate should have.
         common_name: String,
     },
+    #[cfg(feature = "insecure-for-tests")]
     /// Skip TLS certificate verification entirely. Only for use in tests.
     InsecureForTests,
 }


### PR DESCRIPTION
Add feature gates as an extra interlock for using insecure TLS in derp connections, and clean up/refactor a bit