### PR TITLE
.github, rust: automatically publish to crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,28 @@ on:
     # Nightly run; execute daily at 06:37 AM UTC on main (default branch).
     - cron: '37 6 * * *'
 
+  workflow_dispatch:
+    inputs:
+      # It doesn't currently make sense to publish to staging.crates.io because this
+      # requires all our dependencies to be present for the push to succeed, so this is
+      # disabled for now.
+      crates_repo:
+        description: "crates.io repo to publish to"
+        default: prod
+        required: true
+        options:
+          # - staging
+          - prod
+
 env:
   CARGO_TERM_COLOR: always
+  crates_environment: &crates_environment ${{ case(inputs.crates_repo == 'prod', 'crates.io', startsWith(github.ref, 'refs/tags/'), 'crates.io', 'staging.crates.io') }}
+
+  is_tag_push: ${{ startsWith(github.ref, 'refs/tags/') }}
+  is_dispatch: ${{ github.event_name == 'workflow_dispatch' }}
+
+  prev_rust: &prev_rust 1.93.1
+  latest_rust: &latest_rust 1.94.0
 
 jobs:
   build_test:
@@ -29,9 +49,9 @@ jobs:
           - triple: aarch64-apple-darwin
             runner: macos-26
         toolchain:
-          - version: 1.93.1
+          - version: *prev_rust
             label: prev
-          - version: 1.94.0
+          - version: *latest_rust
             label: latest
         exclude:
           # Don't run macOS builds on PR/push workflows; only on the nightly workflow.
@@ -91,10 +111,14 @@ jobs:
           toolchain-version: nightly
           builder-triple: x86_64-unknown-linux-gnu
           components: rustfmt
-      - name: binstall
+      - &binstall
+        name: binstall
         uses: cargo-bins/cargo-binstall@main
       - name: Install cargo-deny
         run: command -v cargo-deny || cargo binstall --no-confirm cargo-deny
+      - &cargo_ws
+        name: Install cargo-workspaces
+        run: command -v cargo-workspaces || cargo binstall --no-confirm cargo-workspaces
       - name: Check for unused dependencies (cargo machete)
         uses: bnjbvr/cargo-machete@main
         with:
@@ -105,3 +129,53 @@ jobs:
         run: cargo +nightly fmt --check
       - name: Custom workspace checks
         run: cargo run -p checks
+      - &dry_publish
+        name: Publish (Dry run)
+        run: cargo ws publish --dry-run --publish-as-is
+
+  publish:
+    name: publish
+    runs-on: linux-x86_64-16cpu
+
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    needs:
+      - build_test
+      - arch_independent
+
+    environment: *crates_environment
+
+    # `id-token` is used to grab the cargo registry token.
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        id: auth
+        with:
+          url: ${{ case(inputs.crates_repo != 'prod', 'https://staging.crates.io', 'https://crates.io') }}
+
+      - name: Setup rust
+        id: setup-rust
+        uses: ./.github/actions/setup-rust
+        with:
+          toolchain-version: *latest_rust
+          builder-triple: x86_64-unknown-linux-gnu
+
+      - *binstall
+      - *cargo_ws
+
+      - name: Configure staging registry
+        if: inputs.crates_repo != 'prod'
+        run: |-
+          echo CARGO_REGISTRIES_STAGING_INDEX=https://staging.crates.io/index >> $GITHUB_ENV
+          echo CARGO_REGISTRY_DEFAULT=staging >> $GITHUB_ENV
+
+      - *dry_publish
+
+      - name: Publish
+        run: cargo ws publish --publish-as-is
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4493,7 +4493,7 @@ dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
  "tailscale",
- "ts_cli_util",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,7 +4304,7 @@ dependencies = [
  "tailscale",
  "tokio",
  "tracing",
- "ts_cli_util",
+ "tracing-subscriber",
  "ts_keys",
 ]
 

--- a/ts_cli_util/Cargo.toml
+++ b/ts_cli_util/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 description = "tailscale utilities for writing command-line tools"
 categories = ["command-line-interface"]
 keywords = ["tailscale", "cli", "util"]
+publish = false
 
 repository.workspace = true
 edition.workspace = true

--- a/ts_ffi/Cargo.toml
+++ b/ts_ffi/Cargo.toml
@@ -13,11 +13,11 @@ publish.workspace = true
 
 [dependencies]
 tailscale.workspace = true
