### PR TITLE
.github: reusable rust cache + toolchain workflow

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -27,7 +27,7 @@ jobs:
           - version: 1.94.0
             label: latest
 
-        target:
+        build:
           - triple: x86_64-unknown-linux-gnu
             runner: linux-x86_64-16cpu
           - triple: aarch64-unknown-linux-gnu
@@ -44,25 +44,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Cache Rust
-        id: cache-rust-c
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Setup rust
+        id: setup-rust
+        uses: ./.github/workflows/setup-rust.yml
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/.rustup/toolchains
-            target/
-          key: ${{ matrix.target.triple }}-rs-c-${{ env.cache_key }}-${{ matrix.rust_toolchain.version }}-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install Rust toolchain
-        id: install-toolchain
-        if: steps.cache-rust-c.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 4/22/2026
-        with:
-          toolchain: ${{ matrix.rust_toolchain.version }}
+          toolchain-version: ${{ matrix.rust_toolchain.version }}
+          builder-triple: ${{ matrix.build.triple }}
+          runner: ${{ matrix.build.runner }}
 
       - name: Build examples
         run: make -C examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,30 +44,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Set up cache
-        id: cache-cargo
-        uses: actions/cache@v5
+      - name: Setup rust
+        id: setup-rust
+        uses: ./.github/workflows/setup-rust.yml
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/.rustup/toolchains
-            target/
-          # the 'cargo+$SUFFIX' below is a cache-busting key -- change it if the build changes in a way that
-          # invalidates old cached state.
-          key: ${{ matrix.target.runner }}-cargo+machete-${{ matrix.toolchain.version }}-${{ matrix.target.triple }}-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install Rust toolchain
-        id: install-toolchain
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.toolchain.version }}
+          toolchain-version: ${{ matrix.toolchain.version }}
+          builder-triple: ${{ matrix.target.build-triple }}
+          runner: ${{ matrix.target.runner }}
           components: clippy
       - name: Install nightly Rust toolchain
         id: install-nightly-toolchain
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
+        if: steps.setup-rust.outputs.toolchain_cache_hit != 'true'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
@@ -75,7 +62,7 @@ jobs:
       - name: binstall
         uses: cargo-bins/cargo-binstall@main
       - name: Install cargo-deny
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
+        if: steps.setup-rust.outputs.toolchain_cache_hit != 'true'
         run: cargo binstall --no-confirm cargo-deny
       - name: Check for unused dependencies (cargo machete)
         uses: bnjbvr/cargo-machete@main

--- a/.github/workflows/setup-rust.yml
+++ b/.github/workflows/setup-rust.yml
@@ -1,0 +1,81 @@
+name: setup rust
+on:
+  workflow_call:
+    inputs:
+      toolchain-version:
+        description: Rust toolchain version to use.
+        required: true
+        type: string
+
+      builder-triple:
+        description: Target-triple of builder system.
+        required: true
+        type: string
+
+      targets:
+        description: Comma-separated list of additional targets to install.
+        default: ""
+        type: string
+
+      components:
+        description: Comma-separated list of components installed with the toolchain.
+        type: string
+        default: none
+        required: true
+
+      runner:
+        description: Runner to use.
+        type: string
+        required: true
+
+    outputs:
+      toolchain_cache_hit:
+        description: Did the toolchain cache hit?
+        value: ${{ jobs.install_and_cache.outputs.toolchain_cache_hit }}
+
+env:
+  cache_key: init
+  targets: ${{ case(inputs.targets == inputs.builder-triple, '', inputs.targets) }}
+
+jobs:
+  install_and_cache:
+    name: Install Rust toolchain and set up cache.
+    runs-on: ${{ inputs.runner }}
+
+    outputs:
+      toolchain_cache_hit: ${{ steps.cache-rust-toolchain.outputs.cache-hit }}
+
+    steps:
+      - name: Cache Rust Toolchain
+        id: cache-rust-toolchain
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ~/.rustup/toolchains
+          key: rust-toolchain-${{ env.cache_key }}-${{ inputs.builder-triple }}-targets=${{ env.targets }}-components=${{ inputs.components }}
+          restore-keys:
+            rust-toolchain-${{ env.cache_key }}-${{ inputs.builder-triple }}-targets=${{ env.targets }}-components=
+            rust-toolchain-${{ env.cache_key }}-${{ inputs.builder-triple }}-targets=
+
+      - name: Install Rust toolchain
+        id: install-toolchain
+        if: steps.cache-rust-toolchain.outputs.cache-hit != 'true' || inputs.builder-triple == 'nightly'
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 4/22/2026
+        with:
+          toolchain: ${{ inputs.toolchain-version }}
+          components: ${{ inputs.components }}
+          targets: ${{ env.targets }}
+
+      - name: Cache target/
+        id: cache-rust-target
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            target/
+          key: rust-target-${{ env.cache_key }}-${{ inputs.builder-triple }}-${{ hashFiles('**/Cargo.lock') }} }}
+          restore-keys:
+            rust-target-${{ env.cache_key }}-${{ inputs.builder-triple }}-


### PR DESCRIPTION
The same caches and toolchain install logic get used across all the different workflows -- centralize to dedup and share the cache state