### PR TITLE
readme: update code sample -> tailscale::Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ use core::{
 async fn main() -> Result<(), Box<dyn Error>> {
     // Open a new connection to tailscale
     let dev = tailscale::Device::new(
-        Default::default(), // control config
+        &tailscale::Config {
+            key_state: tailscale::load_key_file("tsrs_state.json", Default::default()).await?,
+            ..Default::default()
+        },
         Some("YOUR_AUTH_KEY_HERE".to_owned()),
-        Default::default(), // key state: WARNING, this creates a throwaway node identity
     ).await?;
 
     // Bind a UDP socket on our tailnet IP, port 1234


### PR DESCRIPTION
It still had the old-style `tailscale::Device::new`.