### PR TITLE
netcore: remove std dep

### DIFF
--- a/ts_netstack_smoltcp_core/src/command/error.rs
+++ b/ts_netstack_smoltcp_core/src/command/error.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 use smoltcp::socket::{
     icmp::BindError as IcmpBindError,


### PR DESCRIPTION
This was breaking the publish because it wasn't conditioned on `feature = "std"` (the crate is `#![no_std]`).