### PR TITLE
.github: only run Python publish job on tag/workflow_dispatch

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -44,8 +44,8 @@ env:
   rust_toolchain: 1.94.0
 
 jobs:
-  build_test:
-    name: test (${{ matrix.platform.os }}, ${{ matrix.platform.target }})
+  build:
+    name: build (${{ matrix.platform.os }}, ${{ matrix.platform.target }})
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -95,7 +95,8 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: build_test
+    if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
+    needs: build
     environment: *python_environment
     permissions:
       # Use to sign the release artifacts
@@ -122,5 +123,4 @@ jobs:
       - name: (Dry Run) Publish to ${{ env.python_index }}
         run: uv publish --dry-run --directory ts_python --index ${{ env.python_index }} 'wheels-*/*'
       - name: Publish to ${{ env.python_index }}
-        if: ${{ env.is_tag_push || github.event_name == 'workflow_dispatch' }}
         run: uv publish --directory ts_python --index ${{ env.python_index }} 'wheels-*/*'


### PR DESCRIPTION
Fixes broken `main` build.

Also changes name of "build_test" job to "build" to align with other language jobs, and since we're not testing Python yet.