### PR TITLE
ts_elixir: fix mismatched names and format

### DIFF
--- a/ts_elixir/lib/tailscale.ex
+++ b/ts_elixir/lib/tailscale.ex
@@ -2,14 +2,14 @@ defmodule Tailscale do
   @moduledoc """
   Elixir bindings for the Tailscale Rust client. 
   """
-  
+
   @typedoc """
   An IPv4 address.
     
   `tailscale` is capable of interpreting either the `inet` format or a `String`.
   """
   @type ip4_addr() :: :inet.ip4_address() | String.t()
-  
+
   @typedoc """
   An IPv6 address.
     
@@ -23,26 +23,26 @@ defmodule Tailscale do
   `tailscale` is capable of interpreting either the `inet` format or a `String`.
   """
   @type ip_addr() :: ip4_addr() | ip6_addr()
-  
+
   @typedoc """
   Handle to a tailscale "device", i.e. a unique tailnet-connected identity with a network address.
   See the note in `connect/2` about nomenclature for more details.
   """
   @opaque t() :: Tailscale.Native.device()
-  
+
   @spec connect(String.t(), String.t() | nil) :: {:ok, t()}
   @doc """
   Open a connection to tailscale, creating a device connected to a tailnet. 
-  
+
   ## Parameters
     
   - `config_path`: the path of the config/state file to load. This contains the node's cryptographic 
     keys and therefore defines the identity of this device. It will be created if it doesn't exist.
   - `auth_key`: the auth key to be used to authorize this device. You only need to supply this if
     the device state in `config_path` has not been authorized.
-  
+
   ## Nomenclature (devices, peers, nodes, etc.)
-  
+
   In our parlance, anything that shows up on console.tailscale.com 
   and gets a tailnet IP is known canonically as a "device", though these are also variously been 
   referred to as "nodes" or "peers". Conventionally, each of these would be a device running 
@@ -63,13 +63,13 @@ defmodule Tailscale do
   Blocks until the address is available.
   """
   def ipv4_addr(dev), do: Tailscale.Native.ipv4_addr(dev)
-  
+
   @spec ipv6_addr(t()) :: {:ok, :inet.ip6_address()} | {:error, any()}
   @doc """
   Get the current IPv6 address of this Tailscale node.
     
   Blocks until the address is available.
-  
+
   Note that this address is in `:inet` format (16-bit segments), which may be difficult to read. 
   See `:inet.ntoa` to format to a string.
   """

--- a/ts_elixir/lib/tailscale/native.ex
+++ b/ts_elixir/lib/tailscale/native.ex
@@ -1,11 +1,11 @@
 defmodule Tailscale.Native do
   use Rustler,
-      otp_app: :tailscale,
-      crate: :ts_elixir
-      
+    otp_app: :tailscale,
+    crate: :ts_elixir
+
   @moduledoc """
   The Elixir side of the Rustler bindings to `tailscale-rs`.
-  
+
   The rest of this package adapts these bindings to a more Elixir-friendly module layout -- this is
   where Rustler actually connects the Rust nifs to their Elixir names, so it's a flat module.
   """
@@ -14,12 +14,12 @@ defmodule Tailscale.Native do
   A handle to a unique tailscale "identity" on a given tailnet.
   """
   @opaque device :: reference()
-  
+
   @typedoc """
   A handle to a UDP socket.
   """
   @opaque udp_socket :: reference()
-  
+
   @typedoc """
   A handle to a TCP listener.
   """
@@ -30,19 +30,19 @@ defmodule Tailscale.Native do
   @opaque tcp_stream :: reference()
 
   defp err, do: :erlang.nif_error(:nif_not_loaded)
-  
+
   @doc """
   Open a new tailnet connection.
-  
+
   ## Parameters
