### PR TITLE
examples, ts_cli_util, ts_control: report hostname correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4144,7 +4144,6 @@ version = "0.2.0"
 dependencies = [
  "clap",
  "futures-util",
- "gethostname",
  "tailscale",
  "tracing",
  "tracing-subscriber",
@@ -4162,6 +4161,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures-util",
+ "gethostname",
  "ipnet",
  "lazy_static",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ divan = "0.1"
 flume = "0.12"
 futures = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false }
+gethostname = "1.1"
 hashbrown = "0.16"
 heapless = "0.9"
 hex = "0.4"

--- a/examples/axum/main.rs
+++ b/examples/axum/main.rs
@@ -59,6 +59,10 @@ struct Args {
     #[arg(short = 'k', long)]
     auth_key: Option<String>,
 
+    /// The hostname this node will request.
+    #[arg(short = 'H', long, default_value = "axum-example")]
+    hostname: Option<String>,
+
     /// Port to bind to.
     #[arg(short, long, default_value_t = 80)]
     port: u16,
@@ -75,12 +79,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .init();
 
     let args = Args::parse();
-
-    let dev = Device::new(
-        &Config::default_with_key_file(&args.key_file).await?,
-        args.auth_key.clone(),
-    )
-    .await?;
+    let mut config = Config::default_with_key_file(&args.key_file).await?;
+    config.requested_hostname = args.hostname;
+    let dev = Device::new(&config, args.auth_key.clone()).await?;
 
     let listener = dev
         .tcp_listen((dev.ipv4_addr().await?, args.port).into())

--- a/examples/peer_ping/main.rs
+++ b/examples/peer_ping/main.rs
@@ -19,6 +19,10 @@ struct Args {
     #[arg(short = 'k', long)]
     auth_key: Option<String>,
 
+    /// The hostname this node will request.
+    #[arg(short = 'H', long, default_value = "peer_ping_example")]
+    hostname: Option<String>,
+
     /// Peer to send messages to.
     #[clap(short, long)]
     peer: SocketAddr,
@@ -40,11 +44,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let args = Args::parse();
 
-    let dev = Device::new(
-        &Config::default_with_key_file(&args.key_file).await?,
-        args.auth_key,
-    )
-    .await?;
+    let mut config = Config::default_with_key_file(&args.key_file).await?;
+    config.requested_hostname = args.hostname;
+    let dev = Device::new(&config, args.auth_key.clone()).await?;
 
     let sock = dev.udp_bind((dev.ipv4_addr().await?, 1234).into()).await?;
     let mut ticker = tokio::time::interval(Duration::from_secs_f64(args.ping_interval_secs));

--- a/examples/tcp_echo/main.rs
+++ b/examples/tcp_echo/main.rs
@@ -3,7 +3,7 @@
 use std::{error::Error, path::PathBuf};
 
 use clap::Parser;
-use tailscale::Config;
+use tailscale::{Config, Device};
 use tokio::task::spawn;
 use tracing_subscriber::filter::LevelFilter;
 
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
     let mut config = Config::default_with_key_file(&args.key_file).await?;
     config.requested_hostname = args.hostname;
-    let dev = tailscale::Device::new(&config, args.auth_key).await?;
+    let dev = Device::new(&config, args.auth_key).await?;
 
     let sockaddr = (dev.ipv4_addr().await?, args.listen_port).into();
     let listener = dev.tcp_listen(sockaddr).await?;

--- a/examples/tcp_echo/main.rs
+++ b/examples/tcp_echo/main.rs
@@ -3,7 +3,7 @@
 use std::{error::Error, path::PathBuf};
 
 use clap::Parser;
-use tailscale::{Config, Device};
+use tailscale::Config;
 use tokio::task::spawn;
 use tracing_subscriber::filter::LevelFilter;
 
@@ -27,6 +27,10 @@ struct Args {
     #[arg(short = 'k', long)]
     auth_key: Option<String>,
 
+    /// The hostname this node will request.
+    #[arg(short = 'H', long, default_value = "tcp_echo_example")]
+    hostname: Option<String>,
+
     /// Port to listen on (on tailnet IPv4).
     #[clap(short, long, default_value_t = 1234)]
     listen_port: u16,
@@ -43,12 +47,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .init();
 
     let args = Args::parse();
-
-    let dev = Device::new(
-        &Config::default_with_key_file(&args.key_file).await?,
-        args.auth_key,
-    )
-    .await?;
+    let mut config = Config::default_with_key_file(&args.key_file).await?;
+    config.requested_hostname = args.hostname;
+    let dev = tailscale::Device::new(&config, args.auth_key).await?;
 
     let sockaddr = (dev.ipv4_addr().await?, args.listen_port).into();
     let listener = dev.tcp_listen(sockaddr).await?;

--- a/ts_cli_util/Cargo.toml
+++ b/ts_cli_util/Cargo.toml
@@ -20,7 +20,6 @@ ts_transport_derp.workspace = true
 # Unconditionally required dependencies.
 clap = { workspace = true, features = ["derive", "env"] }
 futures-util.workspace = true
-gethostname = "1.1"
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter", "tracing-log"] }
 

--- a/ts_cli_util/src/lib.rs
+++ b/ts_cli_util/src/lib.rs
@@ -29,12 +29,10 @@ pub struct CommonArgs {
     #[arg(short = 'k', long)]
     pub auth_key: Option<String>,
 
-    /// Hostname to request for this node.
-    #[arg(
-        short = 'H',
-        long,
-        default_value = "gethostname::gethostname.into_string().ok()"
-    )]
+    /// The hostname this node will request.
+    ///
+    /// If left blank, uses the hostname reported by the OS.
+    #[arg(short = 'H', long)]
     pub hostname: Option<String>,
 }
 

--- a/ts_control/Cargo.toml
+++ b/ts_control/Cargo.toml
@@ -30,6 +30,7 @@ ts_transport_derp.workspace = true
 # Unconditionally required dependencies.
 bytes.workspace = true
 chrono = { workspace = true, features = ["serde"] }
+gethostname.workspace = true
 ipnet = { workspace = true, features = ["serde"] }
 lazy_static.workspace = true
 serde.workspace = true

--- a/ts_control/src/config.rs
+++ b/ts_control/src/config.rs
@@ -51,7 +51,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             server_url: DEFAULT_CONTROL_SERVER.clone(),
-            hostname: None,
+            hostname: gethostname::gethostname().into_string().ok(),
             client_name: None,
         }
     }

