### PR TITLE
README.md: document Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ We support the following platforms and architectures:
 
 - Linux (`x86_64`/`ARM64`)
 - macOS (`ARM64`)
+- Windows (`x86_64`)
 
 ## Status
 
@@ -134,7 +135,6 @@ no guarantees on timeline or completion:
 - Direct connections (NAT traversal, STUN, and Disco)
 - Peer lookups (addressing peers by hostname)
 - Third-party code and cryptography audit
-- Official Windows support
 
 ### Unsupported
 


### PR DESCRIPTION
Updates #65

---

IIRC having CI up for Windows was the thing holding us back from saying we have Windows support, so time to update the readme? I documented x86_64 only, since I don't think we test on arm64 yet (even though it should also be fine, probably)