-  
+
   - `config_path`: the path to the state file to load (created if it doesn't exist)
   - `auth_key`: the auth key to use to authorize this device (may be `nil` if the device is already
   authorized)
   """
   @spec connect(String.t(), String.t() | nil) :: {:ok, device()} | {:error, any()}
-  def connect(_config_path, _auth_key), do: err() 
-  
+  def connect(_config_path, _auth_key), do: err()
+
   @doc """
   Bind a new udp socket.
 
@@ -51,7 +51,8 @@ defmodule Tailscale.Native do
   - `dev`: the `m:Tailscale` device on which to create the socket.
   - `port`: the port to which the socket should bind.
   """
-  @spec udp_bind(device(), Tailscale.ip() | :ip4 | :ip6, :inet.port_number()) :: {:ok, udp_socket()} | {:error, any()}
+  @spec udp_bind(device(), Tailscale.ip_addr() | :ip4 | :ip6, :inet.port_number()) ::
+          {:ok, udp_socket()} | {:error, any()}
   def udp_bind(_dev, _addr, _port), do: err()
 
   @doc """
@@ -60,17 +61,19 @@ defmodule Tailscale.Native do
   ## Parameters
 
   - `sock`: the socket to send the packet from.
-  - `ip`: the IP address to send the packet to. Currently this must be a string.
+  - `ip`: the IP address to send the packet to.
   - `port`: the port to send the packet to.
   - `msg`: the packet to send.
   """
-  @spec udp_send(udp_socket(), Tailscale.ip(), :inet.port_number(), binary()) :: :ok | {:error, any()}
+  @spec udp_send(udp_socket(), Tailscale.ip_addr(), :inet.port_number(), binary()) ::
+          :ok | {:error, any()}
   def udp_send(_sock, _ip, _port, _msg), do: err()
 
   @doc """
   Receive an incoming UDP packet on the given socket.
   """
-  @spec udp_recv(udp_socket()) :: {:ok, :inet.ip_address(), :inet.port_number(), binary()} | {:error, any()}
+  @spec udp_recv(udp_socket()) ::
+          {:ok, :inet.ip_address(), :inet.port_number(), binary()} | {:error, any()}
   def udp_recv(_sock), do: err()
 
   @doc """
@@ -85,11 +88,12 @@ defmodule Tailscale.Native do
   """
   @spec start_tracing() :: :ok
   def start_tracing(), do: err()
-  
+
   @doc """
   Start a TCP listener on the given device, address, and port.
   """
-  @spec tcp_listen(device(), Tailscale.ip() | :ip4 | :ip6, :inet.port_number()) :: {:ok, tcp_listener()} | {:error, any()}
+  @spec tcp_listen(device(), Tailscale.ip_addr() | :ip4 | :ip6, :inet.port_number()) ::
+          {:ok, tcp_listener()} | {:error, any()}
   def tcp_listen(_dev, _addr, _port), do: err()
 
   @doc """
@@ -101,24 +105,25 @@ defmodule Tailscale.Native do
   @doc """
   Connect to the given TCP endpoint using the given device.
   """
-  @spec tcp_connect(device(), Tailscale.ip(), :inet.port_number()) :: {:ok, tcp_stream()} | {:error, any()}
+  @spec tcp_connect(device(), Tailscale.ip_addr(), :inet.port_number()) ::
+          {:ok, tcp_stream()} | {:error, any()}
   def tcp_connect(_dev, _addr, _port), do: err()
-  
+
   @doc """
   Accept an incoming TCP connection. Blocks until one is available.
   """
   @spec tcp_accept(tcp_listener()) :: {:ok, tcp_stream()} | {:error, any()}
   def tcp_accept(_listener), do: err()
-  
+
   @doc """
   Send a message to the remote peer on the given tcp socket, blocking until at least one byte can be
   sent.
-  
+
   Returns the number of bytes actually written to the remote.
   """
   @spec tcp_send(tcp_stream(), binary()) :: {:ok, integer()} | {:error, any()}
   def tcp_send(_stream, _msg), do: err()
-  
+
   @doc """
   Receive incoming data from the tcp socket, blocking until at least one byte can be received.
   """
@@ -139,15 +144,15 @@ defmodule Tailscale.Native do
 
   @doc """
   Retrieve the IPv4 address for the given tailscale device.
-  
+
   Blocks until the device is connected and gets its address from control.
   """
   @spec ipv4_addr(device()) :: {:ok, :inet.ip4_address()} | {:error, any()}
   def ipv4_addr(_dev), do: err()
-  
+
   @doc """
   Retrieve the IPv6 address for the given tailscale device.
-  
+
   Blocks until the device is connected and gets its address from control.
   """
   @spec ipv6_addr(device()) :: {:ok, :inet.ip6_address()} | {:error, any()}

--- a/ts_elixir/lib/tailscale/node_info.ex
+++ b/ts_elixir/lib/tailscale/node_info.ex
@@ -9,7 +9,7 @@ defmodule Tailscale.NodeInfo do
 
   defstruct [
     :id,
-    :name,
+    :hostname,
     :stable_id,
     :derp_region,
     :node_key,
@@ -17,6 +17,7 @@ defmodule Tailscale.NodeInfo do
     :machine_key,
     underlay_addresses: [],
     tags: [],
-    tailnet_addresses: [],
+    tailnet: nil,
+    tailnet_addresses: []
   ]
 end

--- a/ts_elixir/lib/tailscale/tcp.ex
+++ b/ts_elixir/lib/tailscale/tcp.ex
@@ -1,22 +1,23 @@
 defmodule Tailscale.Tcp do
   @moduledoc """
   Functionality to create tailscale TCP sockets.
-  
-  See `Tailscale.Tcp.Listener` and `Tailscale.Tcp.Stream` for listen and established sockets, 
+
+  See `Tailscale.Tcp.Listener` and `Tailscale.Tcp.Stream` for listen and established sockets,
   respectively.
   """
-  
+
   @doc """
   Create a TCP listener on the specified port.
-  
+
   ## Parameters
-    
+
   - `dev`: the tailscale device.
   - `addr`: the address to listen on. You can either pass an address or `:ip4`/`:ip6` to bind to the
             tailscale device's respective tailnet address.
   - `port`: the port to listen on.
   """
-  @spec listen(Tailscale.t(), Tailscale.ip() | :ip4 | :ip6, :inet.port_number()) :: {:ok, Tailscale.Tcp.Listener.t()} | {:error, any()}
+  @spec listen(Tailscale.t(), Tailscale.ip_addr() | :ip4 | :ip6, :inet.port_number()) ::
+          {:ok, Tailscale.Tcp.Listener.t()} | {:error, any()}
   def listen(dev, addr, port) do
     Tailscale.Native.tcp_listen(dev, addr, port)
   end
@@ -24,7 +25,8 @@ defmodule Tailscale.Tcp do
   @doc """
   Open a TCP connection to the specified address and port.
   """
-  @spec connect(Tailscale.t(), Tailscale.ip(), :inet.port_number()) :: {:ok, Tailscale.Tcp.Stream.t()} | {:error, any()}
+  @spec connect(Tailscale.t(), Tailscale.ip_addr(), :inet.port_number()) ::
+          {:ok, Tailscale.Tcp.Stream.t()} | {:error, any()}
   def connect(dev, addr, port) do
     Tailscale.Native.tcp_connect(dev, addr, port)
   end

--- a/ts_elixir/lib/tailscale/tcp/listener.ex
+++ b/ts_elixir/lib/tailscale/tcp/listener.ex
@@ -3,7 +3,7 @@ defmodule Tailscale.Tcp.Listener do
   A TCP listener waiting for incoming connections.
   """
   @opaque t :: Tailscale.Native.tcp_listener()
-  
+
   @spec accept(t()) :: {:ok, Tailscale.Tcp.Stream.t()} | {:error, any()}
   @doc """
   Accept an incoming connection on the socket, yielding a connected `Tailscale.Tcp.Stream`.

--- a/ts_elixir/lib/tailscale/tcp/stream.ex
+++ b/ts_elixir/lib/tailscale/tcp/stream.ex
@@ -3,31 +3,31 @@ defmodule Tailscale.Tcp.Stream do
   A handle to a TCP stream (connected socket).
   """
   @opaque t :: Tailscale.Native.tcp_stream()
-  
+
   @spec send(t(), binary()) :: {:ok, integer()} | {:error, any()}
   @doc """
   Send data over the TCP socket, blocking until at least one byte can be sent.
-  
+
   Returns the number of bytes actually sent.
   """
   def send(res, msg) do
     Tailscale.Native.tcp_send(res, msg)
   end
-  
+
   @spec send_all(t(), binary()) :: :ok | {:error, any()}
   @doc """
   Send the payload over the TCP socket, blocking until it is fully sent.
   """
   def send_all(res, msg) do
     len = byte_size(msg)
-    
+
     case Tailscale.Tcp.Stream.send(res, msg) do
       {:ok, ^len} -> :ok
       {:ok, n} -> Tailscale.Tcp.Stream.send_all(res, binary_slice(msg, n..len))
       err -> err
     end
   end
-  
+
   @spec recv(t()) :: {:ok, binary()} | {:error, any()}
   @doc """
   Receive data from the TCP socket, blocking until at least one byte can be received.

--- a/ts_elixir/lib/tailscale/udp.ex
+++ b/ts_elixir/lib/tailscale/udp.ex
@@ -2,45 +2,44 @@ defmodule Tailscale.Udp do
   @moduledoc """
   Tailscale UDP sockets.
   """
-  
+
   @typedoc """
   A handle to a tailscale UDP socket.
   """
   @opaque t() :: Tailscale.Native.udp_socket()
-  
-  @spec bind(Tailscale.t(), Tailscale.ip() | :ip4 | :ip6, :inet.port_number()) :: {:ok, t()}
+
+  @spec bind(Tailscale.t(), Tailscale.ip_addr() | :ip4 | :ip6, :inet.port_number()) :: {:ok, t()} | {:error, any()}
   @doc """
   Bind a UDP socket on the specified port.
-    
+
   ## Parameters
-  
+
   - `dev`: the tailscale device on which to bind a socket.
-  - `addr`: the address to bind to. Passing `:ip4` or `:ip6` will cause the socket to bind to the 
+  - `addr`: the address to bind to. Passing `:ip4` or `:ip6` will cause the socket to bind to the
             tailscale node's respective tailnet ip.
   - `port`: the port number to bind.
   """
   def bind(dev, addr, port) do
     Tailscale.Native.udp_bind(dev, addr, port)
   end
-  
-  @spec send(t(), Tailscale.ip(), :inet.port_number(), binary()) :: :ok | {:error, any()}
+
+  @spec send(t(), Tailscale.ip_addr(), :inet.port_number(), binary()) :: :ok | {:error, any()}
   @doc """
   Send a packet to a specified remote address.
-    
+
   ## Parameters
-  
+
   - `sock`: the socket to send on
-  - `remote`: the host to deliver the packet to. DNS is not yet supported: this must be an IP 
-     address for now. 
+  - `remote`: the host to deliver the packet to. DNS is not yet supported: this must be an IP
+     address for now.
   - `port`: the port on the remote host the packet should be delivered to.
   - `payload`: the message payload.
   """
   def send(sock, remote, port, payload) do
     Tailscale.Native.udp_send(sock, remote, port, payload)
   end
-  
-  
-  @spec recv(t()) :: {:ok, Tailscale.ip(), :inet.port_number(), binary()} | {:error, any()}
+
+  @spec recv(t()) :: {:ok, Tailscale.ip_addr(), :inet.port_number(), binary()} | {:error, any()}
   @doc """
   Receive a packet from the socket, blocking until one is ready.
   """

--- a/ts_elixir/mix.exs
+++ b/ts_elixir/mix.exs
@@ -11,13 +11,12 @@ defmodule TsElixir.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),
-
       name: "Tailscale",
       description: "tailscale client in elixir",
       source_url: @source_url,