--- a/ts_control/src/tokio/client.rs
+++ b/ts_control/src/tokio/client.rs
@@ -276,13 +276,18 @@ pub async fn run_once(
             command = command_rx.recv() => {
                 match command.unwrap() {
                     Command::SetDerpHomeRegion { id, latencies } => {
-                        let req = MapRequestBuilder::new(node_keys)
+                        let builder = MapRequestBuilder::new(node_keys)
                             .keep_alive(false)
                             .omit_peers(true)
                             .stream(false)
                             .preferred_derp(id)
-                            .derp_latencies(latencies.iter().map(|(k, v)| (k.as_str(), *v)))
-                            .build();
+                            .derp_latencies(latencies.iter().map(|(k, v)| (k.as_str(), *v)));
+
+                        let req = if let Some(hostname) = &config.hostname {
+                            builder.hostname(hostname)
+                        } else {
+                            builder
+                        }.build();
 
                         drop(send_map_request(req, &map_url, &h2_client).await?);
                     },

--- a/ts_control/src/tokio/client.rs
+++ b/ts_control/src/tokio/client.rs
@@ -276,18 +276,17 @@ pub async fn run_once(
             command = command_rx.recv() => {
                 match command.unwrap() {
                     Command::SetDerpHomeRegion { id, latencies } => {
-                        let builder = MapRequestBuilder::new(node_keys)
+                        let mut builder = MapRequestBuilder::new(node_keys)
                             .keep_alive(false)
                             .omit_peers(true)
                             .stream(false)
                             .preferred_derp(id)
                             .derp_latencies(latencies.iter().map(|(k, v)| (k.as_str(), *v)));
 
-                        let req = if let Some(hostname) = &config.hostname {
-                            builder.hostname(hostname)
-                        } else {
-                            builder
-                        }.build();
+                        if let Some(hostname) = &config.hostname {
+                            builder = builder.hostname(hostname);
+                        }
+                        let req = builder.build();
 
                         drop(send_map_request(req, &map_url, &h2_client).await?);
                     },


### PR DESCRIPTION
Correctly report the requested hostname to the control plane for all messages (`RegisterRequest`/`MapRequest`). If no hostname is requested, use `gethostname::gethostname()` to get the OS hostname and report that.

Updates the Rust examples to report an example-specific hostname so it's easier to find them in the admin console. I've left the C/Python examples alone, because we don't have a way to set the hostname in those bindings; they'll use the OS hostname for now.

Closes #120 .