### PR TITLE
ffi: fix doc warning

### DIFF
--- a/ts_ffi/src/lib.rs
+++ b/ts_ffi/src/lib.rs
@@ -78,7 +78,7 @@ pub extern "C" fn ts_init_tracing() {
 ///
 /// # Safety
 ///
-/// `auth_token`  must be able to be read according to [`CStr`][ffi::CStr] rules, i.e.
+/// `auth_token`  must be able to be read according to [`CStr`] rules, i.e.
 /// it must be NUL-terminated and valid for reading up to and including the NUL.
 /// The string fields of `config` may be `NULL`, but if they are not, they must
 /// obey the same invariants.
@@ -118,7 +118,7 @@ pub unsafe extern "C" fn ts_init(
 ///
 /// # Safety
 ///
-/// `auth_token` and `key_file` must be able to be read according to [`CStr`][ffi::CStr] rules, i.e.
+/// `auth_token` and `key_file` must be able to be read according to [`CStr`] rules, i.e.
 /// they must be NUL-terminated and valid for reading up to and including the NUL.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn ts_init_from_key_file(


### PR DESCRIPTION
I previously added an import for `CStr` separately from some other changes, which makes `rustdoc` warn that `[CStr][ffi::CStr]` is unnecessary because `CStr` is already in scope. Remove the explicit link to quiet this warning.