-      homepage_url:  @source_url,
+      homepage_url: @source_url,
       docs: docs(),
-      package: package(),
+      package: package()
     ]
   end
 
@@ -33,10 +32,10 @@ defmodule TsElixir.MixProject do
 
       # dev
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
-      {:ex_doc, "~> 0.27", only: :dev, runtime: false},
+      {:ex_doc, "~> 0.27", only: :dev, runtime: false}
     ]
   end
-  
+
   defp elixirc_paths(:test), do: ["lib", "test/util"]
   defp elixirc_paths(_), do: ["lib"]
 
@@ -45,7 +44,7 @@ defmodule TsElixir.MixProject do
       files: ~w(lib .formatter.exs mix.exs README.md LICENSE),
       licenses: ["MIT"],
       links: %{
-        "GitHub": "https://github.com/tailscale/tailscale-rs"
+        "GitHub" => "https://github.com/tailscale/tailscale-rs"
       }
     ]
   end
@@ -60,9 +59,9 @@ defmodule TsElixir.MixProject do
         Tcp: [
           Tailscale.Tcp,
           Tailscale.Tcp.Listener,
-          Tailscale.Tcp.Stream,
+          Tailscale.Tcp.Stream
         ]
-      ],
+      ]
     ]
   end
 end

--- a/ts_elixir/test/basic_test.exs
+++ b/ts_elixir/test/basic_test.exs
@@ -1,6 +1,6 @@
 defmodule Tailscale.Test do
   use ExUnit.Case, async: true
