### PR TITLE
repo: bump version to 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,30 @@ Record breaking or significant changes here. All dates are UTC.
 
 ## Unreleased - June 2026
 
+Put changes for the upcoming release here!
+
+## [0.3.3](https://github.com/tailscale/tailscale-rs/releases/tag/v0.3.3) - 2026-05-20
+
+- Fixed: don't generate `tailscale.h` on publish.
+  [#196](https://github.com/tailscale/tailscale-rs/pull/196).
+- Fixed: Elixir CI/CD publishing infrastructure.
+  [#197](https://github.com/tailscale/tailscale-rs/pull/197).
+
 ## [0.3.2](https://github.com/tailscale/tailscale-rs/releases/tag/v0.3.2) - 2026-05-20
 
-- Minor fixes to CI/CD publishing infrastructure.
+Partial release; this version is tagged and published to PyPI, but was not published to crates.io or hex.pm.
+
+- Fixed: removed `std` dependency from `ts_netstack_smoltcp_core`.
+  [#194](https://github.com/tailscale/tailscale-rs/pull/194).
 
 ## [0.3.1](https://github.com/tailscale/tailscale-rs/releases/tag/v0.3.1) - 2026-05-20
 
-- Minor fixes to CI/CD publishing infrastructure.
+Partial release; this version is tagged and published to PyPI, but was not published to crates.io or hex.pm.
+
+- Fixed: Python CI/CD publishing infrastructure.
+  [#191](https://github.com/tailscale/tailscale-rs/pull/191).
+- Fixed: Rust CI/CD publishing infrastructure.
+  [#193](https://github.com/tailscale/tailscale-rs/pull/193).
 
 ## [0.3.0](https://github.com/tailscale/tailscale-rs/releases/tag/v0.3.0) - 2026-05-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "checks"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "clap",
  "globwalk",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "tailscale"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "axum",
  "clap",
@@ -4066,7 +4066,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ts_array256"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "heapless",
  "lazy_static",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "ts_bart"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cfg-if",
  "divan",
@@ -4097,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "ts_bart_packetfilter"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "hashbrown 0.17.1",
  "ipnet",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "ts_bitset"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cfg-if",
  "divan",
@@ -4122,14 +4122,14 @@ dependencies = [
 
 [[package]]
 name = "ts_capabilityversion"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ts_cli_util"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cfg-if",
  "clap",
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "ts_control"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "ts_control_noise"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "ts_control_serde"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "ts_dataplane"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "etherparse",
  "tokio",
@@ -4241,7 +4241,7 @@ dependencies = [
 
 [[package]]
 name = "ts_devtools"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "clap",
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "ts_disco_protocol"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aead",
  "crypto_box",
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "ts_dynbitset"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "proptest",
  "smallvec",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "ts_elixir"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "rustler",
  "tailscale",
@@ -4292,7 +4292,7 @@ dependencies = [
 
 [[package]]
 name = "ts_ffi"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cbindgen",
  "tailscale",
@@ -4304,14 +4304,14 @@ dependencies = [
 
 [[package]]
 name = "ts_hexdump"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "heapless",
 ]
 
 [[package]]
 name = "ts_http_util"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "futures",
@@ -4332,7 +4332,7 @@ dependencies = [
 
 [[package]]
 name = "ts_keys"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "crypto_box",
  "serde",
@@ -4343,7 +4343,7 @@ dependencies = [
 
 [[package]]
 name = "ts_netcheck"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "dashmap",
@@ -4364,7 +4364,7 @@ dependencies = [
 
 [[package]]
 name = "ts_netstack_smoltcp"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "axum",
  "bytes",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "ts_netstack_smoltcp_core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "flume",
@@ -4399,7 +4399,7 @@ dependencies = [
 
 [[package]]
 name = "ts_netstack_smoltcp_socket"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "futures-io",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "ts_nodecapability"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cfg-if",
  "serde",
@@ -4419,7 +4419,7 @@ dependencies = [
 
 [[package]]
 name = "ts_overlay_router"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "itertools",
  "tracing",
@@ -4431,7 +4431,7 @@ dependencies = [
 
 [[package]]
 name = "ts_packet"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "crypto_box",
@@ -4440,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "ts_packetfilter"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "hashbrown 0.17.1",
  "ipnet",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "ts_packetfilter_serde"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ipnet",
  "nom 8.0.0",
@@ -4463,7 +4463,7 @@ dependencies = [
 
 [[package]]
 name = "ts_packetfilter_state"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "divan",
  "serde_json",
@@ -4474,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "ts_peercapability"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "serde",
  "url",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "ts_python"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "hex",
  "pyo3",
@@ -4493,7 +4493,7 @@ dependencies = [
 
 [[package]]
 name = "ts_runtime"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "futures",
  "ipnet",
@@ -4519,18 +4519,18 @@ dependencies = [
 
 [[package]]
 name = "ts_test_util"
-version = "0.3.2"
+version = "0.3.3"
 
 [[package]]
 name = "ts_time"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "ts_tls_util"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "tokio",
  "tokio-rustls",
@@ -4541,7 +4541,7 @@ dependencies = [
 
 [[package]]
 name = "ts_transport"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ts_keys",
  "ts_packet",
@@ -4549,7 +4549,7 @@ dependencies = [
 
 [[package]]
 name = "ts_transport_derp"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "crypto_box",
@@ -4577,7 +4577,7 @@ dependencies = [
 
 [[package]]
 name = "ts_transport_tun"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "ipnet",
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "ts_tunnel"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aead",
  "base64 0.22.1",
@@ -4616,7 +4616,7 @@ dependencies = [
 
 [[package]]
 name = "ts_underlay_router"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ts_keys",
  "ts_packet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ members = [
 edition = "2024"
 license = "BSD-3-Clause"
 publish = true
-version = "0.3.2"
+version = "0.3.3"
 repository = "https://github.com/tailscale/tailscale-rs"
 
 # This disagrees with the README's stated MSRV. That's intentional: this field causes cargo to error
@@ -104,42 +104,42 @@ yoke = { version = "0.8", default-features = false }
 zerocopy = { version = "0.8", features = ["derive"] }
 
 # local workspace deps
-tailscale = { path = ".", version = "0.3.2" }
-ts_array256 = { path = "ts_array256", version = "0.3.2" }
-ts_bart = { path = "ts_bart", version = "0.3.2" }
-ts_bart_packetfilter = { path = "ts_bart_packetfilter", version = "0.3.2" }
-ts_bitset = { path = "ts_bitset", default-features = false, version = "0.3.2" }
-ts_capabilityversion = { path = "ts_capabilityversion", version = "0.3.2" }
+tailscale = { path = ".", version = "0.3.3" }
+ts_array256 = { path = "ts_array256", version = "0.3.3" }
+ts_bart = { path = "ts_bart", version = "0.3.3" }
+ts_bart_packetfilter = { path = "ts_bart_packetfilter", version = "0.3.3" }
+ts_bitset = { path = "ts_bitset", default-features = false, version = "0.3.3" }
+ts_capabilityversion = { path = "ts_capabilityversion", version = "0.3.3" }
 ts_cli_util = { path = "ts_cli_util" }
-ts_control = { path = "ts_control", version = "0.3.2" }
-ts_control_noise = { path = "ts_control_noise", version = "0.3.2" }
-ts_control_serde = { path = "ts_control_serde", version = "0.3.2" }
-ts_dataplane = { path = "ts_dataplane", version = "0.3.2" }
-ts_disco_protocol = { path = "ts_disco_protocol", version = "0.3.2" }
-ts_dynbitset = { path = "ts_dynbitset", version = "0.3.2" }
-ts_hexdump = { path = "ts_hexdump", version = "0.3.2" }
-ts_keys = { path = "ts_keys", version = "0.3.2" }
-ts_netcheck = { path = "ts_netcheck", version = "0.3.2" }
-ts_netstack_smoltcp = { path = "ts_netstack_smoltcp", version = "0.3.2" }
-ts_netstack_smoltcp_core = { path = "ts_netstack_smoltcp_core", version = "0.3.2" }
-ts_netstack_smoltcp_socket = { path = "ts_netstack_smoltcp_socket", version = "0.3.2" }
-ts_nodecapability = { path = "ts_nodecapability", version = "0.3.2" }
-ts_overlay_router = { path = "ts_overlay_router", version = "0.3.2" }
-ts_packet = { path = "ts_packet", version = "0.3.2" }
-ts_packetfilter = { path = "ts_packetfilter", version = "0.3.2" }
-ts_packetfilter_serde = { path = "ts_packetfilter_serde", version = "0.3.2" }
-ts_packetfilter_state = { path = "ts_packetfilter_state", version = "0.3.2" }
-ts_peercapability = { path = "ts_peercapability", version = "0.3.2" }
-ts_http_util = { path = "ts_http_util", version = "0.3.2" }
-ts_tls_util = { path = "ts_tls_util", version = "0.3.2" }
-ts_runtime = { path = "ts_runtime", version = "0.3.2" }
+ts_control = { path = "ts_control", version = "0.3.3" }
+ts_control_noise = { path = "ts_control_noise", version = "0.3.3" }
+ts_control_serde = { path = "ts_control_serde", version = "0.3.3" }
+ts_dataplane = { path = "ts_dataplane", version = "0.3.3" }
+ts_disco_protocol = { path = "ts_disco_protocol", version = "0.3.3" }
+ts_dynbitset = { path = "ts_dynbitset", version = "0.3.3" }
+ts_hexdump = { path = "ts_hexdump", version = "0.3.3" }
+ts_keys = { path = "ts_keys", version = "0.3.3" }
+ts_netcheck = { path = "ts_netcheck", version = "0.3.3" }
+ts_netstack_smoltcp = { path = "ts_netstack_smoltcp", version = "0.3.3" }
+ts_netstack_smoltcp_core = { path = "ts_netstack_smoltcp_core", version = "0.3.3" }
+ts_netstack_smoltcp_socket = { path = "ts_netstack_smoltcp_socket", version = "0.3.3" }
+ts_nodecapability = { path = "ts_nodecapability", version = "0.3.3" }
+ts_overlay_router = { path = "ts_overlay_router", version = "0.3.3" }
+ts_packet = { path = "ts_packet", version = "0.3.3" }
+ts_packetfilter = { path = "ts_packetfilter", version = "0.3.3" }
+ts_packetfilter_serde = { path = "ts_packetfilter_serde", version = "0.3.3" }
+ts_packetfilter_state = { path = "ts_packetfilter_state", version = "0.3.3" }
+ts_peercapability = { path = "ts_peercapability", version = "0.3.3" }
+ts_http_util = { path = "ts_http_util", version = "0.3.3" }
+ts_tls_util = { path = "ts_tls_util", version = "0.3.3" }
+ts_runtime = { path = "ts_runtime", version = "0.3.3" }
 ts_test_util = { path = "ts_test_util" }
-ts_time = { path = "ts_time", version = "0.3.2" }
-ts_transport = { path = "ts_transport", version = "0.3.2" }
-ts_transport_derp = { path = "ts_transport_derp", version = "0.3.2" }
-ts_transport_tun = { path = "ts_transport_tun", version = "0.3.2" }
-ts_underlay_router = { path = "ts_underlay_router", version = "0.3.2" }
-ts_tunnel = { path = "ts_tunnel", version = "0.3.2" }
+ts_time = { path = "ts_time", version = "0.3.3" }
+ts_transport = { path = "ts_transport", version = "0.3.3" }
+ts_transport_derp = { path = "ts_transport_derp", version = "0.3.3" }
+ts_transport_tun = { path = "ts_transport_tun", version = "0.3.3" }
+ts_underlay_router = { path = "ts_underlay_router", version = "0.3.3" }
+ts_tunnel = { path = "ts_tunnel", version = "0.3.3" }
 
 [workspace.lints.rust]
 closure_returning_async_block = "warn"

--- a/ts_elixir/mix.exs
+++ b/ts_elixir/mix.exs
@@ -6,7 +6,7 @@ defmodule TsElixir.MixProject do
   def project do
     [
       app: :tailscale,
-      version: "0.3.2",
+      version: "0.3.3",
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/ts_python/pyproject.toml
+++ b/ts_python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tailscale-py"
-version = "0.3.2"
+version = "0.3.3"
 description = "Work-in-progress Tailscale library written in Rust."
 license = "BSD-3-Clause"
 readme = "README.md"

--- a/ts_python/uv.lock
+++ b/ts_python/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "tailscale-py"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }


### PR DESCRIPTION

Updates the changelog, crate versions, and `ts_python`/`ts_elixir` versions in preparation for the `v0.3.3` release.