### PR TITLE
all: align name for key state files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@ flamegraph.svg
 perf.data
 perf.data.old
 heaptrack.*
-config.json
-key_file*.json
+tsrs_keys*.json
 priv/
 _build/
 ts_elixir/deps/

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Open a new connection to tailscale
     let dev = tailscale::Device::new(
         &tailscale::Config {
-            key_state: tailscale::load_key_file("tsrs_state.json", Default::default()).await?,
+            key_state: tailscale::load_key_file("tsrs_keys.json", Default::default()).await?,
             ..Default::default()
         },
         Some("YOUR_AUTH_KEY_HERE".to_owned()),

--- a/examples/axum/README.md
+++ b/examples/axum/README.md
@@ -7,7 +7,7 @@ An `axum`-based HTTP server that serves a simple webpage over the tailnet. This 
 `tailscale-rs` to be compiled with the `axum` feature:
 
 ```sh
-$ TS_RS_EXPERIMENT=this_is_unstable_software cargo run --example axum --features axum -- --auth-key $AUTH_KEY --key-file key_file.json
+$ TS_RS_EXPERIMENT=this_is_unstable_software cargo run --example axum --features axum -- --auth-key $AUTH_KEY --key-file tsrs_keys.json
 ...
 INFO axum: http server listening url=http://<tailnet IP>:80/index.html
 ```

--- a/examples/peer_ping/README.md
+++ b/examples/peer_ping/README.md
@@ -23,7 +23,7 @@ Then, in another terminal, run the example:
 
 ```sh
 # Terminal 2
-$ TS_RS_EXPERIMENT=this_is_unstable_software cargo run --example peer_ping -- --auth-key $AUTH_KEY --key-file key_file.json --peer <tailnet IP>:5678 
+$ TS_RS_EXPERIMENT=this_is_unstable_software cargo run --example peer_ping -- --auth-key $AUTH_KEY --key-file tsrs_keys.json --peer <tailnet IP>:5678 
 ...
 INFO ts_runtime::multiderp: new home derp region selected region_id=1 latency_ms=12.223305702209473
 ...

--- a/examples/tcp_echo/README.md
+++ b/examples/tcp_echo/README.md
@@ -9,7 +9,7 @@ For this example, you can use netcat (`nc`) to test the server. First, start the
 
 ```sh
 # Terminal 1
-$ TS_RS_EXPERIMENT=this_is_unstable_software cargo run --example tcp_echo -- --auth-key $AUTH_KEY --key-file key_file.json 
+$ TS_RS_EXPERIMENT=this_is_unstable_software cargo run --example tcp_echo -- --auth-key $AUTH_KEY --key-file tsrs_keys.json 
 ...
 INFO tcp_echo: listening_addr=<tailnet IP>:1234
 ...

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -7,7 +7,7 @@
 //! # async fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! let dev = tailscale::Device::new(
 //!     &tailscale::Config {
-//!         key_state: tailscale::load_key_file("tsrs_key.json", Default::default()).await?,
+//!         key_state: tailscale::load_key_file("tsrs_keys.json", Default::default()).await?,
 //!         ..Default::default()
 //!     },
 //!     Some("YOUR_AUTH_KEY".to_owned()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! // Open a new connection to the tailnet
 //! let dev = tailscale::Device::new(
 //!     &tailscale::Config {
-//!         key_state: tailscale::load_key_file("tsrs_key.json", Default::default()).await?,
+//!         key_state: tailscale::load_key_file("tsrs_keys.json", Default::default()).await?,
 //!         ..Default::default()
 //!     },
 //!     Some("YOUR_AUTH_KEY_HERE".to_owned()),
@@ -173,7 +173,7 @@ impl Device {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let dev = tailscale::Device::new(
     ///     &tailscale::Config {
-    ///         key_state: tailscale::load_key_file("tsrs_state.json", Default::default()).await?,
+    ///         key_state: tailscale::load_key_file("tsrs_keys.json", Default::default()).await?,
     ///         ..Default::default()
     ///     },
     ///     Some("MY_AUTH_KEY".to_string()),

--- a/ts_cli_util/src/lib.rs
+++ b/ts_cli_util/src/lib.rs
@@ -20,7 +20,7 @@ static GLOBAL_ALLOC: tracy_client::ProfiledAllocator<std::alloc::System> =
 #[derive(Debug, Clone, PartialEq, Eq, clap::Parser)]
 pub struct CommonArgs {
     /// The path of the key file to save to.
-    #[arg(short = 'c', long, default_value = "config.json")]
+    #[arg(short = 'c', long, default_value = "tsrs_keys.json")]
     pub key_state_path: std::path::PathBuf,
 
     /// The auth key to connect with.

--- a/ts_elixir/README.md
+++ b/ts_elixir/README.md
@@ -9,7 +9,7 @@ the API as we iterate.
 
 ```elixir
 # Connect to tailscale:
-{:ok, dev} = Tailscale.connect("state.json", "YOUR_AUTH_KEY")
+{:ok, dev} = Tailscale.connect("tsrs_keys.json", "YOUR_AUTH_KEY")
 # Fetch our tailnet IPv4:
 {:ok, ip} = Tailscale.ip4(dev)
 

--- a/ts_ffi/examples/tcp_echo/tcp_echo.c
+++ b/ts_ffi/examples/tcp_echo/tcp_echo.c
@@ -21,7 +21,7 @@
 
 #define USAGE \
     "usage: tcp_echo CONFIG_PATH AUTH_TOKEN\n" \
-    "  e.g. tcp_echo test.json tskey-auth-XXX"
+    "  e.g. tcp_echo tsrs_keys.json tskey-auth-XXX"
 
 static void* run_conn_echo(void* arg) {
     uint8_t* buf = malloc(1024);

--- a/ts_ffi/examples/udp_ping/udp_ping.c
+++ b/ts_ffi/examples/udp_ping/udp_ping.c
@@ -18,7 +18,7 @@
 
 #define USAGE \
     "usage: udp_ping CONFIG_PATH AUTH_TOKEN PEER_ADDR\n" \
-    "  e.g. udp_ping test.json tskey-auth-XXX 1.2.3.4:5678"
+    "  e.g. udp_ping tsrs_keys.json tskey-auth-XXX 1.2.3.4:5678"
 
 int main(int argc, char** argv) {
     if (argc != 4) {

--- a/ts_python/README.md
+++ b/ts_python/README.md
@@ -14,7 +14,7 @@ import tailscale
 
 async def main():
     # connect to the tailnet:
-    dev = await tailscale.connect('tsrs_state.json', "tskey-auth-$MY_AUTH_KEY")
+    dev = await tailscale.connect('tsrs_keys.json', "tskey-auth-$MY_AUTH_KEY")
 
     # bind a udp socket on this node's ipv4 address:
     tailnet_ipv4 = await dev.ipv4_addr()

--- a/ts_python/examples/udp/recv.py
+++ b/ts_python/examples/udp/recv.py
@@ -8,7 +8,7 @@ import tailscale
 
 async def main(auth_key: str, bind_port: int) -> None:
     # Connect to the tailnet:
-    dev = await tailscale.connect('key_file_recv.json', auth_key)
+    dev = await tailscale.connect('tsrs_keys_recv.json', auth_key)
 
     # Bind a UDP socket on this device's IPv4 address:
     tailnet_ipv4 = await dev.ipv4_addr()

--- a/ts_python/examples/udp/send.py
+++ b/ts_python/examples/udp/send.py
@@ -11,7 +11,7 @@ MESSAGE = b'HELLO'
 
 async def main(auth_key: str, peer_ip: str, peer_port: int) -> None:
     # Connect to the tailnet:
-    dev = await tailscale.connect('key_file_send.json', auth_key)
+    dev = await tailscale.connect('tsrs_keys_send.json', auth_key)
 
     # Bind a UDP socket on this device's IPv4 address:
     tailnet_ipv4 = await dev.ipv4_addr()


### PR DESCRIPTION
Use the same filename/prefix for key state files across examples, default options, and langauge bindings (where appropriate).

Updates #cleanup