-  
+
   describe "client connect" do
     setup [:check_net, :auth_key, :state_file]
 
@@ -8,35 +8,35 @@ defmodule Tailscale.Test do
       {:ok, dev} = Tailscale.connect(state_file, auth_key)
       IO.puts("connected!")
 
-      {:ok, ip} = Tailscale.ipv4(dev)
-      IO.puts("tailnet ip: #{ip |> :inet.ntoa}")
+      {:ok, ip} = Tailscale.ipv4_addr(dev)
+      IO.puts("tailnet ip: #{ip |> :inet.ntoa()}")
     end
   end
-  
+
   describe "connected client" do
     setup [:connected_client]
 
     test "ip4", %{ts: dev} do
-      {:ok, ip} = Tailscale.ipv4(dev)
+      {:ok, ip} = Tailscale.ipv4_addr(dev)
       assert :inet.is_ipv4_address(ip)
     end
 
     test "ip6", %{ts: dev} do
-      {:ok, ip} = Tailscale.ipv6(dev)
+      {:ok, ip} = Tailscale.ipv6_addr(dev)
       assert :inet.is_ipv6_address(ip)
     end
 
     test "udp bind", %{ts: dev} do
-      {:ok, ip} = Tailscale.ipv4(dev)
+      {:ok, ip} = Tailscale.ipv4_addr(dev)
       {:ok, _sock} = Tailscale.Udp.bind(dev, ip, 1234)
     end
 
     test "tcp listen", %{ts: dev} do
