### PR TITLE
ffi: support construction by config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3127,9 +3127,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4306,6 +4306,7 @@ dependencies = [
  "tokio",
  "tracing",
  "ts_cli_util",
+ "ts_keys",
 ]
 
 [[package]]

--- a/ts_ffi/Cargo.toml
+++ b/ts_ffi/Cargo.toml
@@ -14,6 +14,7 @@ publish.workspace = true
 [dependencies]
 tailscale.workspace = true
 ts_cli_util.workspace = true
+ts_keys.workspace = true
 
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true, features = ["release_max_level_info"] }

--- a/ts_ffi/examples/lookup_peer/lookup_peer.c
+++ b/ts_ffi/examples/lookup_peer/lookup_peer.c
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
         exit(EXIT_FAILURE);
     }
 
-    const struct ts_device* dev = ts_init(
+    const struct ts_device* dev = ts_init_from_key_file(
         argv[1],
         argv[2]
     );
@@ -38,7 +38,7 @@ int main(int argc, char** argv) {
     ts_in6_addr_t addrv6;
     char addr_str[INET6_ADDRSTRLEN];
 
-    assert(!ts_ipv4(dev, &addrv4));
+    assert(!ts_ipv4_addr(dev, &addrv4));
 
     if (ts_peer_ipv4_addr(dev, argv[3], &addrv4) <= 0) {
         return EXIT_FAILURE;

--- a/ts_ffi/examples/tcp_echo/tcp_echo.c
+++ b/ts_ffi/examples/tcp_echo/tcp_echo.c
@@ -65,7 +65,13 @@ int main(int argc, char** argv) {
         exit(EXIT_FAILURE);
     }
 
-    const struct ts_device* dev = ts_init(
+    /*
+     * This example uses `ts_init_from_key_file`, which uses a `ts_config` set to defaults,  other
+     * than the key state loaded from the given file.
+     *
+     * See the UDP example for use of `ts_init` with a `ts_config` and explicit key file loading.
+     */
+    const struct ts_device* dev = ts_init_from_key_file(
         argv[1],
         argv[2]
     );

--- a/ts_ffi/examples/udp_ping/udp_ping.c
+++ b/ts_ffi/examples/udp_ping/udp_ping.c
@@ -26,8 +26,22 @@ int main(int argc, char** argv) {
         exit(EXIT_FAILURE);
     }
 
+    /*
+     * This example explicitly loads the key state from a file using `ts_load_key_file` for
+     * illustrative purposes. This enables explicit setup for the `ts_config`, though all we do
+     * here with it is assign the key state.
+     *
+     * See the TCP example for a usage of `ts_init_from_key_file`, which collapses this init to a
+     * single line, using a default config and key state from the selected file.
+     */
+    struct ts_node_key_state key_state = {0};
+    assert(ts_load_key_file(argv[1], false, &key_state) >= 0);
+
+    struct ts_config config = {0};
+    config.key_state = &key_state;
+
     const struct ts_device* dev = ts_init(
-        argv[1],
+        &config,
         argv[2]
     );
     assert(dev);

--- a/ts_ffi/src/config.rs
+++ b/ts_ffi/src/config.rs
@@ -1,0 +1,197 @@
+use std::ffi::c_char;
+
+use crate::{keys::node_key_state, util};
+
+/// Tailscale configuration.
+///
+/// This struct is safe to zero-initialize, in which case default values will be used.
+/// You _must_ actually zero-initialize this struct in this case (`struct ts_config config = {0};`);
+/// an uninitialized declaration (`struct ts_config config;`) is insufficient and may invoke UB.
+///
+/// On the Rust side, the [`Default`] instance for this type is equivalent to a C-side zero-
+/// init.
+#[derive(Default)]
+#[repr(C)]
+pub struct config<'a> {
+    /// The control server URL to use.
+    ///
+    /// May be `NULL` to use the default value.
+    pub control_server_url: *const c_char,
+
+    /// The hostname to use. This will be the device's MagicDNS name, if it's available.
+    ///
+    /// May be `NULL` to use the default (the OS-reported hostname).
+    pub hostname: *const c_char,
+
+    /// An array of tags to be requested.
+    ///
+    /// Use `NULL` as the sentinel for the end of the array.
+    ///
+    /// May be `NULL` to indicate that no tags are requested.
+    pub tags: *const *const c_char,
+
+    /// The client name to report to the control server. This is reported as `Hostinfo.App`.
+    ///
+    /// May be `NULL` to use the default (`ts_ffi`).
+    pub client_name: *const c_char,
+
+    /// The key state to use.
+    ///
+    /// If `NULL`, ephemeral key state is generated.
+    pub key_state: Option<&'a mut node_key_state>,
+}
+
+impl config<'_> {
+    /// Convert this config into a [`tailscale::Config`].
+    ///
+    /// # Safety
+    ///
+    /// All string fields (including elements of `tags`, if any) must be either null or
+    /// NUL-terminated and valid for reads up to the nul-terminator.
+    ///
+    /// The `tags` field must be either null or a pointer to a contiguous array of valid,
+    /// aligned, NUL-terminated strings, fully contained in a single
+    /// [allocation](https://doc.rust-lang.org/std/ptr/index.html#allocation). A null
+    /// pointer must be used to terminate the array.
+    pub unsafe fn to_ts_config(&self) -> tailscale::Config {
+        let mut cfg = tailscale::Config::default();
+
+        // SAFETY: validity ensured by preconditions
+        let ctrl_url = unsafe { util::str(self.control_server_url) }.and_then(|u| u.parse().ok());
+
+        if let Some(u) = ctrl_url {
+            cfg.control_server_url = u;
+        }
+
+        // SAFETY: validity ensured by preconditions
+        if let Some(hostname) = unsafe { util::str(self.hostname) } {
+            cfg.requested_hostname = Some(hostname.to_string());
+        }
+
+        // SAFETY: validity ensured by preconditions
+        cfg.client_name = Some(
+            unsafe { util::str(self.client_name) }
+                .unwrap_or("ts_ffi")
+                .to_owned(),
+        );
+
+        if let Some(key_state) = &self.key_state {
+            cfg.key_state = (&**key_state).into();
+        }
+
+        // SAFETY: by preconditions and function termination on null tag
+        cfg.requested_tags = unsafe {
+            load_sentinel_array(self.tags, |&tag| {
+                if tag.is_null() {
+                    return None;
+                };
+
+                match util::str(tag) {
+                    Some(tag_str) => Some(Some(tag_str.to_owned())),
+                    None => {
+                        tracing::error!("skipping invalid requested tag");
+                        Some(None)
+                    }
+                }
+            })
+        }
+        .collect();
+
+        cfg
+    }
+}
+
+/// Iterate a raw pointer `ary` as a C-style sentinel-terminated array.
+///
+/// Starting at `ary`, increment `ary` (strides of `size_of::<T>()`) until the pointee does
+/// not satisfy `elem_txfm`, a `filter_map`-style simultaneous predicate-and-transform.
+///
+/// # Safety
+///
+/// `ary` must be either null or follow the rules for [`std::slice::from_raw_parts`], except
+/// that it needn't have a definite length known before calling this function. The extents
+/// of `ary` are defined by `elem_txfm`: the first element that returns `None` under
+/// `elem_txfm` is the final (sentinel) element of the array (excluded here from the
+/// returned iterated elements, but part of the memory extents).
+///
+/// The extents of `ary` must be contiguous and aligned, and its elements must be valid for
+/// reads and properly-initialized. They must obey rust mutability rules -- no
+/// mutations to the extents of `ary` are permitted for the lifetime of the returned
+/// iterator.
+///
+/// Note that this definition implies a strong safety condition on the definition
+/// of `elem_txfm`: it defines what memory is accessed by this function and must not permit
+/// iteration beyond valid bounds.
+unsafe fn load_sentinel_array<'t, T, It>(
+    mut ary: *const T,
+    elem_txfm: impl Fn(&T) -> Option<It> + 't,
+) -> impl Iterator<Item = It::Item>
+where
+    T: 't,
+    It: IntoIterator,
+{
+    std::iter::from_fn(move || {
+        if ary.is_null() {
+            return None;
+        }
+
+        // SAFETY: ref-validity ensured by preconditions, non-nullity by above check
+        let it = match elem_txfm(unsafe { ary.as_ref().unwrap() }) {
+            Some(u) => u,
+            None => {
+                return None;
+            }
+        };
+
+        // SAFETY: ensured by preconditions
+        ary = unsafe { ary.offset(1) };
+
+        Some(it)
+    })
+    .flatten()
+}
+
+#[cfg(test)]
+mod test {
+    use std::{ffi::CString, ptr::null};
+
+    use super::*;
+
+    #[test]
+    fn sentinel_array() {
+        let mut v = unsafe { load_sentinel_array::<u8, _>(null(), |_| Option::<[u8; 1]>::None) };
+        assert!(v.next().is_none());
+
+        let ary = [0u8, 1, 2, 3, 4, 5, 6, 128, 32];
+
+        let mut v =
+            unsafe { load_sentinel_array(&ary as *const u8, |_elt| Option::<Option<u8>>::None) };
+        assert!(v.next().is_none());
+
+        let v = unsafe {
+            load_sentinel_array(
+                &ary as *const u8,
+                |&elt| {
+                    if elt < 10 { Some([elt]) } else { None }
+                },
+            )
+        }
+        .collect::<Vec<_>>();
+        assert!(!v.is_empty());
+        assert_eq!(v, ary[..=6].to_vec());
+    }
+
+    #[test]
+    fn tags() {
+        let tag_foo = CString::new("foo").unwrap();
+        let tag_bar = CString::new("bar").unwrap();
+
+        let config = config {
+            tags: &[tag_foo.as_ptr(), tag_bar.as_ptr(), null()] as *const *const c_char,
+            ..Default::default()
+        };
+
+        let cfg = unsafe { config.to_ts_config() };
+        assert_eq!(cfg.requested_tags, vec!["foo", "bar"]);
+    }
+}

--- a/ts_ffi/src/keys.rs
+++ b/ts_ffi/src/keys.rs
@@ -1,0 +1,152 @@
+use std::{
+    ffi,
+    ffi::{CStr, c_char},
+};
+
+use crate::TOKIO_RUNTIME;
+
+/// A Tailscale cryptographic key.
+#[derive(Debug, Default)]
+#[repr(transparent)]
+pub struct key(pub [u8; 32]);
+
+macro_rules! impl_to_from {
+    ($key:ty, $($keys:ty),+) => {
+        impl_to_from!($key);
+        impl_to_from!($($keys),+);
+    };
+
+    ($key:ty$(,)?) => {
+        impl From<key> for $key {
+            fn from(value: key) -> Self {
+                value.0.into()
+            }
+        }
+
+        impl From<&key> for $key {
+            fn from(value: &key) -> Self {
+                value.0.into()
+            }
+        }
+
+        impl From<$key> for key {
+            fn from(value: $key) -> Self {
+                key(conv::<[u8; 32]>(value))
+            }
+        }
+        impl From<&$key> for key {
+            fn from(value: &$key) -> Self {
+                key(conv::<[u8; 32]>(*value))
+            }
+        }
+    };
+}
+
+impl_to_from!(
+    ts_keys::NodePublicKey,
+    ts_keys::NodePrivateKey,
+    ts_keys::DiscoPublicKey,
+    ts_keys::DiscoPrivateKey,
+    ts_keys::MachinePrivateKey,
+    ts_keys::MachinePublicKey,
+    ts_keys::NetworkLockPrivateKey,
+    ts_keys::NetworkLockPublicKey
+);
+
+/// Tailscale key state for running a device.
+#[derive(Debug, Default)]
+#[repr(C)]
+pub struct node_key_state {
+    /// Private key for the node (device) identity.
+    pub node_private_key: key,
+    /// Private key for the machine.
+    pub machine_private_key: key,
+    /// Private key for tailnet lock.
+    pub network_lock_private_key: key,
+    /// Private key for Tailscale discovery protocol (disco).
+    pub disco_private_key: key,
+}
+
+fn conv<T>(u: impl Into<T>) -> T {
+    u.into()
+}
+
+impl From<node_key_state> for ts_keys::NodeState {
+    fn from(value: node_key_state) -> Self {
+        (&value).into()
+    }
+}
+
+impl From<&node_key_state> for ts_keys::NodeState {
+    fn from(value: &node_key_state) -> Self {
+        ts_keys::NodeState {
+            disco_keys: conv::<ts_keys::DiscoPrivateKey>(&value.disco_private_key).into(),
+            machine_keys: conv::<ts_keys::MachinePrivateKey>(&value.machine_private_key).into(),
+            network_lock_keys: conv::<ts_keys::NetworkLockPrivateKey>(
+                &value.network_lock_private_key,
+            )
+            .into(),
+            node_keys: conv::<ts_keys::NodePrivateKey>(&value.node_private_key).into(),
+        }
+    }
+}
+
+impl From<ts_keys::NodeState> for node_key_state {
+    fn from(value: ts_keys::NodeState) -> Self {
+        Self {
+            machine_private_key: value.machine_keys.private.into(),
+            network_lock_private_key: value.network_lock_keys.private.into(),
+            disco_private_key: value.disco_keys.private.into(),
+            node_private_key: value.node_keys.private.into(),
+        }
+    }
+}
+
+/// Load the key state from the given file path.
+///
+/// The second parameter indicates whether to overwrite the file with a new key state if the
+/// contents couldn't be read.
+///
+/// Returns a negative number on error.
+///
+/// # Safety
+///
+/// `path` must be safe to convert to a [`CStr`], i.e. it must be NUL-terminated and valid for read
+/// up to the NUL-terminator.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ts_load_key_file(
+    path: *const c_char,
+    overwrite_if_invalid: bool,
+    key_state: &mut node_key_state,
+) -> ffi::c_int {
+    let s = unsafe { CStr::from_ptr(path) };
+    let s = match s.to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(error = %e, "converting path to str");
+            return -1;
+        }
+    };
+
+    let mode = if overwrite_if_invalid {
+        tailscale::config::BadFormatBehavior::Overwrite
+    } else {
+        tailscale::config::BadFormatBehavior::Error
+    };
+
+    let _span = tracing::trace_span!("ts_load_key_file", ?mode, path = %s).entered();
+
+    match TOKIO_RUNTIME.block_on(tailscale::config::load_key_file(s, mode)) {
+        Ok(state) => {
+            *key_state = state.into();
+            tracing::info!(?key_state, "loaded key state");
+
+            0
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "loading key file");
+
+            -1
+        }
+    }
+}

