### PR TITLE
tailscale: Modularise the top-level API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,9 +172,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -279,9 +279,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
@@ -376,7 +376,7 @@ checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "clap",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "proc-macro2",
  "quote",
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -436,7 +436,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -459,7 +459,7 @@ dependencies = [
  "clap",
  "globwalk",
  "serde",
- "toml 1.0.6+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -528,9 +528,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -1051,11 +1051,11 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1267,11 +1267,11 @@ dependencies = [
 
 [[package]]
 name = "getifaddrs"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06f770241660efeeedb30b48ccbe0a8e6f649322148237539e71f3ccd14a4461"
+checksum = "802c6e75f730346652928a55c200ca680741aaaa60c4973d52a999f520c4fde4"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -1312,7 +1312,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1352,7 +1352,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "ignore",
  "walkdir",
 ]
@@ -1369,7 +1369,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1416,6 +1416,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hdrhistogram"
@@ -1545,9 +1551,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1560,7 +1566,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1568,15 +1573,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1646,12 +1650,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1659,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1672,9 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1686,15 +1691,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1706,15 +1711,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1806,12 +1811,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1827,9 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -1845,9 +1850,9 @@ dependencies = [
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1870,9 +1875,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -1930,10 +1935,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1992,9 +1999,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -2014,9 +2021,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2128,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2139,34 +2146,23 @@ dependencies = [
 
 [[package]]
 name = "netconfig-rs"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "207561c8758738388c2fd851c3e759f503583d8dd70ddc895baae806753ad4c9"
+checksum = "733ad7a1352f0748a620368f2ea5cd94f0e449c5108fbac86ace31df1601bf6f"
 dependencies = [
  "cfg-if",
- "core-foundation 0.9.4",
+ "core-foundation 0.10.1",
  "ipnet",
  "libc",
- "netlink-packet-core 0.7.0",
- "netlink-packet-route 0.24.0",
+ "netlink-packet-core",
+ "netlink-packet-route 0.25.1",
  "netlink-sys",
  "nix 0.30.1",
  "scopeguard",
- "system-configuration-sys 0.5.0",
+ "system-configuration-sys",
  "thiserror 2.0.18",
  "widestring",
  "windows",
-]
-
-[[package]]
-name = "netlink-packet-core"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
-dependencies = [
- "anyhow",
- "byteorder",
- "netlink-packet-utils",
 ]
 
 [[package]]
@@ -2180,17 +2176,14 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.24.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d83370a96813d7c977f8b63054f1162df6e5784f1c598d689236564fb5a6f2"
+checksum = "3ec2f5b6839be2a19d7fa5aab5bc444380f6311c2b693551cb80f45caaa7b5ef"
 dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "byteorder",
+ "bitflags 2.11.1",
  "libc",
  "log",
- "netlink-packet-core 0.7.0",
- "netlink-packet-utils",
+ "netlink-packet-core",
 ]
 
 [[package]]
@@ -2199,22 +2192,10 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "log",
- "netlink-packet-core 0.8.1",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.69",
+ "netlink-packet-core",
 ]
 
 [[package]]
@@ -2234,7 +2215,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2247,7 +2228,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2308,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -2467,12 +2448,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,9 +2489,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2613,15 +2588,15 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -2664,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "bytes",
  "libc",
