### PR TITLE
.github: pin actions to commit hashes instead of version tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.target.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup rust
         id: setup-rust
         uses: ./.github/actions/setup-rust
@@ -83,7 +83,7 @@ jobs:
     runs-on: linux-x86_64-16cpu
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup rust
         id: setup-rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -58,11 +58,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Cache mix
         id: cache-mix
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.mix
@@ -72,7 +72,7 @@ jobs:
 
       - name: Install elixir
         id: install-elixir
-        uses: erlef/setup-beam@v1.24.0
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # 1.24.0
         with:
           otp-version: ${{ matrix.otp.version }}
           elixir-version: ${{ matrix.elixir.version }}
@@ -117,7 +117,7 @@ jobs:
         run: mix docs --warnings-as-errors
 
       - name: Upload docs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: exdoc-${{ github.sha }}
           path: ts_elixir/doc
@@ -144,7 +144,7 @@ jobs:
           MIX_ENV: prod
 
       - name: Upload package tarball
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.package_artifact }}
           path: ts_elixir/tailscale
@@ -165,11 +165,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Cache mix
         id: cache-mix
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.mix
@@ -179,7 +179,7 @@ jobs:
 
       - name: Install elixir
         id: install-elixir
-        uses: erlef/setup-beam@v1.24.0
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # 1.24.0
         with:
           otp-version: ${{ env.latest_otp }}
           elixir-version: ${{ env.latest_elixir }}
@@ -198,13 +198,13 @@ jobs:
         run: mix deps.compile
 
       - name: Download built package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.package_artifact }}
           path: ts_elixir/tailscale
 
       - name: Generate attestation
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: ts_elixir/tailscale
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,8 +11,8 @@ jobs:
     name: nix flake check
     runs-on: linux-x86_64-16cpu
     steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
       - run: nix flake check -L
 
   build:
@@ -27,8 +27,8 @@ jobs:
     name: nix build ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
 
       - name: nix build
         run: |-


### PR DESCRIPTION
Avoids vector for supply-chain attacks.

Closes #136 .