### PR TITLE
ts_python: fix PyPI upload URL

### DIFF
--- a/ts_python/pyproject.toml
+++ b/ts_python/pyproject.toml
@@ -36,7 +36,7 @@ module-name = "tailscale._internal"
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple/"
-publish-url = "https://pypi.org/legacy/"
+publish-url = "https://upload.pypi.org/legacy/"
 explicit = true
 
 [[tool.uv.index]]


### PR DESCRIPTION
Adds the `upload` subdomain to the PyPI index URL; this prevented automatic publishing of the v0.3.0 release.