### PR TITLE
ts_control_serde: fix PeerChange::endpoints type

### DIFF
--- a/ts_control_serde/src/netmap.rs
+++ b/ts_control_serde/src/netmap.rs
@@ -484,7 +484,7 @@ pub struct PeerChange<'a> {
     pub cap_map: Option<ts_nodecapability::Map<'a>>,
 
     /// If present, the node's UDP endpoints have changed to the new value.
-    pub endpoints: Option<Vec<Endpoint>>,
+    pub endpoints: Option<Vec<SocketAddr>>,
 
     /// If present, the node's wireguard public key has changed.
     pub key: Option<NodePublicKey>,


### PR DESCRIPTION
`PeerChange::endpoints` should be an `Option<Vec<SocketAddr>>`, not an `Option<Vec<Endpoint>>`; this was causing deserialization of `PeersChangedPatch` messages to fail and disconnects from control.

Closes #123 .