-ts_cli_util.workspace = true
 ts_keys.workspace = true
 
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true, features = ["release_max_level_info"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/ts_ffi/src/lib.rs
+++ b/ts_ffi/src/lib.rs
@@ -22,6 +22,8 @@ use std::{
     sync::{LazyLock, Once},
 };
 
+use tracing::level_filters::LevelFilter;
+
 mod config;
 mod keys;
 mod net_types;
@@ -64,7 +66,15 @@ static TRACING_ONCE: Once = Once::new();
 /// errors if initialization needs to be done before `ts_init`.
 #[unsafe(no_mangle)]
 pub extern "C" fn ts_init_tracing() {
-    TRACING_ONCE.call_once(ts_cli_util::init_tracing);
+    TRACING_ONCE.call_once(|| {
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::builder()
+                    .with_default_directive(LevelFilter::INFO.into())
+                    .from_env_lossy(),
+            )
+            .init();
+    });
 }
 
 /// Initialize a new Tailscale device.

--- a/ts_netstack_smoltcp/Cargo.toml
+++ b/ts_netstack_smoltcp/Cargo.toml
@@ -20,7 +20,7 @@ ts_netstack_smoltcp_socket.workspace = true
 
 # Unconditionally required dependencies.
 bytes.workspace = true
-futures-util.workspace = true
+futures-util = { workspace = true, features = ["async-await", "async-await-macro"] }
 tracing.workspace = true
 
 # Required dependencies for the "tokio" feature.

--- a/ts_netstack_smoltcp/src/run.rs
+++ b/ts_netstack_smoltcp/src/run.rs
@@ -65,7 +65,7 @@ pub async fn run(
 
         tracing::trace!(parent: &span, "select");
 
-        futures_util::select![
+        futures_util::select_biased![
             _ = netstack.wait_io_async(now, dev)
                 .instrument(span.clone())
                 .fuse() =>

--- a/ts_python/Cargo.toml
+++ b/ts_python/Cargo.toml
@@ -12,10 +12,10 @@ rust-version.workspace = true
 
 [dependencies]
 tailscale.workspace = true
-ts_cli_util.workspace = true
 
 pyo3 = { version = "0.28", features = ["bytes", "abi3-py312"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime", "attributes"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [lib]
 name = "tailscale"

--- a/ts_python/src/lib.rs
+++ b/ts_python/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
 
 use pyo3::{exceptions::PyValueError, prelude::*};
 use pyo3_async_runtimes::tokio::future_into_py;
+use tracing_subscriber::filter::LevelFilter;
 
 use crate::ip_or_str::IpRepr;
 
@@ -37,7 +38,15 @@ pub mod _internal {
     #[pyo3(signature = (config_path, auth_key=None))]
     pub fn connect(py: Python<'_>, config_path: String, auth_key: Option<String>) -> PyFut<'_> {
         static TRACING_ONCE: Once = Once::new();
-        TRACING_ONCE.call_once(ts_cli_util::init_tracing);
+        TRACING_ONCE.call_once(|| {
+            tracing_subscriber::fmt()
+                .with_env_filter(
+                    tracing_subscriber::EnvFilter::builder()
+                        .with_default_directive(LevelFilter::INFO.into())
+                        .from_env_lossy(),
+                )
+                .init();
+        });
 
         future_into_py(py, async move {
             let config = ts::Config {


### PR DESCRIPTION
Set up for publish to `crates.io`. Adds a `publish` job to the rust workflow and a dry-run publish to the normal arch-independent checks. I haven't actually been able to run the workflow yet, and I don't believe it's possible to do without actually publishing something to production crates.io.

I would have liked to support publishing to `staging.crates.io`, but it very strongly requires all our dependencies to be there first. In elixir the hacking to make that happen on staging Hex wasn't too bad, but it feels like a lot more of a pain for Rust, so I left the capability in the workflow, but disabled.

This uses [`cargo-workspaces`](https://github.com/pksunkara/cargo-workspaces) to manage the publish, which is the best tool I found while trying things last week &mdash; it strips `dev-dependencies` and solves the dependency -> publish order problem properly. It's possible I was just holding [`cargo-release`](https://github.com/crate-ci/cargo-release) wrong last week, given that it's more popular and seems more polished, but I don't believe it handled `dev-dependencies`, which we need currently.

I added trusted publishing configs to all the crates owned by `tailscale:rust-crate-owners` with non-trivial versions (driven by a little python script in my repo).

Also includes some small fixes I made locally last week, most notably that `ts_cli_util` creates a dependency loop that excludes it from being published to crates.io: it depends on `tailscale` (for `Config`), but dependencies of `tailscale` also use it &mdash; so there's no upload order to crates.io that can work. We're really just using it in the lang bindings as a common place to define the tracing init, but I want to replace that anyway (#10), so just copy-pasted a generic tracing-subscriber init for now.

Closes #44 .