--- a/ts_ffi/src/lib.rs
+++ b/ts_ffi/src/lib.rs
@@ -22,9 +22,12 @@ use std::{
     sync::{LazyLock, Once},
 };
 
+mod config;
+mod keys;
 mod net_types;
 mod tcp;
 mod udp;
+mod util;
 
 pub use net_types::{
     AF_INET, AF_INET6, in_addr_t, in6_addr_t, sa_family_t, sockaddr, sockaddr_data, sockaddr_in,
@@ -47,18 +50,27 @@ static TOKIO_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
     rt
 });
 
-type Result<T> = std::result::Result<T, Box<dyn core::error::Error + Send + Sync + 'static>>;
-
 /// A Tailscale device, also variously called a "node" or "peer".
 ///
 /// A device is the unit of identity in a tailnet; it has a tailnet IP and can send and
 /// receive IP datagrams to other peers.
 pub struct device(tailscale::Device);
 
+static TRACING_ONCE: Once = Once::new();
+
+/// Initialize the Rust tailscale tracing subsystem.
+///
+/// This is automatically called during `ts_init`, but you may want to call this first to log any
+/// errors if initialization needs to be done before `ts_init`.
+#[unsafe(no_mangle)]
+pub extern "C" fn ts_init_tracing() {
+    TRACING_ONCE.call_once(ts_cli_util::init_tracing);
+}
+
 /// Initialize a new Tailscale device.
 ///
