### PR TITLE
.github: reusable rust setup composite action

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,72 @@
+name: setup rust
+description: Setup rust toolchain and caches.
+
+inputs:
+  toolchain-version:
+    description: Rust toolchain version to use.
+    required: true
+
+  builder-triple:
+    description: Target-triple of builder system.
+    required: true
+
+  targets:
+    description: Comma-separated list of additional targets to install.
+    default: ""
+
+  components:
+    description: Comma-separated list of components installed with the toolchain.
+    default: ""
+    required: true
+
+  cache-key:
+    description: Cache-busting key. If you set this to anything other than its default, it will bust all caches and prevent sharing caches with other workflows.
+    required: true
+    default: init
+
+outputs:
+  toolchain_cache_hit:
+    description: Did the toolchain cache hit?
+    value: ${{ steps.cache-rust-toolchain.outputs.cache-hit }}
+
+  target_cache_hit:
+    description: Did the target cache hit?
+    value: ${{ steps.cache-rust-target.outputs.cache-hit }}
+
+runs:
+  using: composite
+
+  steps:
+    - name: Cache Rust toolchain
+      id: cache-rust-toolchain
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          ~/.rustup/toolchains
+        key: rust-toolchain-${{ inputs.cache-key }}-${{ inputs.builder-triple }}-${{ inputs.toolchain-version }}-targets=${{ env.targets }}-components=${{ case(inputs.components == '', 'none', inputs.components) }}
+        restore-keys:
+          rust-toolchain-${{ inputs.cache-key }}-${{ inputs.builder-triple }}-${{ inputs.toolchain-version }}-targets=${{ env.targets }}-components=
+          rust-toolchain-${{ inputs.cache-key }}-${{ inputs.builder-triple }}-${{ inputs.toolchain-version }}-targets=
+
+    - name: Install Rust toolchain
+      id: install-toolchain
+      if: steps.cache-rust-toolchain.outputs.cache-hit != 'true' || inputs.builder-triple == 'nightly' || inputs.builder-triple == 'beta' || inputs.builder-triple == 'stable'
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 4/22/2026
+      with:
+        toolchain: ${{ inputs.toolchain-version }}
+        components: ${{ inputs.components }}
+        targets: ${{ env.targets }}
+
+    - name: Cache target/
+      id: cache-rust-target
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          target/
+        key: rust-target-${{ inputs.cache-key }}-${{ inputs.builder-triple }}-${{ inputs.toolchain-version }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys:
+          rust-target-${{ inputs.cache-key }}-${{ inputs.builder-triple }}-${{ inputs.toolchain-version }}-

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -11,15 +11,10 @@ on:
 permissions:
   contents: read
 
-env:
-  # cache-busting key -- change it if the build changes in a way that invalidates old
-  # cached state
-  cache_key: init
-
 jobs:
   build_test:
-    name: build (rust ${{ matrix.rust_toolchain.label }}, ${{ matrix.target.runner }})
-    runs-on: ${{ matrix.target.runner }}
+    name: build (rust ${{ matrix.rust_toolchain.label }}, ${{ matrix.build.runner }})
+    runs-on: ${{ matrix.build.runner }}
 
     strategy:
       matrix:
@@ -27,7 +22,7 @@ jobs:
           - version: 1.94.0
             label: latest
 
-        target:
+        build:
           - triple: x86_64-unknown-linux-gnu
             runner: linux-x86_64-16cpu
           - triple: aarch64-unknown-linux-gnu
@@ -44,25 +39,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Cache Rust
-        id: cache-rust-c
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Setup rust
+        id: setup-rust
+        uses: ./.github/actions/setup-rust
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/.rustup/toolchains
-            target/
-          key: ${{ matrix.target.triple }}-rs-c-${{ env.cache_key }}-${{ matrix.rust_toolchain.version }}-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install Rust toolchain
-        id: install-toolchain
-        if: steps.cache-rust-c.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 4/22/2026
-        with:
-          toolchain: ${{ matrix.rust_toolchain.version }}
+          toolchain-version: ${{ matrix.rust_toolchain.version }}
+          builder-triple: ${{ matrix.build.triple }}
 
       - name: Build examples
         run: make -C examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,28 +53,6 @@ jobs:
           toolchain-version: ${{ matrix.toolchain.version }}
           builder-triple: ${{ matrix.target.triple }}
           components: clippy
-      - name: Install nightly Rust toolchain
-        id: install-nightly-toolchain
-        if: steps.setup-rust.outputs.toolchain_cache_hit != 'true'
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
-          components: rustfmt
-      - name: binstall
-        uses: cargo-bins/cargo-binstall@main
-      - name: Install cargo-deny
-        if: steps.setup-rust.outputs.toolchain_cache_hit != 'true'
-        run: cargo binstall --no-confirm cargo-deny
-      - name: Check for unused dependencies (cargo machete)
-        uses: bnjbvr/cargo-machete@main
-        with:
-          args: "--with-metadata"
-      - name: Dependency audit (cargo deny)
-        run: cargo deny --workspace --all-features check all
-      - name: Check formatting (cargo fmt)
-        run: cargo +nightly fmt --check
-      - name: Custom workspace checks
-        run: cargo +${{ matrix.toolchain.version }} run -p checks
       - name: Lint lib targets (cargo clippy)
         run: |-
           cargo +${{ matrix.toolchain.version }} clippy \
@@ -99,3 +77,31 @@ jobs:
         run: cargo +${{ matrix.toolchain.version }} build --all-features --workspace --release --verbose --all-targets --target ${{ matrix.target.triple }}
       - name: Docs (cargo doc)
         run: cargo +${{ matrix.toolchain.version }} doc --workspace --no-deps --all-features --target ${{ matrix.target.triple }}
+
+  arch_independent:
+    name: arch-independent checks
+    runs-on: linux-x86_64-16cpu
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup rust
+        id: setup-rust
+        uses: ./.github/actions/setup-rust
+        with:
+          toolchain-version: nightly
+          builder-triple: x86_64-unknown-linux-gnu
+          components: rustfmt
+      - name: binstall
+        uses: cargo-bins/cargo-binstall@main
+      - name: Install cargo-deny
+        run: command -v cargo-deny || cargo binstall --no-confirm cargo-deny
+      - name: Check for unused dependencies (cargo machete)
+        uses: bnjbvr/cargo-machete@main
+        with:
+          args: "--with-metadata"
+      - name: Dependency audit (cargo deny)
+        run: cargo deny --workspace --all-features check all
+      - name: Check formatting (cargo fmt)
+        run: cargo +nightly fmt --check
+      - name: Custom workspace checks
+        run: cargo run -p checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,30 +46,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Set up cache
-        id: cache-cargo
-        uses: actions/cache@v5
+      - name: Setup rust
+        id: setup-rust
+        uses: ./.github/actions/setup-rust
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/.rustup/toolchains
-            target/
-          # the 'cargo+$SUFFIX' below is a cache-busting key -- change it if the build changes in a way that
-          # invalidates old cached state.
-          key: ${{ matrix.target.runner }}-cargo+machete-${{ matrix.toolchain.version }}-${{ matrix.target.triple }}-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install Rust toolchain
-        id: install-toolchain
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.toolchain.version }}
+          toolchain-version: ${{ matrix.toolchain.version }}
+          builder-triple: ${{ matrix.target.triple }}
           components: clippy
       - name: Install nightly Rust toolchain
         id: install-nightly-toolchain
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
+        if: steps.setup-rust.outputs.toolchain_cache_hit != 'true'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
@@ -77,7 +63,7 @@ jobs:
       - name: binstall
         uses: cargo-bins/cargo-binstall@main
       - name: Install cargo-deny
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
+        if: steps.setup-rust.outputs.toolchain_cache_hit != 'true'
         run: cargo binstall --no-confirm cargo-deny
       - name: Check for unused dependencies (cargo machete)
         uses: bnjbvr/cargo-machete@main

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -70,19 +70,6 @@ jobs:
             ts_elixir/deps/
           key: ${{ runner.os }}-mix-${{ env.cache_key }}-elixir-${{ matrix.elixir.version }}-otp-${{ matrix.otp.version }}-${{ hashFiles('**/mix.lock') }}
 
