### PR TITLE
ts_elixir: re-export as canonical Erlang

### DIFF
--- a/ts_elixir/lib/erlang.ex
+++ b/ts_elixir/lib/erlang.ex
@@ -1,0 +1,52 @@
+defmodule :tailscale do
+  @moduledoc """
+  Erlang-friendly re-export of `Tailscale`.
+  """
+
+  defdelegate connect(config_path), to: Tailscale
+  defdelegate connect(config_path, auth_key), to: Tailscale
+  defdelegate ipv4_addr(dev), to: Tailscale
+  defdelegate ipv6_addr(dev), to: Tailscale
+  defdelegate peer_by_name(dev, name), to: Tailscale
+end
+
+defmodule :tailscale_tcp do
+  @moduledoc """
+  Erlang-friendly re-export of `Tailscale.Tcp`.
+  """
+
+  defdelegate listen(dev, addr, port), to: Tailscale.Tcp
+  defdelegate connect(dev, addr, port), to: Tailscale.Tcp
+end
+
+defmodule :tailscale_tcp_listener do
+  @moduledoc """
+  Erlang-friendly re-export of `Tailscale.Tcp.Listener`.
+  """
+
+  defdelegate accept(listener), to: Tailscale.Tcp.Listener
+  defdelegate local_addr(listener), to: Tailscale.Tcp.Listener
+end
+
+defmodule :tailscale_tcp_stream do
+  @moduledoc """
+  Erlang-friendly re-export of `Tailscale.Tcp.Stream`.
+  """
+
+  defdelegate send(stream, msg), to: Tailscale.Tcp.Stream
+  defdelegate send_all(stream, msg), to: Tailscale.Tcp.Stream
+  defdelegate recv(stream), to: Tailscale.Tcp.Stream
+  defdelegate local_addr(stream), to: Tailscale.Tcp.Stream
+  defdelegate remote_addr(stream), to: Tailscale.Tcp.Stream
+end
+
+defmodule :tailscale_udp do
+  @moduledoc """
+  Erlang-friendly re-export of `Tailscale.Udp`.
+  """
+
+  defdelegate bind(dev, addr, port), to: Tailscale.Udp
+  defdelegate send(sock, remote, port, payload), to: Tailscale.Udp
+  defdelegate recv(sock), to: Tailscale.Udp
+  defdelegate local_addr(sock), to: Tailscale.Udp
+end


### PR DESCRIPTION
Elixir is well equipped for using Erlang modules directly, for obvious reasons the reverse is not true. Yet with minimal adaptations the bindings can be made to look native for Erlang as well.

Main friction point is the module naming. Unlike Elixir, module aliasing is not supported, and the only way to hide the awkward full atom syntax is to import individual funcs. Which goes against the Erlang convention of using fully qualified names universally. In short, Erlang users would have to deal with the likes of 'Elixir.Tailscale':connect/1 everywhere, or -import('Elixir.Tailscale', [connect/1]), which is unconventional.

This change re-exports the bindings under Erlang native module names removing the need to quote module atoms.

Change-Id: I3237d7b62541731c8dccca115c4b551d6a6a6964

---

~~Unsure if there is much value in the new tests, happy to clean it up.~~

Also consider that some Elixir modules choose to export under Erlang convention. It is trivial for Elixir to use those, as demonstrated in tests. That would remove the need to maintain the wrapping. OTOH I am an Erlang dev primarily, so take it with a grain of salt.