-      {:ok, ip} = Tailscale.ipv4(dev)
+      {:ok, ip} = Tailscale.ipv4_addr(dev)
       {:ok, _sock} = Tailscale.Tcp.listen(dev, ip, 1234)
     end
   end
-  
+
   defp check_net(ctx), do: Tailscale.Test.Helpers.check_net(ctx)
   defp auth_key(ctx), do: Tailscale.Test.Helpers.auth_key(ctx)
   defp state_file(ctx), do: Tailscale.Test.Helpers.state_file(ctx)

--- a/ts_elixir/test/util/helper.ex
+++ b/ts_elixir/test/util/helper.ex
@@ -3,7 +3,9 @@ defmodule Tailscale.Test.Helpers do
 
   def check_net(_ctx) do
     case :gen_tcp.connect(~c"controlplane.tailscale.com", 443, [:binary, active: false]) do
-      {:ok, _} -> :ok
+      {:ok, _} ->
+        :ok
+
       _ ->
         {:error, "couldn't tcp connect"}
     end
@@ -11,13 +13,14 @@ defmodule Tailscale.Test.Helpers do
 
   def auth_key(_ctx) do
     k = System.get_env(@auth_env_var)
+
     if k == nil || k == "" do
       {:error, "#{@auth_env_var} not set"}
     else
       {:ok, auth_key: k}
     end
   end
-  
+
   def state_file(_ctx) do
     state_file = "#{System.tmp_dir!()}/tsrs_ex_test/state_#{Enum.random(0..65535)}.json"
     File.rm(state_file)
@@ -28,13 +31,13 @@ defmodule Tailscale.Test.Helpers do
   end
 
   def connected_client(ctx) do
-    :ok  = check_net(ctx)
+    :ok = check_net(ctx)
     {:ok, auth_key: auth_key} = auth_key(ctx)
     {:ok, state_file: state_file} = state_file(ctx)
-    
+
     with {:ok, dev} <- Tailscale.connect(state_file, auth_key) do
       # wait for ipv4 to be available (successful control connection)
-      {:ok, _ip} = Tailscale.ipv4(dev)
+      {:ok, _ip} = Tailscale.ipv4_addr(dev)
       {:ok, ts: dev, state_file: state_file, auth_key: auth_key}
     else
       _ -> {:error, "failed to start tailscale client"}


### PR DESCRIPTION
Fixes mismatched identifiers:
  ipv4() > ipv4_addr()
  ipv6() > ipv6_addr()
  ip() > ip_addr()
  NodeInfo:host > NodeInfo:hostname
  NodeInfo:tailnet added

Fixed return type definition and type mismatch in the doc.

Additionally `mix format` whole package.

Change-Id: I9b2ac48c5fe6adf24985725386b3b6836a6a6964