-/// `config_path` is the path to a config file on your system. It will be created if it doesn't
-/// exist.
+/// `config` is the configuration with which to initialize the device. You may pass `NULL`, and a
+/// default ephemeral configuration will be used.
 ///
 /// `auth_token` is an optional auth token (you may pass `NULL`) that is used to authenticate the
 /// device if required. If you pass `NULL`, the credentials in `config_path` must already be
@@ -66,49 +78,68 @@ pub struct device(tailscale::Device);
 ///
 /// # Safety
 ///
-/// `config_path` and `auth_token` must be able to be read according to [`CStr`] rules, i.e.
-/// they must be NUL-terminated and valid for reading up to and including the NUL.
+/// `auth_token`  must be able to be read according to [`CStr`][ffi::CStr] rules, i.e.
+/// it must be NUL-terminated and valid for reading up to and including the NUL.
+/// The string fields of `config` may be `NULL`, but if they are not, they must
+/// obey the same invariants.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn ts_init(
-    config_path: *const c_char,
+    config: Option<&config::config>,
     auth_token: *const c_char,
 ) -> Option<Box<device>> {
-    static TRACING_ONCE: Once = Once::new();
-    TRACING_ONCE.call_once(ts_cli_util::init_tracing);
+    ts_init_tracing();
 
-    async fn _ts_init(config_path: &CStr, auth_token: Option<&CStr>) -> Result<device> {
-        let config_path = config_path.to_str()?.to_string();
-        tracing::info!(config_path);
+    let config = match config {
+        Some(cfg) => unsafe { cfg.to_ts_config() },
+        None => Default::default(),
+    };
 
-        let auth_token = auth_token
-            .and_then(|x| x.to_str().ok())
-            .map(ToOwned::to_owned);
+    let auth_token = if auth_token.is_null() {
+        None
+    } else {
+        unsafe { util::str(auth_token).map(ToOwned::to_owned) }
+    };
 
-        let dev = tailscale::Device::new(
-            &tailscale::Config::default_with_key_file(&config_path).await?,
-            auth_token,
-        )
-        .await?;
+    match TOKIO_RUNTIME.block_on(tailscale::Device::new(&config, auth_token)) {
+        Ok(dev) => Some(Box::new(device(dev))),
+        Err(e) => {
+            tracing::error!(err = %e, "ts_init failed");
+            None
+        }
+    }
+}
 
-        Result::<_>::Ok(device(dev))
+/// Initialize a new Tailscale device with a default configuration using the given key file for the
+/// key state. The file is created with new keys if it doesn't exist.
+///
+/// `auth_token` is an optional auth token (you may pass `NULL`) that is used to authenticate the
+/// device if required. If you pass `NULL`, the credentials in `key_file` must already be
+/// authorized to make a successful connection.
+///
+/// # Safety
+///
+/// `auth_token` and `key_file` must be able to be read according to [`CStr`][ffi::CStr] rules, i.e.
+/// they must be NUL-terminated and valid for reading up to and including the NUL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ts_init_from_key_file(
+    key_file: *const c_char,
+    auth_token: *const c_char,
+) -> Option<Box<device>> {
+    let mut state = keys::node_key_state::default();
+
+    // SAFETY: CStr invariants maintained by function precondition
+    if unsafe { keys::ts_load_key_file(key_file, false, &mut state) } < 0 {
+        return None;
     }
 
-    // SAFETY: ensured by function precondition
-    unsafe {
-        TOKIO_RUNTIME.block_on(_ts_init(
-            CStr::from_ptr(config_path),
-            if auth_token.is_null() {
-                None
-            } else {
-                Some(CStr::from_ptr(auth_token))
-            },
-        ))
-    }
-    .inspect_err(|e| {
-        tracing::error!(err = %e, "ts_init failed");
-    })
-    .ok()
-    .map(Box::new)
+    let config = config::config {
+        key_state: Some(&mut state),
+        ..Default::default()
+    };
+
+    // SAFETY: `auth_token` meets the CStr invariants by this function precondition. `config` is
+    // safely default-initialized, except for key state, which has no safety requirements.
+    unsafe { ts_init(Some(&config), auth_token) }
 }
 
 /// Deinitialize and shut down a Tailscale device.

