### PR TITLE
.github/rust: don't run `cargo build --release` on windows for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,12 @@ jobs:
               $COMMON_FLAGS \
               ${{ case(env.is_windows_gnu == 'true', '--exclude ts_python', '') }}
 
+      # Release builds on Windows specifically take forever: disable them on PRs to speed
+      # the check (the dev build is sufficient to establish that the code compiles)
       - name: Release build (cargo build --release)
+        if: ${{ runner.os != 'Windows' || github.event_name != 'pull_request' }}
         run: cargo build $COMMON_FLAGS --release --all-targets
+
       - name: Docs (cargo doc)
         run: cargo doc $COMMON_FLAGS --no-deps
 


### PR DESCRIPTION
This is by far the slowest step, turning it off on Windows puts the check nearly in line with Linux, and the normal dev-build tells us that it compiles anyway. The `--release` compile still runs for checks run in any other context than PRs.

Arguably we should turn off Rust checks on Windows for PRs entirely though (along the same lines as macos), since it can take a forever to grab a Windows runner at all &mdash; open to that also, but this is at least an incremental improvement