### PR TITLE
.github/python: build on windows

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -62,6 +62,10 @@ jobs:
             runner: macos-26
             target: aarch64
             triple: aarch64-apple-darwin
+          - os: windows
+            runner: windows-8vcpu
+            target: x86_64
+            triple: x86_64-pc-windows-msvc
 
     steps:
       - name: Checkout
@@ -81,7 +85,7 @@ jobs:
         with:
           working-directory: ts_python
           rust-toolchain: ${{ env.rust_toolchain }}
-          target: ${{ matrix.platform.target }}
+          target: ${{ matrix.platform.triple }}
           args: --release --out dist
           sccache: ${{ !env.is_tag_push }}
           manylinux: auto


### PR DESCRIPTION
Build using the `*-msvc` toolchain -- I tried both `-msvc` and `-gnu`, they both work, but we only need to upload one, and `-msvc` seems to be more stable.

Stacked on #149 for common changes, intended to merge after it