@@ -2705,18 +2680,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2724,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2736,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2783,7 +2758,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2842,9 +2817,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2858,7 +2833,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2891,9 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -2910,7 +2885,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3028,7 +3003,7 @@ checksum = "319bb478ff9aae1dc7a544fa599e9eb47e2521621dc3921fba6abcaaa312092c"
 dependencies = [
  "flume",
  "libc",
- "netlink-packet-core 0.8.1",
+ "netlink-packet-core",
  "netlink-packet-route 0.28.0",
  "netlink-sys",
  "windows-sys 0.61.2",
@@ -3036,9 +3011,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3055,7 +3030,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3089,9 +3064,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3255,7 +3230,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3274,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3345,9 +3320,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -3374,7 +3349,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -3444,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -3533,7 +3508,7 @@ dependencies = [
  "precis-core",
  "precis-profiles",
  "quoted-string-parser",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -3579,19 +3554,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -3649,12 +3614,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3739,9 +3704,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3764,9 +3729,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -3782,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3833,28 +3798,28 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -3868,27 +3833,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -3938,7 +3903,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -3955,7 +3920,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -4692,9 +4657,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-parse"
@@ -4833,11 +4798,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4846,14 +4811,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4864,23 +4829,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4888,9 +4849,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4901,9 +4862,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -4925,7 +4886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4936,17 +4897,17 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4964,18 +4925,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5392,6 +5353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+
+[[package]]
 name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5409,6 +5376,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -5429,7 +5402,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -5459,8 +5432,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5479,7 +5452,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -5491,9 +5464,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x25519-dalek"
@@ -5514,15 +5487,15 @@ checksum = "b3d5d6ff67acd3945b933e592bfa7143db4fcbb2f871754b6b9fbd7847fc5aea"
 dependencies = [
  "curve25519-dalek 5.0.0-pre.6",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5531,9 +5504,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5543,18 +5516,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5563,18 +5536,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5604,9 +5577,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5615,9 +5588,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5626,9 +5599,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -41,20 +41,18 @@ repository layout, see [ARCHITECTURE.md](ARCHITECTURE.md).
 A simple UDP client that periodically sends messages to a tailnet peer at `100.64.0.1:5678`:
 
 ```rust
-use core::{
+use std::{
     time::Duration,
     net::Ipv4Addr,
     error::Error,
 };
+use tailscale::{Config, Device};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // Open a new connection to tailscale
-    let dev = tailscale::Device::new(
-        &tailscale::Config {
-            key_state: tailscale::load_key_file("tsrs_keys.json", Default::default()).await?,
-            ..Default::default()
-        },
+    let dev = Device::new(
+        &Config::from_key_file("tsrs_keys.json").await?,
         Some("YOUR_AUTH_KEY_HERE".to_owned()),
     ).await?;
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ use tailscale::{Config, Device};
 async fn main() -> Result<(), Box<dyn Error>> {
     // Open a new connection to tailscale
     let dev = Device::new(
-        &Config::from_key_file("tsrs_keys.json").await?,
+        &Config::default_with_key_file("tsrs_keys.json").await?,
         Some("YOUR_AUTH_KEY_HERE".to_owned()),
     ).await?;
 

--- a/examples/axum/main.rs
+++ b/examples/axum/main.rs
@@ -1,22 +1,29 @@
 //! An `axum`-based HTTP server that serves a simple webpage over the tailnet. Requires
 //! `tailscale-rs` to be compiled with the `axum` feature.
 
-use core::sync::atomic::AtomicUsize;
-use std::sync::Arc;
+use std::{
+    error::Error,
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
 use axum::{
     Router,
     extract::{Path, State},
-    http::StatusCode,
-    response::IntoResponse,
+    http::{StatusCode, header::CONTENT_TYPE},
+    response::{IntoResponse, Response},
     routing::{get, post},
 };
 use clap::Parser;
+use tailscale::{Config, Device};
 use tracing::level_filters::LevelFilter;
 
 static WWW: include_dir::Dir = include_dir::include_dir!("$CARGO_MANIFEST_DIR/examples/axum/www");
 
-async fn assets(Path(path): Path<String>) -> axum::response::Response {
+async fn assets(Path(path): Path<String>) -> Response {
     let Some(result) = WWW
         .get_file(&path)
         .or_else(|| WWW.get_file(format!("{path}/index.html")))
@@ -27,17 +34,14 @@ async fn assets(Path(path): Path<String>) -> axum::response::Response {
     let mime = mime_guess::from_path(result.path());
 
     (
-        [(
-            axum::http::header::CONTENT_TYPE,
-            mime.first_or_octet_stream().as_ref(),
-        )],
+        [(CONTENT_TYPE, mime.first_or_octet_stream().as_ref())],
         result.contents(),
     )
         .into_response()
 }
 
 async fn count(count: State<Arc<AtomicUsize>>) -> impl IntoResponse {
-    let new = count.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let new = count.0.fetch_add(1, Ordering::SeqCst);
 
     format!(r#"{{"count": {new}}}"#)
 }
@@ -47,7 +51,7 @@ async fn count(count: State<Arc<AtomicUsize>>) -> impl IntoResponse {
 struct Args {
     /// Path to a key file to use. Will be created if it doesn't exist.
     #[arg(short = 'c', long, default_value = "tsrs_keys.json")]
-    key_file: std::path::PathBuf,
+    key_file: PathBuf,
 
     /// The auth key to connect with.
     ///
@@ -61,7 +65,7 @@ struct Args {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn core::error::Error>> {
+async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::builder()
@@ -72,8 +76,8 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
 
     let args = Args::parse();
 
-    let dev = tailscale::Device::new(
-        &tailscale::Config::from_key_file(&args.key_file).await?,
+    let dev = Device::new(
+        &Config::from_key_file(&args.key_file).await?,
         args.auth_key.clone(),
     )
     .await?;

--- a/examples/axum/main.rs
+++ b/examples/axum/main.rs
@@ -73,10 +73,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
     let args = Args::parse();
 
     let dev = tailscale::Device::new(
-        &tailscale::Config {
-            key_state: tailscale::load_key_file(&args.key_file, Default::default()).await?,
-            ..Default::default()
-        },
+        &tailscale::Config::from_key_file(&args.key_file).await?,
         args.auth_key.clone(),
     )
     .await?;

--- a/examples/axum/main.rs
+++ b/examples/axum/main.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
 
     let dev = Device::new(
-        &Config::from_key_file(&args.key_file).await?,
+        &Config::default_with_key_file(&args.key_file).await?,
         args.auth_key.clone(),
     )
     .await?;

--- a/examples/peer_ping/main.rs
+++ b/examples/peer_ping/main.rs
@@ -40,7 +40,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let args = Args::parse();
 
-    let dev = Device::new(&Config::from_key_file(&args.key_file).await?, args.auth_key).await?;
+    let dev = Device::new(
+        &Config::default_with_key_file(&args.key_file).await?,
+        args.auth_key,
+    )
+    .await?;
 
     let sock = dev.udp_bind((dev.ipv4_addr().await?, 1234).into()).await?;
     let mut ticker = tokio::time::interval(Duration::from_secs_f64(args.ping_interval_secs));

--- a/examples/peer_ping/main.rs
+++ b/examples/peer_ping/main.rs
@@ -1,8 +1,9 @@
 //! Send UDP messages to a peer on a configurable interval.
 
-use core::{net::SocketAddr, time::Duration};
+use std::{error::Error, net::SocketAddr, path::PathBuf, time::Duration};
 
 use clap::Parser;
+use tailscale::{Config, Device};
 use tracing_subscriber::filter::LevelFilter;
 
 #[derive(clap::Parser)]
@@ -10,7 +11,7 @@ use tracing_subscriber::filter::LevelFilter;
 struct Args {
     /// Path to a key file to use. Will be created if it doesn't exist.
     #[arg(short = 'c', long, default_value = "tsrs_keys.json")]
-    key_file: std::path::PathBuf,
+    key_file: PathBuf,
 
     /// The auth key to connect with.
     ///
@@ -28,7 +29,7 @@ struct Args {
 }
 
 #[tokio::main(flavor = "multi_thread")]
-async fn main() -> Result<(), Box<dyn core::error::Error>> {
+async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::builder()
@@ -39,11 +40,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
 
     let args = Args::parse();
 
-    let dev = tailscale::Device::new(
-        &tailscale::Config::from_key_file(&args.key_file).await?,
-        args.auth_key,
-    )
-    .await?;
+    let dev = Device::new(&Config::from_key_file(&args.key_file).await?, args.auth_key).await?;
 
     let sock = dev.udp_bind((dev.ipv4_addr().await?, 1234).into()).await?;
     let mut ticker = tokio::time::interval(Duration::from_secs_f64(args.ping_interval_secs));

--- a/examples/peer_ping/main.rs
+++ b/examples/peer_ping/main.rs
@@ -40,10 +40,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
     let args = Args::parse();
 
     let dev = tailscale::Device::new(
-        &tailscale::Config {
-            key_state: tailscale::load_key_file(&args.key_file, Default::default()).await?,
-            ..Default::default()
-        },
+        &tailscale::Config::from_key_file(&args.key_file).await?,
         args.auth_key,
     )
     .await?;

--- a/examples/tcp_echo/main.rs
+++ b/examples/tcp_echo/main.rs
@@ -44,7 +44,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let args = Args::parse();
 
-    let dev = Device::new(&Config::from_key_file(&args.key_file).await?, args.auth_key).await?;
+    let dev = Device::new(
+        &Config::default_with_key_file(&args.key_file).await?,
+        args.auth_key,
+    )
+    .await?;
 
     let sockaddr = (dev.ipv4_addr().await?, args.listen_port).into();
     let listener = dev.tcp_listen(sockaddr).await?;

--- a/examples/tcp_echo/main.rs
+++ b/examples/tcp_echo/main.rs
@@ -41,10 +41,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
     let args = Args::parse();
 
     let dev = tailscale::Device::new(
-        &tailscale::Config {
-            key_state: tailscale::load_key_file(&args.key_file, Default::default()).await?,
-            ..Default::default()
-        },
+        &tailscale::Config::from_key_file(&args.key_file).await?,
         args.auth_key,
     )
     .await?;

--- a/examples/tcp_echo/main.rs
+++ b/examples/tcp_echo/main.rs
@@ -1,6 +1,10 @@
 //! Run a TCP echo server on the tailnet on a particular port.
 
+use std::{error::Error, path::PathBuf};
+
 use clap::Parser;
+use tailscale::{Config, Device};
+use tokio::task::spawn;
 use tracing_subscriber::filter::LevelFilter;
 
 /// Run a TCP echo server on the tailnet on a particular port.
@@ -15,7 +19,7 @@ use tracing_subscriber::filter::LevelFilter;
 struct Args {
     /// Path to a key file to use. Will be created if it doesn't exist.
     #[arg(short = 'c', long, default_value = "tsrs_keys.json")]
-    key_file: std::path::PathBuf,
+    key_file: PathBuf,
 
     /// The auth key to connect with.
     ///
@@ -29,7 +33,7 @@ struct Args {
 }
 
 #[tokio::main(flavor = "multi_thread")]
-async fn main() -> Result<(), Box<dyn core::error::Error>> {
+async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::builder()
@@ -40,11 +44,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
 
     let args = Args::parse();
 
-    let dev = tailscale::Device::new(
-        &tailscale::Config::from_key_file(&args.key_file).await?,
-        args.auth_key,
-    )
-    .await?;
+    let dev = Device::new(&Config::from_key_file(&args.key_file).await?, args.auth_key).await?;
 
     let sockaddr = (dev.ipv4_addr().await?, args.listen_port).into();
     let listener = dev.tcp_listen(sockaddr).await?;
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
     loop {
         let conn = listener.accept().await?;
 
-        tokio::task::spawn(async move {
+        spawn(async move {
             let remote_ep = conn.remote_addr();
             tracing::info!(%remote_ep, "accepted connection");
 

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -5,11 +5,9 @@
 //! ```rust,no_run
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn core::error::Error>> {
-//! let dev = tailscale::Device::new(
-//!     &tailscale::Config {
-//!         key_state: tailscale::load_key_file("tsrs_keys.json", Default::default()).await?,
-//!         ..Default::default()
-//!     },
+//! # use tailscale::{Config, Device};
+//! let dev = Device::new(
+//!     &Config::from_key_file("tsrs_keys.json").await?,
 //!     Some("YOUR_AUTH_KEY".to_owned()),
 //! ).await?;
 //!

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -1,4 +1,4 @@
-//! Support for the [`axum`] http server wrapping [`TcpListener`].
+//! Support for the [`axum`] http server wrapping [`netstack::TcpListener`].
 //!
 //! # Example
 //!
@@ -26,32 +26,32 @@
 
 use std::net::SocketAddr;
 
-use crate::{TcpListener, TcpStream};
+use crate::netstack;
 
-/// Wrapper type implementing [`axum::serve::Listener`] on [`TcpListener`].
+/// Wrapper type implementing [`axum::serve::Listener`] on [`netstack::TcpListener`].
 #[derive(Debug)]
-pub struct Listener(TcpListener);
+pub struct Listener(netstack::TcpListener);
 
-impl From<TcpListener> for Listener {
-    fn from(listener: TcpListener) -> Self {
+impl From<netstack::TcpListener> for Listener {
+    fn from(listener: netstack::TcpListener) -> Self {
         Self(listener)
     }
 }
 
-impl From<Listener> for TcpListener {
+impl From<Listener> for netstack::TcpListener {
     fn from(listener: Listener) -> Self {
         listener.0
     }
 }
 
-impl AsRef<TcpListener> for Listener {
-    fn as_ref(&self) -> &TcpListener {
+impl AsRef<netstack::TcpListener> for Listener {
+    fn as_ref(&self) -> &netstack::TcpListener {
         &self.0
     }
 }
 
 impl axum::serve::Listener for Listener {
-    type Io = TcpStream;
+    type Io = netstack::TcpStream;
     type Addr = SocketAddr;
 
     async fn accept(&mut self) -> (Self::Io, Self::Addr) {

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -7,7 +7,7 @@
 //! # async fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! # use tailscale::{Config, Device};
 //! let dev = Device::new(
-//!     &Config::from_key_file("tsrs_keys.json").await?,
+//!     &Config::default_with_key_file("tsrs_keys.json").await?,
 //!     Some("YOUR_AUTH_KEY".to_owned()),
 //! ).await?;
 //!

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,9 @@
+//! Types and utilities for configuring a Tailscale [`Device`](crate::Device).
+
 use std::path::Path;
+
+#[doc(inline)]
+pub use ts_keys::NodeState;
 
 /// Config for connecting to Tailscale.
 pub struct Config {
@@ -7,7 +12,7 @@ pub struct Config {
     /// This file represents this node's identity. The key file format is specific to
     /// tailscale-rs; key files are not interchangeable with those produced by other
     /// implementations of Tailscale, e.g. `tailscaled` or `tsnet`.
-    pub key_state: crate::NodeState,
+    pub key_state: NodeState,
 
     // TODO(npry): let clients also define an app name once the sdk-level name moves
     //  to a dedicated field
@@ -28,6 +33,20 @@ pub struct Config {
     pub requested_tags: Vec<String>,
 }
 
+impl Config {
+    /// Create a new config with it's [`key_state`](Config::key_state) populated from the specified key file and using
+    /// default options for other configuration.
+    ///
+    /// See [`load_key_file`] for more details and an alternative with more options for reading
+    /// the key file.
+    pub async fn from_key_file(p: impl AsRef<Path>) -> Result<Self, crate::Error> {
+        Ok(Config {
+            key_state: load_key_file(p, Default::default()).await?,
+            ..Default::default()
+        })
+    }
+}
+
 /// Load key state from a path on the filesystem, or create a file with a new key state if
 /// one doesn't exist.
 ///
@@ -36,7 +55,7 @@ pub struct Config {
 pub async fn load_key_file(
     p: impl AsRef<Path>,
     bad_format: BadFormatBehavior,
-) -> Result<crate::NodeState, crate::Error> {
+) -> Result<NodeState, crate::Error> {
     let p = p.as_ref();
 
     tracing::trace!(key_file = %p.display(), "loading key file");
@@ -47,7 +66,7 @@ pub async fn load_key_file(
 
 #[derive(serde::Serialize, serde::Deserialize, Default)]
 struct KeyFile {
-    key_state: crate::NodeState,
+    key_state: NodeState,
 }
 
 impl From<&Config> for ts_control::Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,7 +39,7 @@ impl Config {
     ///
     /// See [`load_key_file`] for more details and an alternative with more options for reading
     /// the key file.
-    pub async fn from_key_file(p: impl AsRef<Path>) -> Result<Self, crate::Error> {
+    pub async fn default_with_key_file(p: impl AsRef<Path>) -> Result<Self, crate::Error> {
         Ok(Config {
             key_state: load_key_file(p, Default::default()).await?,
             ..Default::default()

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,8 +2,7 @@
 
 use std::path::Path;
 
-#[doc(inline)]
-pub use ts_keys::NodeState;
+use crate::keys::NodeState;
 
 /// Config for connecting to Tailscale.
 pub struct Config {
@@ -34,7 +33,7 @@ pub struct Config {
 }
 
 impl Config {
-    /// Create a new config with it's [`key_state`](Config::key_state) populated from the specified key file and using
+    /// Create a new config with its [`key_state`](Config::key_state) populated from the specified key file and using
     /// default options for other configuration.
     ///
     /// See [`load_key_file`] for more details and an alternative with more options for reading

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use netstack::netcore;
+use crate::netstack::Error as NetstackError;
 
 /// Errors that may occur while interacting with a device.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]
@@ -35,16 +35,16 @@ impl From<ts_runtime::Error> for Error {
     }
 }
 
-impl From<netcore::Error> for Error {
-    fn from(value: netcore::Error) -> Self {
+impl From<NetstackError> for Error {
+    fn from(value: NetstackError) -> Self {
         match value {
-            netcore::Error::ChannelClosed => Error::RuntimeDegraded,
+            NetstackError::ChannelClosed => Error::RuntimeDegraded,
 
-            netcore::Error::WrongType
-            | netcore::Error::BadRequest
-            | netcore::Error::InvariantViolated => Error::InternalFailure,
+            NetstackError::WrongType
+            | NetstackError::BadRequest
+            | NetstackError::InvariantViolated => Error::InternalFailure,
 
-            netcore::Error::TcpStream(netcore::tcp::stream::Error::Reset) => Error::ConnectionReset,
+            NetstackError::TcpStream(_) => Error::ConnectionReset,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //! # async fn main() -> Result<(), Box<dyn Error>> {
 //! // Open a new connection to the tailnet
 //! let dev = tailscale::Device::new(
-//!     &tailscale::Config::from_key_file("tsrs_keys.json").await?,
+//!     &tailscale::Config::default_with_key_file("tsrs_keys.json").await?,
 //!     Some("YOUR_AUTH_KEY_HERE".to_owned()),
 //! ).await?;
 //!
@@ -164,7 +164,7 @@ impl Device {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # use tailscale::*;
     /// let dev = Device::new(
-    ///     &Config::from_key_file("tsrs_keys.json").await?,
+    ///     &Config::default_with_key_file("tsrs_keys.json").await?,
     ///     Some("MY_AUTH_KEY".to_string()),
     /// ).await?;
     /// # Ok(()) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,12 @@ pub mod netstack {
     pub use ts_netstack_smoltcp::netsock::{TcpListener, TcpStream, UdpSocket};
 }
 
+/// Tailscale cryptographic key types.
+pub mod keys {
+    #[doc(inline)]
+    pub use ts_keys::{DiscoKeyPair, MachineKeyPair, NetworkLockKeyPair, NodeKeyPair, NodeState};
+}
+
 const ENV_MAGIC_VAR: &str = "TS_RS_EXPERIMENT";
 const ENV_MAGIC_VALUE: &str = "this_is_unstable_software";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,10 +38,7 @@
 //! # async fn main() -> Result<(), Box<dyn Error>> {
 //! // Open a new connection to the tailnet
 //! let dev = tailscale::Device::new(
-//!     &tailscale::Config {
-//!         key_state: tailscale::load_key_file("tsrs_keys.json", Default::default()).await?,
-//!         ..Default::default()
-//!     },
+//!     &tailscale::Config::from_key_file("tsrs_keys.json").await?,
 //!     Some("YOUR_AUTH_KEY_HERE".to_owned()),
 //! ).await?;
 //!
@@ -133,19 +130,16 @@ use std::{
     time::Duration,
 };
 
-#[doc(inline)]
-pub use config::{BadFormatBehavior, Config, load_key_file};
+pub use config::Config;
 #[doc(inline)]
 pub use error::Error;
-use ts_netstack_smoltcp::{CreateSocket, netcore::Channel};
 #[doc(inline)]
 pub use ts_control::Node as NodeInfo;
-#[doc(inline)]
-pub use ts_keys::NodeState;
+use ts_netstack_smoltcp::{CreateSocket, netcore::Channel};
 
 #[cfg(feature = "axum")]
 pub mod axum;
-mod config;
+pub mod config;
 mod error;
 
 /// How a program connects to a tailnet and communicates with peers.
@@ -169,10 +163,7 @@ impl Device {
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let dev = tailscale::Device::new(
-    ///     &tailscale::Config {
-    ///         key_state: tailscale::load_key_file("tsrs_keys.json", Default::default()).await?,
-    ///         ..Default::default()
-    ///     },
+    ///     &tailscale::Config::from_key_file("tsrs_keys.json").await?,
     ///     Some("MY_AUTH_KEY".to_string()),
     /// ).await?;
     /// # Ok(()) }
@@ -216,7 +207,10 @@ impl Device {
     }
 
     /// Bind a TCP listener to the specified [`SocketAddr`].
-    pub async fn tcp_listen(&self, socket_addr: SocketAddr) -> Result<netstack::TcpListener, Error> {
+    pub async fn tcp_listen(
+        &self,
+        socket_addr: SocketAddr,
+    ) -> Result<netstack::TcpListener, Error> {
         self.channel
             .tcp_listen(socket_addr)
             .await
@@ -272,9 +266,9 @@ impl Device {
 /// easier-to-integrate, more-portable API.
 pub mod netstack {
     #[doc(inline)]
-    pub use ts_netstack_smoltcp::netsock::{TcpListener, TcpStream, UdpSocket};
-    #[doc(inline)]
     pub use ts_netstack_smoltcp::netcore::Error;
+    #[doc(inline)]
+    pub use ts_netstack_smoltcp::netsock::{TcpListener, TcpStream, UdpSocket};
 }
 
 const ENV_MAGIC_VAR: &str = "TS_RS_EXPERIMENT";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,8 +162,9 @@ impl Device {
     /// ```rust,no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let dev = tailscale::Device::new(
-    ///     &tailscale::Config::from_key_file("tsrs_keys.json").await?,
+    /// # use tailscale::*;
+    /// let dev = Device::new(
+    ///     &Config::from_key_file("tsrs_keys.json").await?,
     ///     Some("MY_AUTH_KEY".to_string()),
     /// ).await?;
     /// # Ok(()) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@
 //! ## Feature Flags
 //!
 //! - `axum`: enables the [`axum`] module, which enables you to run an [`axum` HTTP server] on top
-//!   of a [`TcpListener`].
+//!   of a [`netstack::TcpListener`].
 //!
 //! ## Platform Support
 //!
@@ -105,7 +105,8 @@
 //! or the [GitHub repo](https://github.com/tailscale/tailscale-rs).
 //!
 //! - [ts_runtime](https://docs.rs/ts_runtime): for each API-level `Device`, the runtime uses an actor
-//!   architecture to manage the lifecycle of the control client, data plane components, netstack, etc. A message bus passes updates and communications between these top-level actors.
+//!   architecture to manage the lifecycle of the control client, data plane components, netstack, etc.
+//!   A message bus passes updates and communications between these top-level actors.
 //! - [ts_netcheck](https://docs.rs/ts_netcheck): checks network availability and reports latency to
 //!   DERP servers in different regions.
 //! - [ts_netstack_smoltcp](https://docs.rs/ts_netstack_smoltcp): a [smoltcp](https://docs.rs/smoltcp)-based
@@ -127,8 +128,6 @@
 //! [open an issue]: https://github.com/tailscale/tailscale-rs/issues
 //! [`axum` HTTP server]: https://docs.rs/axum/latest/axum/
 
-extern crate ts_netstack_smoltcp as netstack;
-
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     time::Duration,
@@ -138,9 +137,7 @@ use std::{
 pub use config::{BadFormatBehavior, Config, load_key_file};
 #[doc(inline)]
 pub use error::Error;
-#[doc(inline)]
-pub use netstack::netsock::{TcpListener, TcpStream, UdpSocket};
-use netstack::{CreateSocket, netcore::Channel};
+use ts_netstack_smoltcp::{CreateSocket, netcore::Channel};
 #[doc(inline)]
 pub use ts_control::Node as NodeInfo;
 #[doc(inline)]
@@ -214,12 +211,12 @@ impl Device {
     }
 
     /// Bind a UDP socket to the specified [`SocketAddr`].
-    pub async fn udp_bind(&self, socket_addr: SocketAddr) -> Result<UdpSocket, Error> {
+    pub async fn udp_bind(&self, socket_addr: SocketAddr) -> Result<netstack::UdpSocket, Error> {
         self.channel.udp_bind(socket_addr).await.map_err(Into::into)
     }
 
     /// Bind a TCP listener to the specified [`SocketAddr`].
-    pub async fn tcp_listen(&self, socket_addr: SocketAddr) -> Result<TcpListener, Error> {
+    pub async fn tcp_listen(&self, socket_addr: SocketAddr) -> Result<netstack::TcpListener, Error> {
         self.channel
             .tcp_listen(socket_addr)
             .await
@@ -227,7 +224,7 @@ impl Device {
     }
 
     /// Connect to a TCP socket at the remote address.
-    pub async fn tcp_connect(&self, remote: SocketAddr) -> Result<TcpStream, Error> {
+    pub async fn tcp_connect(&self, remote: SocketAddr) -> Result<netstack::TcpStream, Error> {
         let ip: IpAddr = match remote.is_ipv4() {
             true => self.ipv4_addr().await?.into(),
             false => self.ipv6_addr().await?.into(),
@@ -267,6 +264,17 @@ impl Device {
     pub async fn shutdown(self, timeout: Option<Duration>) -> bool {
         self.runtime.graceful_shutdown(timeout).await
     }
+}
+
+/// Command-channel-driven userspace network stack.
+///
+/// This is an opinionated wrapper around [smoltcp](https://docs.rs/smoltcp) that provides an
+/// easier-to-integrate, more-portable API.
+pub mod netstack {
+    #[doc(inline)]
+    pub use ts_netstack_smoltcp::netsock::{TcpListener, TcpStream, UdpSocket};
+    #[doc(inline)]
+    pub use ts_netstack_smoltcp::netcore::Error;
 }
 
 const ENV_MAGIC_VAR: &str = "TS_RS_EXPERIMENT";

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -5,6 +5,7 @@ use std::{
     time::Duration,
 };
 
+use tailscale::{Config, Device, Error, netstack::UdpSocket};
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     time::timeout,
@@ -186,7 +187,7 @@ async fn test_udp(dev: &tailscale::Device, ip: IpAddr) {
     test_udp_unidir(&udp2, &udp1).await;
 }
 
-async fn test_udp_unidir(tx: &tailscale::UdpSocket, rx: &tailscale::UdpSocket) {
+async fn test_udp_unidir(tx: &UdpSocket, rx: &UdpSocket) {
     tx.send_to(rx.local_addr(), b"hello").await.unwrap();
 
     let (who, msg) = rx.recv_from_bytes().await.unwrap();
@@ -195,12 +196,8 @@ async fn test_udp_unidir(tx: &tailscale::UdpSocket, rx: &tailscale::UdpSocket) {
     assert_eq!(msg.as_ref(), b"hello");
 }
 
-async fn make_ts_device() -> Result<tailscale::Device, tailscale::Error> {
+async fn make_ts_device() -> Result<Device, Error> {
     unsafe { std::env::set_var("TS_RS_EXPERIMENT", "this_is_unstable_software") };
 
-    tailscale::Device::new(
-        &tailscale::Config::default(),
-        Some(ts_test_util::auth_key().unwrap()),
-    )
-    .await
+    Device::new(&Config::default(), Some(ts_test_util::auth_key().unwrap())).await
 }

--- a/ts_cli_util/src/lib.rs
+++ b/ts_cli_util/src/lib.rs
@@ -41,7 +41,7 @@ pub struct CommonArgs {
 impl CommonArgs {
     /// Convert the args to a [`tailscale::Config`].
     pub async fn config(&self) -> Result<tailscale::Config> {
-        tailscale::Config::from_key_file(&self.key_state_path)
+        tailscale::Config::default_with_key_file(&self.key_state_path)
             .await
             .map_err(Into::into)
     }

--- a/ts_cli_util/src/lib.rs
+++ b/ts_cli_util/src/lib.rs
@@ -41,11 +41,9 @@ pub struct CommonArgs {
 impl CommonArgs {
     /// Convert the args to a [`tailscale::Config`].
     pub async fn config(&self) -> Result<tailscale::Config> {
-        Ok(tailscale::Config {
-            key_state: tailscale::load_key_file(&self.key_state_path, Default::default()).await?,
-            requested_hostname: self.hostname.clone(),
-            ..Default::default()
-        })
+        tailscale::Config::from_key_file(&self.key_state_path)
+            .await
+            .map_err(Into::into)
     }
 
     /// Load or init the config, then connect to the configured control server.

--- a/ts_elixir/native/ts_elixir/src/lib.rs
+++ b/ts_elixir/native/ts_elixir/src/lib.rs
@@ -103,7 +103,7 @@ where
 fn connect(env: rustler::Env, config_path: String, auth_key: Option<String>) -> impl Encoder {
     let dev = TOKIO_RUNTIME.block_on(async move {
         let config = tailscale::Config {
-            key_state: tailscale::load_key_file(config_path, Default::default()).await?,
+            key_state: tailscale::config::load_key_file(config_path, Default::default()).await?,
             client_name: Some("ts_elixir".to_owned()),
             ..Default::default()
         };

--- a/ts_elixir/native/ts_elixir/src/lib.rs
+++ b/ts_elixir/native/ts_elixir/src/lib.rs
@@ -103,9 +103,8 @@ where
 fn connect(env: rustler::Env, config_path: String, auth_key: Option<String>) -> impl Encoder {
     let dev = TOKIO_RUNTIME.block_on(async move {
         let config = tailscale::Config {
-            key_state: tailscale::config::load_key_file(config_path, Default::default()).await?,
             client_name: Some("ts_elixir".to_owned()),
-            ..Default::default()
+            ..tailscale::Config::default_with_key_file(config_path).await?
         };
 
         let dev = tailscale::Device::new(&config, auth_key).await?;

--- a/ts_elixir/native/ts_elixir/src/tcp.rs
+++ b/ts_elixir/native/ts_elixir/src/tcp.rs
@@ -5,11 +5,11 @@ use rustler::{Encoder, ResourceArc};
 use crate::{IpOrSelf, Result, TOKIO_RUNTIME, atoms, erl_result, ip_from_erl, ok_arc};
 
 pub(crate) struct TcpListener {
-    inner: Arc<tailscale::TcpListener>,
+    inner: Arc<tailscale::netstack::TcpListener>,
 }
 
 pub(crate) struct TcpStream {
-    inner: Arc<tailscale::TcpStream>,
+    inner: Arc<tailscale::netstack::TcpStream>,
 }
 
 #[rustler::resource_impl]

--- a/ts_elixir/native/ts_elixir/src/udp.rs
+++ b/ts_elixir/native/ts_elixir/src/udp.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 pub struct UdpSocket {
-    inner: Arc<tailscale::UdpSocket>,
+    inner: Arc<tailscale::netstack::UdpSocket>,
 }
 
 #[rustler::resource_impl]

--- a/ts_ffi/src/lib.rs
+++ b/ts_ffi/src/lib.rs
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn ts_init(
             .map(ToOwned::to_owned);
 
         let dev = tailscale::Device::new(
-            &tailscale::Config::from_key_file(&config_path).await?,
+            &tailscale::Config::default_with_key_file(&config_path).await?,
             auth_token,
         )
         .await?;

--- a/ts_ffi/src/lib.rs
+++ b/ts_ffi/src/lib.rs
@@ -85,10 +85,7 @@ pub unsafe extern "C" fn ts_init(
             .map(ToOwned::to_owned);
 
         let dev = tailscale::Device::new(
-            &tailscale::Config {
-                key_state: tailscale::load_key_file(&config_path, Default::default()).await?,
-                ..Default::default()
-            },
+            &tailscale::Config::from_key_file(&config_path).await?,
             auth_token,
         )
         .await?;

--- a/ts_ffi/src/tcp.rs
+++ b/ts_ffi/src/tcp.rs
@@ -3,10 +3,10 @@ use std::ffi;
 use crate::TOKIO_RUNTIME;
 
 /// A Tailscale TCP listener handle.
-pub struct tcp_listener(tailscale::TcpListener);
+pub struct tcp_listener(tailscale::netstack::TcpListener);
 
 /// A Tailscale TCP stream handle.
-pub struct tcp_stream(tailscale::TcpStream);
+pub struct tcp_stream(tailscale::netstack::TcpStream);
 
 /// Start a TCP listener on the given `addr`.
 ///

--- a/ts_ffi/src/udp.rs
+++ b/ts_ffi/src/udp.rs
@@ -3,7 +3,7 @@ use std::ffi;
 use crate::TOKIO_RUNTIME;
 
 /// A Tailscale UDP socket handle.
-pub struct udp_socket(tailscale::UdpSocket);
+pub struct udp_socket(tailscale::netstack::UdpSocket);
 
 /// Bind a UDP socket on `addr`.
 ///

--- a/ts_python/src/lib.rs
+++ b/ts_python/src/lib.rs
@@ -41,11 +41,10 @@ pub mod _internal {
 
         future_into_py(py, async move {
             let config = ts::Config {
-                key_state: ts::config::load_key_file(config_path, Default::default())
-                    .await
-                    .map_err(py_value_err)?,
                 client_name: Some("ts_python".to_owned()),
-                ..Default::default()
+                ..ts::Config::default_with_key_file(config_path)
+                    .await
+                    .map_err(py_value_err)?
             };
 
             let dev = ts::Device::new(&config, auth_key)

--- a/ts_python/src/lib.rs
+++ b/ts_python/src/lib.rs
@@ -41,7 +41,7 @@ pub mod _internal {
 
         future_into_py(py, async move {
             let config = ts::Config {
-                key_state: ts::load_key_file(config_path, Default::default())
+                key_state: ts::config::load_key_file(config_path, Default::default())
                     .await
                     .map_err(py_value_err)?,
                 client_name: Some("ts_python".to_owned()),

--- a/ts_python/src/tcp.rs
+++ b/ts_python/src/tcp.rs
@@ -8,13 +8,13 @@ use crate::{PyFut, py_value_err, sockaddr_as_tuple};
 /// A TCP listen socket.
 #[pyclass(frozen, module = "_internal")]
 pub struct TcpListener {
-    pub(crate) listener: Arc<ts::TcpListener>,
+    pub(crate) listener: Arc<ts::netstack::TcpListener>,
 }
 
 /// An established TCP stream.
 #[pyclass(frozen, module = "_internal")]
 pub struct TcpStream {
-    pub(crate) sock: Arc<ts::TcpStream>,
+    pub(crate) sock: Arc<ts::netstack::TcpStream>,
 }
 
 #[pymethods]

--- a/ts_python/src/udp.rs
+++ b/ts_python/src/udp.rs
@@ -9,7 +9,7 @@ use crate::{PyFut, ip_or_str::IpRepr, py_value_err, sockaddr_as_tuple};
 /// A tailscale UDP socket.
 #[pyclass(frozen, module = "_internal")]
 pub struct UdpSocket {
-    pub(crate) sock: Arc<ts::UdpSocket>,
+    pub(crate) sock: Arc<ts::netstack::UdpSocket>,
 }
 
 #[pymethods]


### PR DESCRIPTION
Factors out config and netstack modules for the API and tidies up the examples using more imports. Also adds a helper method for creating `Config`s from a key file.

I wonder if we should re-export the key types used in the fields of `NodeState` in `config`?