--- a/ts_ffi/src/util.rs
+++ b/ts_ffi/src/util.rs
@@ -1,0 +1,29 @@
+use std::ffi::{CStr, c_char};
+
+/// Convert `c` to a `&CStr`
+///
+/// Returns `None` if `c` is null.
+///
+/// # Safety
+///
+/// `c` must either null or NUL-terminated and valid for reads up to the NUL-terminator.
+pub unsafe fn cstr<'a>(c: *const c_char) -> Option<&'a CStr> {
+    if !c.is_null() {
+        // SAFETY: ensured by function safety precondition.
+        Some(unsafe { CStr::from_ptr(c) })
+    } else {
+        None
+    }
+}
+
+/// Convert `c` to a `&str`.
+///
+/// Returns `None` if c is null or not valid UTF-8.
+///
+/// # Safety
+///
+/// `c` must either null or NUL-terminated and valid for reads up to the NUL-terminator.
+pub unsafe fn str<'a>(c: *const c_char) -> Option<&'a str> {
+    // SAFETY: ensured by function safety precondition.
+    unsafe { cstr(c) }.and_then(|cstr| cstr.to_str().ok())
+}


### PR DESCRIPTION
Add zero-initializable `ts_config` struct mirroring `tailscale::Config`, but in C style. Change `ts_init` to take this new type, add `ts_init_from_key_file` with the old behavior.

Add C versions of the key types.

Alternative to the approach in #94 that doesn't require a million params :)