-      - name: Cache Rust
-        id: cache-rust-elixir
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/.rustup/toolchains
-            target/
-          key: ${{ runner.os }}-elixir-rs-${{ env.cache_key }}-${{ matrix.rust_toolchain.version }}-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Install elixir
         id: install-elixir
         uses: erlef/setup-beam@v1.24.0
@@ -90,12 +77,12 @@ jobs:
           otp-version: ${{ matrix.otp.version }}
           elixir-version: ${{ matrix.elixir.version }}
 
-      - name: Install Rust toolchain
-        id: install-rust-toolchain
-        if: steps.cache-rust-elixir.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@master
+      - name: Setup rust
+        id: setup-rust
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: ${{ matrix.rust_toolchain.version }}
+          toolchain-version: ${{ matrix.rust_toolchain.version }}
+          builder-triple: x86_64-linux-unknown-gnu
 
       - name: Install dependencies
         run: mix deps.get
@@ -166,7 +153,7 @@ jobs:
     name: publish
     runs-on: linux-x86_64-16cpu
     needs: build_test
-    if: ${{ startsWith(github.ref, 'refs/tags/*') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
 
     environment: *hex_environment
 
@@ -190,19 +177,6 @@ jobs:
             ts_elixir/deps/
           key: ${{ runner.os }}-mix-${{ env.cache_key }}-elixir-${{ env.latest_elixir }}-otp-${{ env.latest_otp }}-${{ hashFiles('**/mix.lock') }}
 
-      - name: Cache Rust
-        id: cache-rust-elixir
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/.rustup/toolchains
-            target/
-          key: ${{ runner.os }}-elixir-rs-${{ env.cache_key }}-${{ env.latest_rust }}-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Install elixir
         id: install-elixir
         uses: erlef/setup-beam@v1.24.0
@@ -210,12 +184,12 @@ jobs:
           otp-version: ${{ env.latest_otp }}
           elixir-version: ${{ env.latest_elixir }}
 
-      - name: Install Rust toolchain
-        id: install-rust-toolchain
-        if: steps.cache-rust-elixir.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@master
+      - name: Setup rust
+        id: setup-rust
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: ${{ env.latest_rust }}
+          toolchain-version: ${{ matrix.rust_toolchain.version }}
+          builder-triple: x86_64-linux-unknown-gnu
 
       - name: Install dependencies
         run: mix deps.get

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -53,27 +53,25 @@ jobs:
           - os: linux
             runner: linux-arm64-16cpu
             target: aarch64
+            triple: aarch64-unknown-linux-gnu
           - os: linux
             runner: linux-x86_64-16cpu
             target: x86_64
+            triple: x86_64-unknown-linux-gnu
           - os: macOS
             runner: macos-26
             target: aarch64
+            triple: aarch64-apple-darwin
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Set up Rust cache
-        id: cache-cargo
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Setup rust
+        id: setup-rust
+        uses: ./.github/actions/setup-rust
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/.rustup/toolchains
-            target/
-          key: ${{ matrix.platform.os }}-python-${{ env.cache_key }}-${{ env.rust_toolchain }}-${{ matrix.platform.target }}-${{ hashFiles('**/Cargo.lock') }}
+          toolchain-version: ${{ env.rust_toolchain }}
+          builder-triple: ${{ matrix.platform.triple }}
       - name: Install python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:


### PR DESCRIPTION
The same caches and toolchain install logic get used across all the different workflows for setting up rust -- centralize to dedup and share the cache state. Separate the `target/` cache because it's tied specifically to the `Cargo.lock` hashing, where the toolchain install doesn't care and should be fine to be reused even if our deps change.

Also separate arch-independent checks in the Rust into their own job, which should (in principle) accelerate things by letting them run concurrently.