### PR TITLE
python: configure connection with keyword args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4490,6 +4490,7 @@ dependencies = [
 name = "ts_python"
 version = "0.2.0"
 dependencies = [
+ "hex",
  "pyo3",
  "pyo3-async-runtimes",
  "tailscale",

--- a/ts_python/Cargo.toml
+++ b/ts_python/Cargo.toml
@@ -13,6 +13,7 @@ rust-version.workspace = true
 [dependencies]
 tailscale.workspace = true
 
+hex.workspace = true
 pyo3 = { version = "0.28", features = ["bytes", "abi3-py312"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime", "attributes"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/ts_python/src/key_state.rs
+++ b/ts_python/src/key_state.rs
@@ -1,0 +1,95 @@
+use ts::keys::{DiscoPrivateKey, MachinePrivateKey, NetworkLockPrivateKey, NodePrivateKey};
+
+/// Tailscale keys.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[pyo3::pyclass(frozen, get_all, from_py_object, module = "tailscale")]
+pub struct Keystate {
+    /// Machine key.
+    pub machine: Vec<u8>,
+    /// Node (device) key.
+    pub node: Vec<u8>,
+    /// Disco key.
+    pub disco: Vec<u8>,
+    /// Network lock key.
+    pub network_lock: Vec<u8>,
+}
+
+#[pyo3::pymethods]
+impl Keystate {
+    #[new]
+    #[pyo3(signature = (machine=None, node=None, disco=None, network_lock=None))]
+    pub fn new(
+        machine: Option<Vec<u8>>,
+        node: Option<Vec<u8>>,
+        disco: Option<Vec<u8>>,
+        network_lock: Option<Vec<u8>>,
+    ) -> Self {
+        let mut out = Self {
+            ..ts::keys::NodeState::default().into()
+        };
+
+        if let Some(machine) = machine {
+            out.machine = machine;
+        }
+
+        if let Some(node) = node {
+            out.node = node;
+        }
+
+        if let Some(disco) = disco {
+            out.disco = disco;
+        }
+
+        if let Some(network_lock) = network_lock {
+            out.network_lock = network_lock;
+        }
+
+        out
+    }
+
+    pub fn __repr__(&self) -> String {
+        match tailscale::keys::NodeState::try_from(self) {
+            Ok(state) => {
+                format!(
+                    "tailscale.Keystate(machine={}, node={}, disco={}, network_lock={})",
+                    hex::encode(state.machine_keys.public.to_bytes()),
+                    hex::encode(state.node_keys.public.to_bytes()),
+                    hex::encode(state.disco_keys.public.to_bytes()),
+                    hex::encode(state.network_lock_keys.public.to_bytes()),
+                )
+            }
+            Err(_) => "tailscale.Keystate(<invalid>)".to_owned(),
+        }
+    }
+}
+
+impl From<tailscale::keys::NodeState> for Keystate {
+    fn from(value: tailscale::keys::NodeState) -> Self {
+        Self {
+            machine: value.machine_keys.private.to_bytes().into(),
+            node: value.node_keys.private.to_bytes().into(),
+            disco: value.disco_keys.private.to_bytes().into(),
+            network_lock: value.network_lock_keys.private.to_bytes().into(),
+        }
+    }
+}
+
+impl TryFrom<&Keystate> for tailscale::keys::NodeState {
+    type Error = ();
+
+    fn try_from(value: &Keystate) -> Result<Self, ()> {
+        fn key<T>(v: &[u8]) -> Result<T, ()>
+        where
+            T: From<[u8; 32]>,
+        {
+            Ok(<[u8; 32]>::try_from(v).map_err(|_| ())?.into())
+        }
+
+        Ok(Self {
+            machine_keys: key::<MachinePrivateKey>(&value.machine)?.into(),
+            node_keys: key::<NodePrivateKey>(&value.node)?.into(),
+            disco_keys: key::<DiscoPrivateKey>(&value.disco)?.into(),
+            network_lock_keys: key::<NetworkLockPrivateKey>(&value.network_lock)?.into(),
+        })
+    }
+}

--- a/ts_python/src/lib.rs
+++ b/ts_python/src/lib.rs
@@ -16,10 +16,12 @@ extern crate tailscale as ts;
 type PyFut<'p> = PyResult<Bound<'p, PyAny>>;
 
 mod ip_or_str;
+mod key_state;
 mod node_info;
 mod tcp;
 mod udp;
 
+use key_state::Keystate;
 use node_info::NodeInfo;
 
 /// Tailscale API.
@@ -28,15 +30,23 @@ pub mod _internal {
     use super::*;
     #[pymodule_export]
     use crate::{
-        Device,
+        Device, Keystate,
         tcp::{TcpListener, TcpStream},
         udp::UdpSocket,
     };
 
-    /// Connect to tailscale using the specified config file and optional auth key.
+    /// Connect to tailscale using the specified parameters.
     #[pyfunction]
-    #[pyo3(signature = (config_path, auth_key=None))]
-    pub fn connect(py: Python<'_>, config_path: String, auth_key: Option<String>) -> PyFut<'_> {
+    #[pyo3(signature = (key_file_path=None, /, auth_key=None, *, control_server_url=None, hostname=None, tags=None, keys=None))]
+    pub fn connect(
+        py: Python<'_>,
+        key_file_path: Option<String>,
+        auth_key: Option<String>,
+        control_server_url: Option<String>,
+        hostname: Option<String>,
+        tags: Option<Vec<String>>,
+        keys: Option<Keystate>,
+    ) -> PyFut<'_> {
         static TRACING_ONCE: Once = Once::new();
         TRACING_ONCE.call_once(|| {
             tracing_subscriber::fmt()
@@ -49,12 +59,30 @@ pub mod _internal {
         });
 
         future_into_py(py, async move {
-            let config = ts::Config {
-                client_name: Some("ts_python".to_owned()),
-                ..ts::Config::default_with_key_file(config_path)
+            let mut config = if let Some(key_file_path) = key_file_path {
+                ts::Config::default_with_key_file(key_file_path)
                     .await
                     .map_err(py_value_err)?
+            } else {
+                ts::Config::default()
             };
+
+            config.client_name = Some("ts_python".to_owned());
+            if let Some(control_server_url) = control_server_url {
+                config.control_server_url = control_server_url.parse().map_err(py_value_err)?;
+            }
+
+            if let Some(hostname) = hostname {
+                config.requested_hostname = Some(hostname);
+            }
+
+            if let Some(tags) = tags {
+                config.requested_tags = tags;
+            }
+
+            if let Some(keys) = &keys {
+                config.key_state = keys.try_into().map_err(|_| py_value_err("invalid keys"))?;
+            }
 
             let dev = ts::Device::new(&config, auth_key)
                 .await


### PR DESCRIPTION
Updates #125

Figure we can have a dedicated `tailscale.Config` type if we want later, but the need seems well-enough-served for now with just keyword args

Stacked on #140 due to some shared changes, intent is to merge to main once that merges