### PR TITLE
tailscale: support loading config from env

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,7 @@ impl From<&Config> for ts_control::Config {
             client_name: value.client_name.clone(),
             hostname: value.requested_hostname.clone(),
             server_url: value.control_server_url.clone(),
+            tags: value.requested_tags.clone(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,10 @@ use std::path::Path;
 
 use crate::keys::NodeState;
 
+const CONTROL_URL_VAR: &str = "TS_CONTROL_URL";
+const HOSTNAME_VAR: &str = "TS_HOSTNAME";
+const AUTHKEY_VAR: &str = "TS_AUTH_KEY";
+
 /// Config for connecting to Tailscale.
 pub struct Config {
     /// The path of the file used to store cryptographic keys.
@@ -44,6 +48,37 @@ impl Config {
             ..Default::default()
         })
     }
+
+    /// Construct a default config, setting certain fields from environment variables.
+    ///
+    /// The fields are only set if the corresponding environment variable is present, using
+    /// the default value otherwise.
+    ///
+    /// Loads:
+    ///
+    /// - `control_server_url` from `TS_CONTROL_URL`
+    /// - `requested_hostname` from `TS_HOSTNAME`
+    pub fn default_from_env() -> Config {
+        let mut config = Config::default();
+
+        if let Ok(u) = std::env::var(CONTROL_URL_VAR) {
+            match u.parse() {
+                Ok(u) => config.control_server_url = u,
+                Err(e) => {
+                    tracing::error!(error = %e, "parsing {CONTROL_URL_VAR} (fall back to default value)");
+                }
+            }
+        };
+
+        config.requested_hostname = std::env::var(HOSTNAME_VAR).ok();
+
+        config
+    }
+}
+
+/// Load an auth key from the `TS_AUTH_KEY` environment variable.
+pub fn auth_key_from_env() -> Option<String> {
+    std::env::var(AUTHKEY_VAR).ok()
 }
 
 /// Load key state from a path on the filesystem, or create a file with a new key state if

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,7 @@ use std::{
     time::Duration,
 };
 
+#[doc(inline)]
 pub use config::Config;
 #[doc(inline)]
 pub use error::Error;
@@ -286,7 +287,7 @@ fn check_magic_env() -> Result<(), Error> {
         let warning = format!(
             "
 check failed: set {ENV_MAGIC_VAR}={ENV_MAGIC_VALUE} to acknowledge that tailscale-rs is early-days
-experimental software containing bugs, unvalidated cryptography, and no stability or compatibility 
+experimental software containing bugs, unvalidated cryptography, and no stability or compatibility
 guarantees.
             "
         );

--- a/ts_control/src/config.rs
+++ b/ts_control/src/config.rs
@@ -20,6 +20,9 @@ pub struct Config {
     ///
     /// This will be reported to the control server in the `HostInfo.App` field.
     pub client_name: Option<String>,
+
+    /// Tags to request from the control server.
+    pub tags: Vec<String>,
 }
 
 impl Config {
@@ -53,6 +56,7 @@ impl Default for Config {
             server_url: DEFAULT_CONTROL_SERVER.clone(),
             hostname: None,
             client_name: None,
+            tags: Default::default(),
         }
     }
 }


### PR DESCRIPTION
Support loading `tailscale::Config` and auth key from Go-compatible env vars.

Alternate to #97.
