### PR TITLE
kv: remove `Clone` requirement for iterators, declutter lifetimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5951,6 +5951,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ts_kv_store"
+version = "0.3.3"
+
+[[package]]
 name = "ts_netcheck"
 version = "0.3.3"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "ts_hexdump",
     "ts_http_util",
     "ts_keys",
+    "ts_kv_store",
     "ts_netcheck",
     "ts_netstack_smoltcp",
     "ts_netstack_smoltcp_core",

--- a/ts_kv_store/Cargo.toml
+++ b/ts_kv_store/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ts_kv_store"
+version.workspace = true
+description = "typed, concurrent and transactional, in-memory key-value store"
+categories = ["data-structures"]
+keywords = ["tailscale", "key-value"]
+
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true

--- a/ts_kv_store/README.md
+++ b/ts_kv_store/README.md
@@ -1,0 +1,5 @@
+# ts_kv_store
+
+typed, concurrent and transactional, in-memory key-value store
+
+See docs in [lib.rs](src/lib.rs) for details.

--- a/ts_kv_store/src/index.rs
+++ b/ts_kv_store/src/index.rs
@@ -19,25 +19,26 @@ use crate::{
 /// SAFETY: `D` and `B` must describe different tables (this is enforced by the macros, but possible
 /// to violate if building a schema by hand).
 pub struct KvTableIndex<
-    'a,
+    'store,
     TableStorage: schema::GeneratedStorage,
     D: IndexDesc<Storage = TableStorage, BaseTable = B>,
     B: TableDesc<Storage = TableStorage>,
 > {
-    pub(crate) store: &'a KvStore<TableStorage>,
+    pub(crate) store: &'store KvStore<TableStorage>,
     pub(crate) owner: Owner,
     pub(crate) index: PhantomData<D>,
     pub(crate) base: PhantomData<B>,
 }
 
 impl<
-    'a,
-    TableStorage: schema::GeneratedStorage + 'a,
+    'store: 'idx,
+    'idx,
+    TableStorage: schema::GeneratedStorage + 'store,
     D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
     B: TableDesc<Storage = TableStorage>,
-> Ops<'a, TableStorage> for &'a KvTableIndex<'a, TableStorage, D, B>
+> Ops<'store, TableStorage> for &'idx KvTableIndex<'store, TableStorage, D, B>
 {
-    type ReadLock = std::sync::RwLockReadGuard<'a, crate::storage::Storage<TableStorage>>;
+    type ReadLock = std::sync::RwLockReadGuard<'idx, crate::storage::Storage<TableStorage>>;
 
     fn read_lock(self) -> Self::ReadLock {
         self.store.storage.read().unwrap()
@@ -45,13 +46,14 @@ impl<
 }
 
 impl<
-    'a,
-    TableStorage: schema::GeneratedStorage + 'a,
+    'store: 'idx,
+    'idx,
+    TableStorage: schema::GeneratedStorage + 'store,
     D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
     B: TableDesc<Storage = TableStorage>,
-> OpsMut<'a, TableStorage> for &'a KvTableIndex<'a, TableStorage, D, B>
+> OpsMut<'store, TableStorage> for &'idx KvTableIndex<'store, TableStorage, D, B>
 {
-    type WriteLock = std::sync::RwLockWriteGuard<'a, crate::storage::Storage<TableStorage>>;
+    type WriteLock = std::sync::RwLockWriteGuard<'idx, crate::storage::Storage<TableStorage>>;
 
     fn write_lock(self) -> Self::WriteLock {
         self.store.storage.write().unwrap()
@@ -59,29 +61,29 @@ impl<
 }
 
 impl<
-    'a,
-    TableStorage: schema::GeneratedStorage + 'a,
+    'store,
+    TableStorage: schema::GeneratedStorage + 'store,
     D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
     B: TableDesc<Storage = TableStorage>,
-> IndexedOps<'a, TableStorage, D, B> for &'a KvTableIndex<'a, TableStorage, D, B>
+> IndexedOps<'store, TableStorage, D, B> for &KvTableIndex<'store, TableStorage, D, B>
 {
 }
 
 impl<
-    'a,
-    TableStorage: schema::GeneratedStorage + 'a,
+    'store,
+    TableStorage: schema::GeneratedStorage + 'store,
     D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
     B: TableDesc<Storage = TableStorage>,
-> IndexedOpsMut<'a, TableStorage, D, B> for &'a KvTableIndex<'a, TableStorage, D, B>
+> IndexedOpsMut<'store, TableStorage, D, B> for &KvTableIndex<'store, TableStorage, D, B>
 {
 }
 
 impl<
-    'a,
+    'store,
     TableStorage: schema::GeneratedStorage,
     D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
     B: TableDesc<Storage = TableStorage>,
-> KvTableIndex<'a, TableStorage, D, B>
+> KvTableIndex<'store, TableStorage, D, B>
 {
     /// Initialize the base table by setting its owner (indexes don't have an owner).
     ///
@@ -90,29 +92,29 @@ impl<
     ///
     /// Returns an error (containing the current owner of the table) if the table has already been
     /// initialized. In this case, the table will be in a consistent state and can be used as normal.
-    pub fn init(&'a self) -> Result<()> {
+    pub fn init(&self) -> Result<()> {
         <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::init(self, self.owner)
     }
 
     /// The number of key/value pairs in the base table.
-    pub fn len(&'a self) -> usize {
+    pub fn len(&self) -> usize {
         <&Self as IndexedOps<'_, TableStorage, D, B>>::len(self)
     }
 
     /// True if the table is empty.
-    pub fn is_empty(&'a self) -> bool {
+    pub fn is_empty(&self) -> bool {
         <&Self as IndexedOps<'_, TableStorage, D, B>>::is_empty(self)
     }
 
     /// Clear the base table by removing all its KVs, but preserving ownership.
-    pub fn clear(&'a self) {
+    pub fn clear(&self) {
         <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::clear(self, self.owner)
     }
 
     /// Get a row of the table from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<Q>(&'a self, key: &Q) -> Option<B::Value>
+    pub fn get<Q>(&self, key: &Q) -> Option<B::Value>
     where
         B::Value: Clone,
         D::Key: Borrow<Q>,
@@ -124,7 +126,7 @@ impl<
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&'a self, key: &Q, f: impl FnOnce(&B::Value) -> T) -> Option<T>
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&B::Value) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -135,7 +137,7 @@ impl<
     /// Insert a value into the table using the base table's key.
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
-    pub fn insert(&'a self, key: B::Key, value: B::Value) -> Option<B::Value>
+    pub fn insert(&self, key: B::Key, value: B::Value) -> Option<B::Value>
     where
         B::Key: Clone,
     {
@@ -145,7 +147,7 @@ impl<
     /// Get mutable access to a row of the table in the store in the store.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with_mut<Q, T>(&'a self, key: &Q, f: impl FnOnce(&mut B::Value) -> T) -> Option<T>
+    pub fn with_mut<Q, T>(&self, key: &Q, f: impl FnOnce(&mut B::Value) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -157,7 +159,7 @@ impl<
     /// Remove a row from the table.
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
-    pub fn remove<Q>(&'a self, key: &Q) -> Option<B::Value>
+    pub fn remove<Q>(&self, key: &Q) -> Option<B::Value>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -166,49 +168,34 @@ impl<
     }
 
     /// Iterate all the keys in the index and value in the base table.
-    ///
-    /// Clones both keys and values (but not the intermediate keys) and provides them by-value. To
-    /// iterate without cloning, see [`Self::for_each`].
-    pub fn iter_cloned(&'a self) -> impl Iterator<Item = (D::Key, B::Value)>
+    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &B::Value)>
     where
-        D::Key: Clone,
-        B::Value: Clone,
+        D: 'store,
+        B: 'store,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_cloned(self, self.owner)
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter(self, self.owner)
     }
 
     /// Iterate all the keys in the index.
-    ///
-    /// Clones the keys and provides them by-value. To iterate without cloning, see
-    /// [`Self::for_each`].
-    pub fn iter_keys_cloned(&'a self) -> impl Iterator<Item = D::Key>
+    pub fn keys(&self) -> impl Iterator<Item = &D::Key>
     where
-        D::Key: Clone,
+        D: 'store,
+        B: 'store,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_keys_cloned(self, self.owner)
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::keys(self, self.owner)
     }
 
     /// Iterate all the values in the base table.
-    ///
-    /// Clones values and provides them by-value. To iterate without cloning, see
-    /// [`Self::for_each`].
-    pub fn iter_values_cloned(&'a self) -> impl Iterator<Item = B::Value>
+    pub fn values(&self) -> impl Iterator<Item = &B::Value>
     where
-        B::Value: Clone,
+        D: 'store,
+        B: 'store,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_values_cloned(self, self.owner)
-    }
-
-    /// Iterate all the keys in the index and value in the base table.
-    ///
-    /// We're not able to make this an iterator because we have to ensure that the references do
-    /// not outlive our lock on the store. For a (cloning) iterator see [`Self::iter_cloned`].
-    pub fn for_each(&'a self, f: impl FnMut(&D::Key, &B::Value)) {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::for_each(self, f, self.owner)
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::values(self, self.owner)
     }
 
     /// Iterate all the key/value pairs in a table. Values are mutable.
-    pub fn for_each_mut(&'a self, f: impl FnMut(&D::Key, &mut B::Value)) {
+    pub fn for_each_mut(&self, f: impl FnMut(&D::Key, &mut B::Value)) {
         <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::for_each_mut(self, f, self.owner)
     }
 }
@@ -221,27 +208,28 @@ impl<
 /// SAFETY: `D` and `B` must describe different tables (this is enforced by the macros, but possible
 /// to violate if building a schema by hand).
 pub struct KvTableTransactionalIndex<
-    'a,
-    't,
+    'guard: 'tx,
+    'tx,
     TableStorage: schema::GeneratedStorage,
     D: IndexDesc<Storage = TableStorage, BaseTable = B>,
     B: TableDesc<Storage = TableStorage>,
 > {
-    pub(crate) txn: &'t mut Transaction<'a, TableStorage>,
+    pub(crate) txn: &'tx mut Transaction<'guard, TableStorage>,
     pub(crate) index: PhantomData<D>,
     pub(crate) base: PhantomData<B>,
 }
 
 impl<
-    'a,
-    't,
-    's,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
-    B: TableDesc<Storage = TableStorage> + 'a,
-> Ops<'a, TableStorage> for &'s KvTableTransactionalIndex<'a, 't, TableStorage, D, B>
+    'store: 'guard,
+    'guard: 'tx,
+    'tx: 'r,
+    'r,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+> Ops<'store, TableStorage> for &'r KvTableTransactionalIndex<'guard, 'tx, TableStorage, D, B>
 {
-    type ReadLock = RefWriteGuard<'s, 'a, Storage<TableStorage>>;
+    type ReadLock = RefWriteGuard<'r, 'guard, Storage<TableStorage>>;
 
     fn read_lock(self) -> Self::ReadLock {
         RefWriteGuard(&self.txn.guard)
@@ -249,15 +237,17 @@ impl<
 }
 
 impl<
-    'a,
-    't,
-    's,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
-    B: TableDesc<Storage = TableStorage> + 'a,
-> OpsMut<'a, TableStorage> for &'s mut KvTableTransactionalIndex<'a, 't, TableStorage, D, B>
+    'store: 'guard,
+    'guard: 'tx,
+    'tx: 'r,
+    'r,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+> OpsMut<'store, TableStorage>
+    for &'r mut KvTableTransactionalIndex<'guard, 'tx, TableStorage, D, B>
 {
-    type WriteLock = RefWriteGuardMut<'s, 'a, Storage<TableStorage>>;
+    type WriteLock = RefWriteGuardMut<'r, 'guard, Storage<TableStorage>>;
 
     fn write_lock(self) -> Self::WriteLock {
         RefWriteGuardMut(&mut self.txn.guard)
@@ -265,35 +255,37 @@ impl<
 }
 
 impl<
-    'a,
-    't,
-    's,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
-    B: TableDesc<Storage = TableStorage> + 'a,
-> IndexedOps<'a, TableStorage, D, B> for &'s KvTableTransactionalIndex<'a, 't, TableStorage, D, B>
+    'store: 'guard,
+    'guard: 'tx,
+    'tx,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+> IndexedOps<'store, TableStorage, D, B>
+    for &KvTableTransactionalIndex<'guard, 'tx, TableStorage, D, B>
 {
 }
 
 impl<
-    'a,
-    't,
-    's,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
-    B: TableDesc<Storage = TableStorage> + 'a,
-> IndexedOpsMut<'a, TableStorage, D, B>
-    for &'s mut KvTableTransactionalIndex<'a, 't, TableStorage, D, B>
+    'store: 'guard,
+    'guard: 'tx,
+    'tx,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+> IndexedOpsMut<'store, TableStorage, D, B>
+    for &mut KvTableTransactionalIndex<'guard, 'tx, TableStorage, D, B>
 {
 }
 
 impl<
-    'a,
-    't,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
-    B: TableDesc<Storage = TableStorage> + 'a,
-> KvTableTransactionalIndex<'a, 't, TableStorage, D, B>
+    'store: 'guard,
+    'guard: 'tx,
+    'tx,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+> KvTableTransactionalIndex<'guard, 'tx, TableStorage, D, B>
 {
     /// Initialize the base table by setting its owner (indexes don't have an owner).
     ///
@@ -336,7 +328,7 @@ impl<
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&'t self, key: &Q, f: impl FnOnce(&B::Value) -> T) -> Option<T>
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&B::Value) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -388,45 +380,30 @@ impl<
     }
 
     /// Iterate all the keys in the index and value in the base table.
-    ///
-    /// Clones both keys and values (but not the intermediate keys) and provides them by-value. To
-    /// iterate without cloning, see [`Self::for_each`].
-    pub fn iter_cloned(&self) -> impl Iterator<Item = (D::Key, B::Value)>
+    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &B::Value)>
     where
-        D::Key: Clone,
-        B::Value: Clone,
+        D: 'store,
+        B: 'store,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_cloned(self, self.txn.owner)
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter(self, self.txn.owner)
     }
 
     /// Iterate all the keys in the index.
-    ///
-    /// Clones the keys and provides them by-value. To iterate without cloning, see
-    /// [`Self::for_each`].
-    pub fn iter_keys_cloned(&self) -> impl Iterator<Item = D::Key>
+    pub fn keys(&self) -> impl Iterator<Item = &D::Key>
     where
-        D::Key: Clone,
+        D: 'store,
+        B: 'store,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_keys_cloned(self, self.txn.owner)
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::keys(self, self.txn.owner)
     }
 
     /// Iterate all the values in the base table.
-    ///
-    /// Clones values and provides them by-value. To iterate without cloning, see
-    /// [`Self::for_each`].
-    pub fn iter_values_cloned(&self) -> impl Iterator<Item = B::Value>
+    pub fn values(&self) -> impl Iterator<Item = &B::Value>
     where
-        B::Value: Clone,
+        D: 'store,
+        B: 'store,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_values_cloned(self, self.txn.owner)
-    }
-
-    /// Iterate all the keys in the index and value in the base table.
-    ///
-    /// We're not able to make this an iterator because we have to ensure that the references do
-    /// not outlive our lock on the store. For a (cloning) iterator see [`Self::iter_cloned`].
-    pub fn for_each(&'a self, f: impl FnMut(&D::Key, &B::Value)) {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::for_each(self, f, self.txn.owner)
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::values(self, self.txn.owner)
     }
 
     /// Iterate all the key/value pairs in a table. Values are mutable.
@@ -443,24 +420,28 @@ impl<
 /// SAFETY: `D` and `B` must describe different tables (this is enforced by the macros, but possible
 /// to violate if building a schema by hand).
 pub struct KvTableRoTransactionalIndex<
-    'a,
+    'guard: 'tx,
+    'tx,
     TableStorage: schema::GeneratedStorage,
     D: IndexDesc<Storage = TableStorage, BaseTable = B>,
     B: TableDesc<Storage = TableStorage>,
 > {
-    pub(crate) txn: &'a RoTransaction<'a, TableStorage>,
+    pub(crate) txn: &'tx RoTransaction<'guard, TableStorage>,
     pub(crate) index: PhantomData<D>,
     pub(crate) base: PhantomData<B>,
 }
 
 impl<
-    'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
-    B: TableDesc<Storage = TableStorage> + 'a,
-> Ops<'a, TableStorage> for &'a KvTableRoTransactionalIndex<'a, TableStorage, D, B>
+    'store: 'guard,
+    'guard: 'tx,
+    'tx: 'r,
+    'r,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+> Ops<'store, TableStorage> for &'r KvTableRoTransactionalIndex<'guard, 'tx, TableStorage, D, B>
 {
-    type ReadLock = RefReadGuard<'a, Storage<TableStorage>>;
+    type ReadLock = RefReadGuard<'r, 'guard, Storage<TableStorage>>;
 
     fn read_lock(self) -> Self::ReadLock {
         RefReadGuard(&self.txn.guard)
@@ -468,35 +449,40 @@ impl<
 }
 
 impl<
-    'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
-    B: TableDesc<Storage = TableStorage> + 'a,
-> IndexedOps<'a, TableStorage, D, B> for &'a KvTableRoTransactionalIndex<'a, TableStorage, D, B>
+    'store: 'guard,
+    'guard: 'tx,
+    'tx,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+> IndexedOps<'store, TableStorage, D, B>
+    for &KvTableRoTransactionalIndex<'guard, 'tx, TableStorage, D, B>
 {
 }
 
 impl<
-    'a,
-    TableStorage: schema::GeneratedStorage,
+    'store: 'guard,
+    'guard: 'tx,
+    'tx,
+    TableStorage: schema::GeneratedStorage + 'store,
     D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
     B: TableDesc<Storage = TableStorage>,
-> KvTableRoTransactionalIndex<'a, TableStorage, D, B>
+> KvTableRoTransactionalIndex<'guard, 'tx, TableStorage, D, B>
 {
     /// The number of key/value pairs in the base table.
-    pub fn len(&'a self) -> usize {
+    pub fn len(&self) -> usize {
         <&Self as IndexedOps<'_, TableStorage, D, B>>::len(self)
     }
 
     /// True if the table is empty.
-    pub fn is_empty(&'a self) -> bool {
+    pub fn is_empty(&self) -> bool {
         <&Self as IndexedOps<'_, TableStorage, D, B>>::is_empty(self)
     }
 
     /// Get a row of the table from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<Q>(&'a self, key: &Q) -> Option<B::Value>
+    pub fn get<Q>(&self, key: &Q) -> Option<B::Value>
     where
         B::Value: Clone,
         D::Key: Borrow<Q>,
@@ -508,7 +494,7 @@ impl<
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&'a self, key: &Q, f: impl FnOnce(&B::Value) -> T) -> Option<T>
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&B::Value) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -517,45 +503,30 @@ impl<
     }
 
     /// Iterate all the keys in the index and value in the base table.
-    ///
-    /// Clones both keys and values (but not the intermediate keys) and provides them by-value. To
-    /// iterate without cloning, see [`Self::for_each`].
-    pub fn iter_cloned(&'a self) -> impl Iterator<Item = (D::Key, B::Value)>
+    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &B::Value)>
     where
-        D::Key: Clone,
-        B::Value: Clone,
+        D: 'store,
+        B: 'store,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_cloned(self, self.txn.owner)
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter(self, self.txn.owner)
     }
 
     /// Iterate all the keys in the index.
-    ///
-    /// Clones the keys and provides them by-value. To iterate without cloning, see
-    /// [`Self::for_each`].
-    pub fn iter_keys_cloned(&'a self) -> impl Iterator<Item = D::Key>
+    pub fn keys(&self) -> impl Iterator<Item = &D::Key>
     where
-        D::Key: Clone,
+        D: 'store,
+        B: 'store,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_keys_cloned(self, self.txn.owner)
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::keys(self, self.txn.owner)
     }
 
     /// Iterate all the values in the base table.
-    ///
-    /// Clones values and provides them by-value. To iterate without cloning, see
-    /// [`Self::for_each`].
-    pub fn iter_values_cloned(&'a self) -> impl Iterator<Item = B::Value>
+    pub fn values(&self) -> impl Iterator<Item = &B::Value>
     where
-        B::Value: Clone,
+        D: 'store,
+        B: 'store,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_values_cloned(self, self.txn.owner)
-    }
-
-    /// Iterate all the keys in the index and value in the base table.
-    ///
-    /// We're not able to make this an iterator because we have to ensure that the references do
-    /// not outlive our lock on the store. For a (cloning) iterator see [`Self::iter_cloned`].
-    pub fn for_each(&'a self, f: impl FnMut(&D::Key, &B::Value)) {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::for_each(self, f, self.txn.owner)
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::values(self, self.txn.owner)
     }
 }
 
@@ -879,7 +850,7 @@ mod test {
     fn index_iter_empty_on_fresh_store() {
         let store = KvStore::new();
         let index = store.table_by::<index::Users::name>(OWNER);
-        let items: Vec<_> = index.iter_cloned().collect();
+        let items: Vec<_> = index.iter().collect();
         assert!(items.is_empty());
     }
 
@@ -889,7 +860,7 @@ mod test {
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         let items: Vec<_> = store
             .table_by::<index::Users::name>(OWNER)
-            .iter_cloned()
+            .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
         assert_eq!(items, vec![("Alice".to_owned(), row("Alice"))]);
@@ -902,7 +873,7 @@ mod test {
         store.table::<Users>(OWNER).insert(2, row("Bob"));
         let mut items: Vec<_> = store
             .table_by::<index::Users::name>(OWNER)
-            .iter_cloned()
+            .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
         items.sort_by_key(|(k, _)| k.clone());
@@ -918,10 +889,9 @@ mod test {
     #[test]
     fn index_iter_keys_cloned_empty() {
         let store = KvStore::new();
-        let keys: Vec<_> = store
-            .table_by::<index::Users::name>(OWNER)
-            .iter_keys_cloned()
-            .collect();
+        let table = store.table_by::<index::Users::name>(OWNER);
+
+        let keys: Vec<_> = table.keys().collect();
         assert!(keys.is_empty());
     }
 
@@ -930,21 +900,18 @@ mod test {
         let store = KvStore::new();
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         store.table::<Users>(OWNER).insert(2, row("Bob"));
-        let mut keys: Vec<_> = store
-            .table_by::<index::Users::name>(OWNER)
-            .iter_keys_cloned()
-            .collect();
+
+        let table = store.table_by::<index::Users::name>(OWNER);
+        let mut keys: Vec<_> = table.keys().collect();
         keys.sort();
-        assert_eq!(keys, vec!["Alice".to_owned(), "Bob".to_owned()]);
+        assert_eq!(keys, vec!["Alice", "Bob"]);
     }
 
     #[test]
     fn index_iter_values_cloned_empty() {
         let store = KvStore::new();
-        let values: Vec<_> = store
-            .table_by::<index::Users::name>(OWNER)
-            .iter_values_cloned()
-            .collect();
+        let table = store.table_by::<index::Users::name>(OWNER);
+        let values: Vec<_> = table.values().collect();
         assert!(values.is_empty());
     }
 
@@ -953,12 +920,10 @@ mod test {
         let store = KvStore::new();
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         store.table::<Users>(OWNER).insert(2, row("Bob"));
-        let mut values: Vec<_> = store
-            .table_by::<index::Users::name>(OWNER)
-            .iter_values_cloned()
-            .collect();
+        let table = store.table_by::<index::Users::name>(OWNER);
+        let mut values: Vec<_> = table.values().collect();
         values.sort_by_key(|r| r.name.clone());
-        assert_eq!(values, vec![row("Alice"), row("Bob")]);
+        assert_eq!(values, vec![&row("Alice"), &row("Bob")]);
     }
 
     #[test]
@@ -966,7 +931,7 @@ mod test {
         let store = KvStore::new();
         let index = store.table_by::<index::Users::name>(OWNER);
         let mut count = 0;
-        index.for_each(|_, _| count += 1);
+        index.iter().for_each(|_| count += 1);
         assert_eq!(count, 0);
     }
 
@@ -976,7 +941,9 @@ mod test {
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         let index = store.table_by::<index::Users::name>(OWNER);
         let mut items: Vec<_> = Vec::new();
-        index.for_each(|k, v| items.push((k.clone(), v.clone())));
+        index
+            .iter()
+            .for_each(|(k, v)| items.push((k.clone(), v.clone())));
         assert_eq!(items, vec![("Alice".to_owned(), row("Alice"))]);
     }
 
@@ -987,7 +954,9 @@ mod test {
         store.table::<Users>(OWNER).insert(2, row("Bob"));
         let index = store.table_by::<index::Users::name>(OWNER);
         let mut items: Vec<_> = Vec::new();
-        index.for_each(|k, v| items.push((k.clone(), v.clone())));
+        index
+            .iter()
+            .for_each(|(k, v)| items.push((k.clone(), v.clone())));
         items.sort_by_key(|(k, _)| k.clone());
         assert_eq!(
             items,
@@ -1623,13 +1592,15 @@ mod test_transactional_index {
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         store.table::<Users>(OWNER).insert(2, row("Bob"));
         let txn = store.begin_ro_transaction(OWNER);
-        let mut rows: Vec<_> = txn.table_by::<index::Users::name>().iter_cloned().collect();
+
+        let table = txn.table_by::<index::Users::name>();
+        let mut rows: Vec<_> = table.iter().collect();
         rows.sort_by(|a, b| a.0.cmp(&b.0));
         assert_eq!(
             rows,
             vec![
-                ("Alice".to_owned(), row("Alice")),
-                ("Bob".to_owned(), row("Bob")),
+                (&"Alice".to_owned(), &row("Alice")),
+                (&"Bob".to_owned(), &row("Bob"))
             ]
         );
     }
@@ -1642,7 +1613,8 @@ mod test_transactional_index {
         let txn = store.begin_ro_transaction(OWNER);
         let mut names: Vec<String> = Vec::new();
         txn.table_by::<index::Users::name>()
-            .for_each(|k, _| names.push(k.clone()));
+            .iter()
+            .for_each(|(k, _)| names.push(k.clone()));
         names.sort();
         assert_eq!(names, vec!["Alice".to_owned(), "Bob".to_owned()]);
     }

--- a/ts_kv_store/src/index.rs
+++ b/ts_kv_store/src/index.rs
@@ -1,0 +1,1681 @@
+use std::{borrow::Borrow, hash::Hash, marker::PhantomData};
+
+use crate::{
+    KvStore, Owner, RefReadGuard, RefWriteGuard, RefWriteGuardMut, Result, RoTransaction,
+    Transaction,
+    operations::{IndexedOps, IndexedOpsMut, Ops, OpsMut},
+    schema::{self, IndexDesc, TableDesc},
+    storage::Storage,
+};
+
+/// An abstraction for operating on a table of key/values pairs via an index.
+///
+/// `KvTableIndex` has no transactional semantics and only exists as a convenience for accessing
+/// tabular data.
+///
+/// `D` describes the index table.
+/// `B` describes the base table.
+///
+/// SAFETY: `D` and `B` must describe different tables (this is enforced by the macros, but possible
+/// to violate if building a schema by hand).
+pub struct KvTableIndex<
+    'a,
+    TableStorage: schema::GeneratedStorage,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B>,
+    B: TableDesc<Storage = TableStorage>,
+> {
+    pub(crate) store: &'a KvStore<TableStorage>,
+    pub(crate) owner: Owner,
+    pub(crate) index: PhantomData<D>,
+    pub(crate) base: PhantomData<B>,
+}
+
+impl<
+    'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+> Ops<'a, TableStorage> for &'a KvTableIndex<'a, TableStorage, D, B>
+{
+    type ReadLock = std::sync::RwLockReadGuard<'a, crate::storage::Storage<TableStorage>>;
+
+    fn read_lock(self) -> Self::ReadLock {
+        self.store.storage.read().unwrap()
+    }
+}
+
+impl<
+    'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+> OpsMut<'a, TableStorage> for &'a KvTableIndex<'a, TableStorage, D, B>
+{
+    type WriteLock = std::sync::RwLockWriteGuard<'a, crate::storage::Storage<TableStorage>>;
+
+    fn write_lock(self) -> Self::WriteLock {
+        self.store.storage.write().unwrap()
+    }
+}
+
+impl<
+    'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+> IndexedOps<'a, TableStorage, D, B> for &'a KvTableIndex<'a, TableStorage, D, B>
+{
+}
+
+impl<
+    'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+> IndexedOpsMut<'a, TableStorage, D, B> for &'a KvTableIndex<'a, TableStorage, D, B>
+{
+}
+
+impl<
+    'a,
+    TableStorage: schema::GeneratedStorage,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+> KvTableIndex<'a, TableStorage, D, B>
+{
+    /// Initialize the base table by setting its owner (indexes don't have an owner).
+    ///
+    /// Calling this function is optional, a table can be used without initialization in which case,
+    /// its owner is set to the owner specifed in the first write.
+    ///
+    /// Returns an error (containing the current owner of the table) if the table has already been
+    /// initialized. In this case, the table will be in a consistent state and can be used as normal.
+    pub fn init(&'a self) -> Result<()> {
+        <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::init(self, self.owner)
+    }
+
+    /// The number of key/value pairs in the base table.
+    pub fn len(&'a self) -> usize {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::len(self)
+    }
+
+    /// True if the table is empty.
+    pub fn is_empty(&'a self) -> bool {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::is_empty(self)
+    }
+
+    /// Clear the base table by removing all its KVs, but preserving ownership.
+    pub fn clear(&'a self) {
+        <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::clear(self, self.owner)
+    }
+
+    /// Get a row of the table from the store by cloning the value.
+    ///
+    /// Returns `None` if there is no value for the specified key.
+    pub fn get<Q>(&'a self, key: &Q) -> Option<B::Value>
+    where
+        B::Value: Clone,
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::get(self, key, self.owner)
+    }
+
+    /// Get immutable access to a row of the table in the store by reference.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn with<Q, T>(&'a self, key: &Q, f: impl FnOnce(&B::Value) -> T) -> Option<T>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::with::<Q, T>(self, key, f, self.owner)
+    }
+
+    /// Insert a value into the table using the base table's key.
+    ///
+    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
+    pub fn insert(&'a self, key: B::Key, value: B::Value) -> Option<B::Value>
+    where
+        B::Key: Clone,
+    {
+        <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::insert(self, key, value, self.owner)
+    }
+
+    /// Get mutable access to a row of the table in the store in the store.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn mutate<Q, T>(&'a self, key: &Q, f: impl FnOnce(&mut B::Value) -> T) -> Option<T>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+        B::Key: Clone,
+    {
+        <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::mutate(self, key, f, self.owner)
+    }
+
+    /// Remove a row from the table.
+    ///
+    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
+    pub fn remove<Q>(&'a self, key: &Q) -> Option<B::Value>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::remove(self, key, self.owner)
+    }
+
+    /// Iterate all the keys in the index and value in the base table.
+    ///
+    /// Clones both keys and values (but not the intermediate keys) and provides them by-value. To
+    /// iterate without cloning, see [`Self::for_each`].
+    pub fn iter_cloned(&'a self) -> impl Iterator<Item = (D::Key, B::Value)>
+    where
+        D::Key: Clone,
+        B::Value: Clone,
+    {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_cloned(self, self.owner)
+    }
+
+    /// Iterate all the keys in the index.
+    ///
+    /// Clones the keys and provides them by-value. To iterate without cloning, see
+    /// [`Self::for_each`].
+    pub fn iter_keys_cloned(&'a self) -> impl Iterator<Item = D::Key>
+    where
+        D::Key: Clone,
+    {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_keys_cloned(self, self.owner)
+    }
+
+    /// Iterate all the values in the base table.
+    ///
+    /// Clones values and provides them by-value. To iterate without cloning, see
+    /// [`Self::for_each`].
+    pub fn iter_values_cloned(&'a self) -> impl Iterator<Item = B::Value>
+    where
+        B::Value: Clone,
+    {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_values_cloned(self, self.owner)
+    }
+
+    /// Iterate all the keys in the index and value in the base table.
+    ///
+    /// We're not able to make this an iterator because we have to ensure that the references do
+    /// not outlive our lock on the store. For a (cloning) iterator see [`Self::iter_cloned`].
+    pub fn for_each(&'a self, f: impl FnMut(&D::Key, &B::Value)) {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::for_each(self, f, self.owner)
+    }
+
+    /// Iterate all the key/value pairs in a table. Values are mutable.
+    pub fn for_each_mut(&'a self, f: impl FnMut(&D::Key, &mut B::Value)) {
+        <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::for_each_mut(self, f, self.owner)
+    }
+}
+
+/// An abstraction for operating on a table of key/values pairs (accessed as part of a transaction) via an index.
+///
+/// `D` describes the index table.
+/// `B` describes the base table.
+///
+/// SAFETY: `D` and `B` must describe different tables (this is enforced by the macros, but possible
+/// to violate if building a schema by hand).
+pub struct KvTableTransactionalIndex<
+    'a,
+    't,
+    TableStorage: schema::GeneratedStorage,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B>,
+    B: TableDesc<Storage = TableStorage>,
+> {
+    pub(crate) txn: &'t mut Transaction<'a, TableStorage>,
+    pub(crate) index: PhantomData<D>,
+    pub(crate) base: PhantomData<B>,
+}
+
+impl<
+    'a,
+    't,
+    's,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
+    B: TableDesc<Storage = TableStorage> + 'a,
+> Ops<'a, TableStorage> for &'s KvTableTransactionalIndex<'a, 't, TableStorage, D, B>
+{
+    type ReadLock = RefWriteGuard<'s, 'a, Storage<TableStorage>>;
+
+    fn read_lock(self) -> Self::ReadLock {
+        RefWriteGuard(&self.txn.guard)
+    }
+}
+
+impl<
+    'a,
+    't,
+    's,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
+    B: TableDesc<Storage = TableStorage> + 'a,
+> OpsMut<'a, TableStorage> for &'s mut KvTableTransactionalIndex<'a, 't, TableStorage, D, B>
+{
+    type WriteLock = RefWriteGuardMut<'s, 'a, Storage<TableStorage>>;
+
+    fn write_lock(self) -> Self::WriteLock {
+        RefWriteGuardMut(&mut self.txn.guard)
+    }
+}
+
+impl<
+    'a,
+    't,
+    's,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
+    B: TableDesc<Storage = TableStorage> + 'a,
+> IndexedOps<'a, TableStorage, D, B> for &'s KvTableTransactionalIndex<'a, 't, TableStorage, D, B>
+{
+}
+
+impl<
+    'a,
+    't,
+    's,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
+    B: TableDesc<Storage = TableStorage> + 'a,
+> IndexedOpsMut<'a, TableStorage, D, B>
+    for &'s mut KvTableTransactionalIndex<'a, 't, TableStorage, D, B>
+{
+}
+
+impl<
+    'a,
+    't,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
+    B: TableDesc<Storage = TableStorage> + 'a,
+> KvTableTransactionalIndex<'a, 't, TableStorage, D, B>
+{
+    /// Initialize the base table by setting its owner (indexes don't have an owner).
+    ///
+    /// Calling this function is optional, a table can be used without initialization in which case,
+    /// its owner is set to the owner specifed in the first write.
+    ///
+    /// Returns an error (containing the current owner of the table) if the table has already been
+    /// initialized. In this case, the table will be in a consistent state and can be used as normal.
+    pub fn init(&mut self) -> Result<()> {
+        <&mut Self as IndexedOpsMut<'_, TableStorage, D, B>>::init(self, self.txn.owner)
+    }
+
+    /// The number of key/value pairs in the base table.
+    pub fn len(&self) -> usize {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::len(self)
+    }
+
+    /// True if the table is empty.
+    pub fn is_empty(&self) -> bool {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::is_empty(self)
+    }
+
+    /// Clear the base table by removing all its KVs, but preserving ownership.
+    pub fn clear(&mut self) {
+        <&mut Self as IndexedOpsMut<'_, TableStorage, D, B>>::clear(self, self.txn.owner)
+    }
+
+    /// Get a row of the table from the store by cloning the value.
+    ///
+    /// Returns `None` if there is no value for the specified key.
+    pub fn get<Q>(&self, key: &Q) -> Option<B::Value>
+    where
+        B::Value: Clone,
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::get::<Q>(self, key, self.txn.owner)
+    }
+
+    /// Get immutable access to a row of the table in the store by reference.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn with<Q, T>(&'t self, key: &Q, f: impl FnOnce(&B::Value) -> T) -> Option<T>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::with::<Q, T>(self, key, f, self.txn.owner)
+    }
+
+    /// Insert a value into the table using the base table's key.
+    ///
+    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
+    pub fn insert(&mut self, key: B::Key, value: B::Value) -> Option<B::Value>
+    where
+        B::Key: Clone,
+    {
+        <&mut Self as IndexedOpsMut<'_, TableStorage, D, B>>::insert(
+            self,
+            key,
+            value,
+            self.txn.owner,
+        )
+    }
+
+    /// Get mutable access to a row of the table in the store in the store.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn mutate<Q, T>(&mut self, key: &Q, f: impl FnOnce(&mut B::Value) -> T) -> Option<T>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+        B::Key: Clone,
+    {
+        <&mut Self as IndexedOpsMut<'_, TableStorage, D, B>>::mutate::<Q, T>(
+            self,
+            key,
+            f,
+            self.txn.owner,
+        )
+    }
+
+    /// Remove a row from the table.
+    ///
+    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<B::Value>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&mut Self as IndexedOpsMut<'_, TableStorage, D, B>>::remove::<Q>(self, key, self.txn.owner)
+    }
+
+    /// Iterate all the keys in the index and value in the base table.
+    ///
+    /// Clones both keys and values (but not the intermediate keys) and provides them by-value. To
+    /// iterate without cloning, see [`Self::for_each`].
+    pub fn iter_cloned(&self) -> impl Iterator<Item = (D::Key, B::Value)>
+    where
+        D::Key: Clone,
+        B::Value: Clone,
+    {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_cloned(self, self.txn.owner)
+    }
+
+    /// Iterate all the keys in the index.
+    ///
+    /// Clones the keys and provides them by-value. To iterate without cloning, see
+    /// [`Self::for_each`].
+    pub fn iter_keys_cloned(&self) -> impl Iterator<Item = D::Key>
+    where
+        D::Key: Clone,
+    {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_keys_cloned(self, self.txn.owner)
+    }
+
+    /// Iterate all the values in the base table.
+    ///
+    /// Clones values and provides them by-value. To iterate without cloning, see
+    /// [`Self::for_each`].
+    pub fn iter_values_cloned(&self) -> impl Iterator<Item = B::Value>
+    where
+        B::Value: Clone,
+    {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_values_cloned(self, self.txn.owner)
+    }
+
+    /// Iterate all the keys in the index and value in the base table.
+    ///
+    /// We're not able to make this an iterator because we have to ensure that the references do
+    /// not outlive our lock on the store. For a (cloning) iterator see [`Self::iter_cloned`].
+    pub fn for_each(&'a self, f: impl FnMut(&D::Key, &B::Value)) {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::for_each(self, f, self.txn.owner)
+    }
+
+    /// Iterate all the key/value pairs in a table. Values are mutable.
+    pub fn for_each_mut(&mut self, f: impl FnMut(&D::Key, &mut B::Value)) {
+        <&mut Self as IndexedOpsMut<'_, TableStorage, D, B>>::for_each_mut(self, f, self.txn.owner)
+    }
+}
+
+/// An abstraction for operating on a table of key/values pairs (accessed as part of a transaction) via an index.
+///
+/// `D` describes the index table.
+/// `B` describes the base table.
+///
+/// SAFETY: `D` and `B` must describe different tables (this is enforced by the macros, but possible
+/// to violate if building a schema by hand).
+pub struct KvTableRoTransactionalIndex<
+    'a,
+    TableStorage: schema::GeneratedStorage,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B>,
+    B: TableDesc<Storage = TableStorage>,
+> {
+    pub(crate) txn: &'a RoTransaction<'a, TableStorage>,
+    pub(crate) index: PhantomData<D>,
+    pub(crate) base: PhantomData<B>,
+}
+
+impl<
+    'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
+    B: TableDesc<Storage = TableStorage> + 'a,
+> Ops<'a, TableStorage> for &'a KvTableRoTransactionalIndex<'a, TableStorage, D, B>
+{
+    type ReadLock = RefReadGuard<'a, Storage<TableStorage>>;
+
+    fn read_lock(self) -> Self::ReadLock {
+        RefReadGuard(&self.txn.guard)
+    }
+}
+
+impl<
+    'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
+    B: TableDesc<Storage = TableStorage> + 'a,
+> IndexedOps<'a, TableStorage, D, B> for &'a KvTableRoTransactionalIndex<'a, TableStorage, D, B>
+{
+}
+
+impl<
+    'a,
+    TableStorage: schema::GeneratedStorage,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+> KvTableRoTransactionalIndex<'a, TableStorage, D, B>
+{
+    /// The number of key/value pairs in the base table.
+    pub fn len(&'a self) -> usize {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::len(self)
+    }
+
+    /// True if the table is empty.
+    pub fn is_empty(&'a self) -> bool {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::is_empty(self)
+    }
+
+    /// Get a row of the table from the store by cloning the value.
+    ///
+    /// Returns `None` if there is no value for the specified key.
+    pub fn get<Q>(&'a self, key: &Q) -> Option<B::Value>
+    where
+        B::Value: Clone,
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::get::<Q>(self, key, self.txn.owner)
+    }
+
+    /// Get immutable access to a row of the table in the store by reference.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn with<Q, T>(&'a self, key: &Q, f: impl FnOnce(&B::Value) -> T) -> Option<T>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::with::<Q, T>(self, key, f, self.txn.owner)
+    }
+
+    /// Iterate all the keys in the index and value in the base table.
+    ///
+    /// Clones both keys and values (but not the intermediate keys) and provides them by-value. To
+    /// iterate without cloning, see [`Self::for_each`].
+    pub fn iter_cloned(&'a self) -> impl Iterator<Item = (D::Key, B::Value)>
+    where
+        D::Key: Clone,
+        B::Value: Clone,
+    {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_cloned(self, self.txn.owner)
+    }
+
+    /// Iterate all the keys in the index.
+    ///
+    /// Clones the keys and provides them by-value. To iterate without cloning, see
+    /// [`Self::for_each`].
+    pub fn iter_keys_cloned(&'a self) -> impl Iterator<Item = D::Key>
+    where
+        D::Key: Clone,
+    {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_keys_cloned(self, self.txn.owner)
+    }
+
+    /// Iterate all the values in the base table.
+    ///
+    /// Clones values and provides them by-value. To iterate without cloning, see
+    /// [`Self::for_each`].
+    pub fn iter_values_cloned(&'a self) -> impl Iterator<Item = B::Value>
+    where
+        B::Value: Clone,
+    {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter_values_cloned(self, self.txn.owner)
+    }
+
+    /// Iterate all the keys in the index and value in the base table.
+    ///
+    /// We're not able to make this an iterator because we have to ensure that the references do
+    /// not outlive our lock on the store. For a (cloning) iterator see [`Self::iter_cloned`].
+    pub fn for_each(&'a self, f: impl FnMut(&D::Key, &B::Value)) {
+        <&Self as IndexedOps<'_, TableStorage, D, B>>::for_each(self, f, self.txn.owner)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{Error, tables};
+
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct Row {
+        pub name: String,
+    }
+
+    fn row(name: &str) -> Row {
+        Row {
+            name: name.to_owned(),
+        }
+    }
+
+    tables!(Users(u32 => Row; index(name: String)));
+
+    const OWNER: &str = "owner";
+    const OTHER: &str = "other";
+
+    #[test]
+    fn index_init_succeeds_on_fresh_table() {
+        let store = KvStore::new();
+        assert!(store.table_by::<index::Users::name>(OWNER).init().is_ok());
+    }
+
+    #[test]
+    fn index_init_second_call_returns_err() {
+        let store = KvStore::new();
+        store.table_by::<index::Users::name>(OWNER).init().unwrap();
+        let err = store
+            .table_by::<index::Users::name>(OWNER)
+            .init()
+            .unwrap_err();
+        assert!(matches!(err, Error::AlreadyInit(o) if o == OWNER));
+    }
+
+    #[test]
+    fn index_init_with_different_owner_returns_err() {
+        let store = KvStore::new();
+        store.table_by::<index::Users::name>(OWNER).init().unwrap();
+        let err = store
+            .table_by::<index::Users::name>(OTHER)
+            .init()
+            .unwrap_err();
+        assert!(matches!(err, Error::AlreadyInit(o) if o == OWNER));
+    }
+
+    #[test]
+    fn index_init_and_base_init_share_owner() {
+        let store = KvStore::new();
+        store.table_by::<index::Users::name>(OWNER).init().unwrap();
+        let err = store.table::<Users>(OWNER).init().unwrap_err();
+        assert!(matches!(err, Error::AlreadyInit(o) if o == OWNER));
+    }
+
+    #[test]
+    fn index_len_is_zero_on_fresh_store() {
+        let store = KvStore::new();
+        assert_eq!(store.table_by::<index::Users::name>(OWNER).len(), 0);
+    }
+
+    #[test]
+    fn index_is_empty_on_fresh_store() {
+        let store = KvStore::new();
+        assert!(store.table_by::<index::Users::name>(OWNER).is_empty());
+    }
+
+    #[test]
+    fn index_len_increases_with_inserts() {
+        let store = KvStore::new();
+        let index = store.table_by::<index::Users::name>(OWNER);
+        index.insert(1, row("Alice"));
+        index.insert(2, row("Bob"));
+        assert_eq!(index.len(), 2);
+    }
+
+    #[test]
+    fn index_is_empty_false_after_insert() {
+        let store = KvStore::new();
+        store
+            .table_by::<index::Users::name>(OWNER)
+            .insert(1, row("Alice"));
+        assert!(!store.table_by::<index::Users::name>(OWNER).is_empty());
+    }
+
+    #[test]
+    fn index_get_returns_none_when_absent() {
+        let store = KvStore::new();
+        assert!(
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Alice")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn index_get_returns_value_after_base_insert() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        let value = store
+            .table_by::<index::Users::name>(OWNER)
+            .get("Alice")
+            .unwrap();
+        assert_eq!(value, row("Alice"));
+    }
+
+    #[test]
+    fn index_get_returns_value_after_index_insert() {
+        let store = KvStore::new();
+        store
+            .table_by::<index::Users::name>(OWNER)
+            .insert(1, row("Alice"));
+        let value = store
+            .table_by::<index::Users::name>(OWNER)
+            .get("Alice")
+            .unwrap();
+        assert_eq!(value, row("Alice"));
+    }
+
+    #[test]
+    fn index_with_returns_none_and_does_not_call_f_when_absent() {
+        let store = KvStore::new();
+        let mut called = false;
+        let result = store
+            .table_by::<index::Users::name>(OWNER)
+            .with("Alice", |_| {
+                called = true;
+            });
+        assert!(result.is_none());
+        assert!(!called);
+    }
+
+    #[test]
+    fn index_with_returns_result_of_f() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        let len = store
+            .table_by::<index::Users::name>(OWNER)
+            .with("Alice", |v| v.name.len());
+        assert_eq!(len, Some(5));
+    }
+
+    #[test]
+    fn index_insert_returns_none_on_first() {
+        let store = KvStore::new();
+        assert!(
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .insert(1, row("Alice"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn index_insert_returns_previous_value_when_overwriting_base_key() {
+        let store = KvStore::new();
+        store
+            .table_by::<index::Users::name>(OWNER)
+            .insert(1, row("Alice"));
+        let old = store
+            .table_by::<index::Users::name>(OWNER)
+            .insert(1, row("Alice"));
+        assert_eq!(old, Some(row("Alice")));
+    }
+
+    #[test]
+    fn index_insert_is_visible_via_base_table() {
+        let store = KvStore::new();
+        store
+            .table_by::<index::Users::name>(OWNER)
+            .insert(1, row("Alice"));
+        let value = store.table::<Users>(OWNER).get(&1).unwrap();
+        assert_eq!(value, row("Alice"));
+    }
+
+    #[test]
+    fn base_insert_is_visible_via_index() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        assert!(
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Alice")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn index_remove_returns_none_when_absent() {
+        let store = KvStore::new();
+        assert!(
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .remove("Alice")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn index_remove_returns_value() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        let value = store.table_by::<index::Users::name>(OWNER).remove("Alice");
+        assert_eq!(value, Some(row("Alice")));
+    }
+
+    #[test]
+    fn index_remove_makes_base_absent() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store.table_by::<index::Users::name>(OWNER).remove("Alice");
+        assert!(store.table::<Users>(OWNER).get(&1).is_none());
+    }
+
+    #[test]
+    fn index_remove_makes_index_absent() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store.table_by::<index::Users::name>(OWNER).remove("Alice");
+        assert!(
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Alice")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn base_remove_makes_index_absent() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store.table::<Users>(OWNER).remove(&1);
+        assert!(
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Alice")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn index_mutate_returns_none_when_absent() {
+        let store = KvStore::new();
+        let result = store
+            .table_by::<index::Users::name>(OWNER)
+            .mutate("Alice", |v| v.name.len());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn index_mutate_modifies_value() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store
+            .table_by::<index::Users::name>(OWNER)
+            .mutate("Alice", |v| v.name.push_str(" Smith"));
+        let value = store.table::<Users>(OWNER).get(&1).unwrap();
+        assert_eq!(value.name, "Alice Smith");
+    }
+
+    #[test]
+    fn index_mutate_updates_index_on_field_change() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store
+            .table_by::<index::Users::name>(OWNER)
+            .mutate("Alice", |v| {
+                v.name = "Charlie".to_owned();
+            });
+        assert!(
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Alice")
+                .is_none()
+        );
+        let value = store
+            .table_by::<index::Users::name>(OWNER)
+            .get("Charlie")
+            .unwrap();
+        assert_eq!(value.name, "Charlie");
+    }
+
+    #[test]
+    fn index_clear_removes_all_rows() {
+        let store = KvStore::new();
+        let index = store.table_by::<index::Users::name>(OWNER);
+        index.insert(1, row("Alice"));
+        index.insert(2, row("Bob"));
+        index.clear();
+        assert!(index.is_empty());
+    }
+
+    #[test]
+    fn index_clear_removes_index_entries() {
+        let store = KvStore::new();
+        let index = store.table_by::<index::Users::name>(OWNER);
+        index.insert(1, row("Alice"));
+        index.clear();
+        assert!(index.get("Alice").is_none());
+    }
+
+    #[test]
+    fn base_clear_removes_index_entries() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store.table::<Users>(OWNER).clear();
+        assert!(
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Alice")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn index_iter_empty_on_fresh_store() {
+        let store = KvStore::new();
+        let index = store.table_by::<index::Users::name>(OWNER);
+        let items: Vec<_> = index.iter_cloned().collect();
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn index_iter_yields_index_key_and_base_value() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        let items: Vec<_> = store
+            .table_by::<index::Users::name>(OWNER)
+            .iter_cloned()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        assert_eq!(items, vec![("Alice".to_owned(), row("Alice"))]);
+    }
+
+    #[test]
+    fn index_iter_yields_all_rows() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store.table::<Users>(OWNER).insert(2, row("Bob"));
+        let mut items: Vec<_> = store
+            .table_by::<index::Users::name>(OWNER)
+            .iter_cloned()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        items.sort_by_key(|(k, _)| k.clone());
+        assert_eq!(
+            items,
+            vec![
+                ("Alice".to_owned(), row("Alice")),
+                ("Bob".to_owned(), row("Bob")),
+            ]
+        );
+    }
+
+    #[test]
+    fn index_iter_keys_cloned_empty() {
+        let store = KvStore::new();
+        let keys: Vec<_> = store
+            .table_by::<index::Users::name>(OWNER)
+            .iter_keys_cloned()
+            .collect();
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn index_iter_keys_cloned_yields_index_keys() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store.table::<Users>(OWNER).insert(2, row("Bob"));
+        let mut keys: Vec<_> = store
+            .table_by::<index::Users::name>(OWNER)
+            .iter_keys_cloned()
+            .collect();
+        keys.sort();
+        assert_eq!(keys, vec!["Alice".to_owned(), "Bob".to_owned()]);
+    }
+
+    #[test]
+    fn index_iter_values_cloned_empty() {
+        let store = KvStore::new();
+        let values: Vec<_> = store
+            .table_by::<index::Users::name>(OWNER)
+            .iter_values_cloned()
+            .collect();
+        assert!(values.is_empty());
+    }
+
+    #[test]
+    fn index_iter_values_cloned_yields_base_values() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store.table::<Users>(OWNER).insert(2, row("Bob"));
+        let mut values: Vec<_> = store
+            .table_by::<index::Users::name>(OWNER)
+            .iter_values_cloned()
+            .collect();
+        values.sort_by_key(|r| r.name.clone());
+        assert_eq!(values, vec![row("Alice"), row("Bob")]);
+    }
+
+    #[test]
+    fn index_for_each_empty_calls_closure_zero_times() {
+        let store = KvStore::new();
+        let index = store.table_by::<index::Users::name>(OWNER);
+        let mut count = 0;
+        index.for_each(|_, _| count += 1);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn index_for_each_yields_index_key_and_base_value() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        let index = store.table_by::<index::Users::name>(OWNER);
+        let mut items: Vec<_> = Vec::new();
+        index.for_each(|k, v| items.push((k.clone(), v.clone())));
+        assert_eq!(items, vec![("Alice".to_owned(), row("Alice"))]);
+    }
+
+    #[test]
+    fn index_for_each_yields_all_rows() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store.table::<Users>(OWNER).insert(2, row("Bob"));
+        let index = store.table_by::<index::Users::name>(OWNER);
+        let mut items: Vec<_> = Vec::new();
+        index.for_each(|k, v| items.push((k.clone(), v.clone())));
+        items.sort_by_key(|(k, _)| k.clone());
+        assert_eq!(
+            items,
+            vec![
+                ("Alice".to_owned(), row("Alice")),
+                ("Bob".to_owned(), row("Bob")),
+            ]
+        );
+    }
+
+    #[test]
+    fn index_for_each_mut_empty_calls_closure_zero_times() {
+        let store = KvStore::new();
+        let index = store.table_by::<index::Users::name>(OWNER);
+        let mut count = 0;
+        index.for_each_mut(|_, _| count += 1);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn index_for_each_mut_modifies_base_values() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        let index = store.table_by::<index::Users::name>(OWNER);
+        index.for_each_mut(|_, v| v.name.push('!'));
+        assert_eq!(store.table::<Users>(OWNER).get(&1), Some(row("Alice!")));
+    }
+
+    #[test]
+    fn table_for_each_mut_updates_index() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store
+            .table::<Users>(OWNER)
+            .for_each_mut(|_, v| v.name = "Charlie".to_owned());
+        assert!(
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Alice")
+                .is_none()
+        );
+        assert_eq!(
+            store.table_by::<index::Users::name>(OWNER).get("Charlie"),
+            Some(row("Charlie"))
+        );
+    }
+
+    #[test]
+    fn index_for_each_mut_updates_index() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store
+            .table_by::<index::Users::name>(OWNER)
+            .for_each_mut(|_, v| v.name = "Charlie".to_owned());
+        assert!(
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Alice")
+                .is_none()
+        );
+        assert_eq!(
+            store.table_by::<index::Users::name>(OWNER).get("Charlie"),
+            Some(row("Charlie"))
+        );
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn index_insert_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.table_by::<index::Users::name>(OWNER).init().unwrap();
+        store
+            .table_by::<index::Users::name>(OTHER)
+            .insert(1, row("Alice"));
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn index_clear_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.table_by::<index::Users::name>(OWNER).init().unwrap();
+        store.table_by::<index::Users::name>(OTHER).clear();
+    }
+}
+
+#[cfg(test)]
+mod test_two_indexes {
+    use crate::tables;
+
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct Person {
+        pub email: String,
+        pub username: Vec<u8>,
+    }
+
+    fn person(email: &str, username: &[u8]) -> Person {
+        Person {
+            email: email.to_owned(),
+            username: username.to_owned(),
+        }
+    }
+
+    tables!(People(u32 => Person; index(email: String); index(username: Vec<u8>)));
+
+    const OWNER: &str = "owner";
+
+    #[test]
+    fn both_indexes_queryable_after_base_insert() {
+        let store = KvStore::new();
+        store
+            .table::<People>(OWNER)
+            .insert(1, person("a@example.com", b"alice"));
+        assert!(
+            store
+                .table_by::<index::People::email>(OWNER)
+                .get("a@example.com")
+                .is_some()
+        );
+        assert!(
+            store
+                .table_by::<index::People::username>(OWNER)
+                .get(b"alice".as_slice())
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn both_indexes_queryable_after_email_index_insert() {
+        let store = KvStore::new();
+        store
+            .table_by::<index::People::email>(OWNER)
+            .insert(1, person("a@example.com", b"alice"));
+        assert_eq!(
+            store
+                .table_by::<index::People::email>(OWNER)
+                .get("a@example.com"),
+            Some(person("a@example.com", b"alice"))
+        );
+        assert_eq!(
+            store
+                .table_by::<index::People::username>(OWNER)
+                .get(b"alice".as_slice()),
+            Some(person("a@example.com", b"alice"))
+        );
+    }
+
+    #[test]
+    fn both_indexes_queryable_after_username_index_insert() {
+        let store = KvStore::new();
+        store
+            .table_by::<index::People::username>(OWNER)
+            .insert(1, person("a@example.com", b"alice"));
+        assert_eq!(
+            store
+                .table_by::<index::People::email>(OWNER)
+                .get("a@example.com"),
+            Some(person("a@example.com", b"alice"))
+        );
+        assert_eq!(
+            store
+                .table_by::<index::People::username>(OWNER)
+                .get(b"alice".as_slice()),
+            Some(person("a@example.com", b"alice"))
+        );
+    }
+
+    #[test]
+    fn each_index_returns_correct_value() {
+        let store = KvStore::new();
+        store
+            .table::<People>(OWNER)
+            .insert(1, person("a@example.com", b"alice"));
+        store
+            .table::<People>(OWNER)
+            .insert(2, person("b@example.com", b"bob"));
+
+        assert_eq!(
+            store
+                .table_by::<index::People::email>(OWNER)
+                .get("a@example.com"),
+            Some(person("a@example.com", b"alice"))
+        );
+        assert_eq!(
+            store
+                .table_by::<index::People::username>(OWNER)
+                .get(b"bob".as_slice()),
+            Some(person("b@example.com", b"bob"))
+        );
+    }
+
+    #[test]
+    fn base_remove_clears_both_indexes() {
+        let store = KvStore::new();
+        store
+            .table::<People>(OWNER)
+            .insert(1, person("a@example.com", b"alice"));
+        store.table::<People>(OWNER).remove(&1);
+        assert!(
+            store
+                .table_by::<index::People::email>(OWNER)
+                .get("a@example.com")
+                .is_none()
+        );
+        assert!(
+            store
+                .table_by::<index::People::username>(OWNER)
+                .get(b"alice".as_slice())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn email_index_remove_clears_both_indexes() {
+        let store = KvStore::new();
+        store
+            .table::<People>(OWNER)
+            .insert(1, person("a@example.com", b"alice"));
+        store
+            .table_by::<index::People::email>(OWNER)
+            .remove("a@example.com");
+        assert!(
+            store
+                .table_by::<index::People::email>(OWNER)
+                .get("a@example.com")
+                .is_none()
+        );
+        assert!(
+            store
+                .table_by::<index::People::username>(OWNER)
+                .get(b"alice".as_slice())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn username_index_remove_clears_both_indexes() {
+        let store = KvStore::new();
+        store
+            .table::<People>(OWNER)
+            .insert(1, person("a@example.com", b"alice"));
+        store
+            .table_by::<index::People::username>(OWNER)
+            .remove(b"alice".as_slice());
+        assert!(
+            store
+                .table_by::<index::People::email>(OWNER)
+                .get("a@example.com")
+                .is_none()
+        );
+        assert!(
+            store
+                .table_by::<index::People::username>(OWNER)
+                .get(b"alice".as_slice())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn index_remove_removes_from_base_table() {
+        let store = KvStore::new();
+        store
+            .table::<People>(OWNER)
+            .insert(1, person("a@example.com", b"alice"));
+        store
+            .table_by::<index::People::email>(OWNER)
+            .remove("a@example.com");
+        assert!(store.table::<People>(OWNER).get(&1).is_none());
+    }
+
+    #[test]
+    fn base_clear_clears_both_indexes() {
+        let store = KvStore::new();
+        store
+            .table::<People>(OWNER)
+            .insert(1, person("a@example.com", b"alice"));
+        store.table::<People>(OWNER).clear();
+        assert!(
+            store
+                .table_by::<index::People::email>(OWNER)
+                .get("a@example.com")
+                .is_none()
+        );
+        assert!(
+            store
+                .table_by::<index::People::username>(OWNER)
+                .get(b"alice".as_slice())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn email_index_clear_clears_both_indexes() {
+        let store = KvStore::new();
+        store
+            .table::<People>(OWNER)
+            .insert(1, person("a@example.com", b"alice"));
+        store.table_by::<index::People::email>(OWNER).clear();
+        assert!(
+            store
+                .table_by::<index::People::email>(OWNER)
+                .get("a@example.com")
+                .is_none()
+        );
+        assert!(
+            store
+                .table_by::<index::People::username>(OWNER)
+                .get(b"alice".as_slice())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn table_for_each_mut_updates_both_indexes() {
+        let store = KvStore::new();
+        store
+            .table::<People>(OWNER)
+            .insert(1, person("a@example.com", b"alice"));
+        store.table::<People>(OWNER).for_each_mut(|_, v| {
+            v.email = "b@example.com".to_owned();
+            v.username = b"bob".to_vec();
+        });
+        assert!(
+            store
+                .table_by::<index::People::email>(OWNER)
+                .get("a@example.com")
+                .is_none()
+        );
+        assert!(
+            store
+                .table_by::<index::People::username>(OWNER)
+                .get(b"alice".as_slice())
+                .is_none()
+        );
+        assert!(
+            store
+                .table_by::<index::People::email>(OWNER)
+                .get("b@example.com")
+                .is_some()
+        );
+        assert!(
+            store
+                .table_by::<index::People::username>(OWNER)
+                .get(b"bob".as_slice())
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn email_index_for_each_mut_updates_both_indexes() {
+        let store = KvStore::new();
+        store
+            .table::<People>(OWNER)
+            .insert(1, person("a@example.com", b"alice"));
+        store
+            .table_by::<index::People::email>(OWNER)
+            .for_each_mut(|_, v| {
+                v.email = "b@example.com".to_owned();
+                v.username = b"bob".to_vec();
+            });
+        assert!(
+            store
+                .table_by::<index::People::email>(OWNER)
+                .get("a@example.com")
+                .is_none()
+        );
+        assert!(
+            store
+                .table_by::<index::People::username>(OWNER)
+                .get(b"alice".as_slice())
+                .is_none()
+        );
+        assert!(
+            store
+                .table_by::<index::People::email>(OWNER)
+                .get("b@example.com")
+                .is_some()
+        );
+        assert!(
+            store
+                .table_by::<index::People::username>(OWNER)
+                .get(b"bob".as_slice())
+                .is_some()
+        );
+    }
+}
+
+#[cfg(test)]
+mod test_transactional_index {
+    use crate::tables;
+
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct Row {
+        pub name: String,
+        pub age: u32,
+    }
+
+    fn row(name: &str) -> Row {
+        Row {
+            name: name.to_owned(),
+            age: 0,
+        }
+    }
+
+    tables!(Users(u32 => Row; index(name: String)));
+
+    const OWNER: &str = "owner";
+    #[cfg(debug_assertions)]
+    const OTHER: &str = "other";
+
+    // Group A: KvTableTransactionalIndex - index maintenance
+
+    #[test]
+    fn txn_index_get_returns_none_when_absent() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
+    }
+
+    #[test]
+    fn txn_index_insert_is_visible_via_index() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table_by::<index::Users::name>().insert(1, row("Alice"));
+        assert_eq!(
+            txn.table_by::<index::Users::name>().get("Alice"),
+            Some(row("Alice"))
+        );
+    }
+
+    #[test]
+    fn txn_index_insert_is_visible_via_base() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table_by::<index::Users::name>().insert(1, row("Alice"));
+        assert_eq!(txn.table::<Users>().get(&1), Some(row("Alice")));
+    }
+
+    #[test]
+    fn txn_index_with_returns_some_after_insert() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table_by::<index::Users::name>().insert(1, row("Alice"));
+        assert_eq!(
+            txn.table_by::<index::Users::name>()
+                .with("Alice", |v| v.name.len()),
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn txn_index_mutate_updates_index_on_field_change() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table_by::<index::Users::name>().insert(1, row("Alice"));
+        txn.table_by::<index::Users::name>()
+            .mutate("Alice", |v| v.name = "Bob".to_owned());
+        assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
+        assert_eq!(
+            txn.table_by::<index::Users::name>().get("Bob"),
+            Some(Row {
+                name: "Bob".to_owned(),
+                age: 0
+            })
+        );
+    }
+
+    #[test]
+    fn txn_index_mutate_non_indexed_field_preserves_index() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table_by::<index::Users::name>().insert(1, row("Alice"));
+        txn.table_by::<index::Users::name>()
+            .mutate("Alice", |v| v.age = 42);
+        assert_eq!(
+            txn.table_by::<index::Users::name>().get("Alice"),
+            Some(Row {
+                name: "Alice".to_owned(),
+                age: 42
+            })
+        );
+    }
+
+    #[test]
+    fn txn_index_remove_removes_from_index() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table_by::<index::Users::name>().insert(1, row("Alice"));
+        txn.table_by::<index::Users::name>().remove("Alice");
+        assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
+    }
+
+    #[test]
+    fn txn_index_remove_removes_from_base() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table_by::<index::Users::name>().insert(1, row("Alice"));
+        txn.table_by::<index::Users::name>().remove("Alice");
+        assert!(txn.table::<Users>().get(&1).is_none());
+    }
+
+    #[test]
+    fn txn_index_clear_removes_from_index() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table_by::<index::Users::name>().insert(1, row("Alice"));
+        txn.table_by::<index::Users::name>().insert(2, row("Bob"));
+        txn.table_by::<index::Users::name>().clear();
+        assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
+        assert!(txn.table_by::<index::Users::name>().get("Bob").is_none());
+    }
+
+    #[test]
+    fn txn_index_for_each_mut_updates_index_on_field_change() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table_by::<index::Users::name>().insert(1, row("Alice"));
+        txn.table_by::<index::Users::name>()
+            .for_each_mut(|_, v| v.name = "Charlie".to_owned());
+        assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
+        assert_eq!(
+            txn.table_by::<index::Users::name>().get("Charlie"),
+            Some(Row {
+                name: "Charlie".to_owned(),
+                age: 0
+            })
+        );
+    }
+
+    // Group B: KvTableTransactional (base table) - index maintenance
+
+    #[test]
+    fn txn_base_insert_updates_index() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Users>().insert(1, row("Alice"));
+        assert_eq!(
+            txn.table_by::<index::Users::name>().get("Alice"),
+            Some(row("Alice"))
+        );
+    }
+
+    #[test]
+    fn txn_base_mutate_updates_index_on_field_change() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Users>().insert(1, row("Alice"));
+        txn.table::<Users>()
+            .mutate(&1, |v| v.name = "Bob".to_owned());
+        assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
+        assert_eq!(
+            txn.table_by::<index::Users::name>().get("Bob"),
+            Some(Row {
+                name: "Bob".to_owned(),
+                age: 0
+            })
+        );
+    }
+
+    #[test]
+    fn txn_base_remove_updates_index() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Users>().insert(1, row("Alice"));
+        txn.table::<Users>().remove(&1);
+        assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
+    }
+
+    #[test]
+    fn txn_base_clear_updates_index() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Users>().insert(1, row("Alice"));
+        txn.table::<Users>().insert(2, row("Bob"));
+        txn.table::<Users>().clear();
+        assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
+        assert!(txn.table_by::<index::Users::name>().get("Bob").is_none());
+    }
+
+    #[test]
+    fn txn_base_for_each_mut_updates_index_on_field_change() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Users>().insert(1, row("Alice"));
+        txn.table::<Users>()
+            .for_each_mut(|_, v| v.name = "Charlie".to_owned());
+        assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
+        assert_eq!(
+            txn.table_by::<index::Users::name>().get("Charlie"),
+            Some(Row {
+                name: "Charlie".to_owned(),
+                age: 0
+            })
+        );
+    }
+
+    // Group C: KvTableRoTransactionalIndex - reads via index in RO transaction
+
+    #[test]
+    fn ro_txn_index_get_returns_none_when_absent() {
+        let store = KvStore::new();
+        let txn = store.begin_ro_transaction(OWNER);
+        assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
+    }
+
+    #[test]
+    fn ro_txn_index_get_returns_value_inserted_before_txn() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        let txn = store.begin_ro_transaction(OWNER);
+        assert_eq!(
+            txn.table_by::<index::Users::name>().get("Alice"),
+            Some(row("Alice"))
+        );
+    }
+
+    #[test]
+    fn ro_txn_index_with_returns_some() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        let txn = store.begin_ro_transaction(OWNER);
+        assert_eq!(
+            txn.table_by::<index::Users::name>()
+                .with("Alice", |v| v.name.len()),
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn ro_txn_index_iter_cloned_yields_rows() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store.table::<Users>(OWNER).insert(2, row("Bob"));
+        let txn = store.begin_ro_transaction(OWNER);
+        let mut rows: Vec<_> = txn.table_by::<index::Users::name>().iter_cloned().collect();
+        rows.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(
+            rows,
+            vec![
+                ("Alice".to_owned(), row("Alice")),
+                ("Bob".to_owned(), row("Bob")),
+            ]
+        );
+    }
+
+    #[test]
+    fn ro_txn_index_for_each_yields_rows() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store.table::<Users>(OWNER).insert(2, row("Bob"));
+        let txn = store.begin_ro_transaction(OWNER);
+        let mut names: Vec<String> = Vec::new();
+        txn.table_by::<index::Users::name>()
+            .for_each(|k, _| names.push(k.clone()));
+        names.sort();
+        assert_eq!(names, vec!["Alice".to_owned(), "Bob".to_owned()]);
+    }
+
+    // Group D: Ownership enforcement
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn txn_index_insert_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).init().unwrap();
+        let mut txn = store.begin_transaction(OTHER);
+        txn.table_by::<index::Users::name>().insert(1, row("Alice"));
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn txn_index_clear_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).init().unwrap();
+        let mut txn = store.begin_transaction(OTHER);
+        txn.table_by::<index::Users::name>().clear();
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn txn_index_for_each_mut_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).init().unwrap();
+        let mut txn = store.begin_transaction(OTHER);
+        txn.table_by::<index::Users::name>().for_each_mut(|_, _| {});
+    }
+}

--- a/ts_kv_store/src/index.rs
+++ b/ts_kv_store/src/index.rs
@@ -145,13 +145,13 @@ impl<
     /// Get mutable access to a row of the table in the store in the store.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn mutate<Q, T>(&'a self, key: &Q, f: impl FnOnce(&mut B::Value) -> T) -> Option<T>
+    pub fn with_mut<Q, T>(&'a self, key: &Q, f: impl FnOnce(&mut B::Value) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
         B::Key: Clone,
     {
-        <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::mutate(self, key, f, self.owner)
+        <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::with_mut(self, key, f, self.owner)
     }
 
     /// Remove a row from the table.
@@ -362,13 +362,13 @@ impl<
     /// Get mutable access to a row of the table in the store in the store.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn mutate<Q, T>(&mut self, key: &Q, f: impl FnOnce(&mut B::Value) -> T) -> Option<T>
+    pub fn with_mut<Q, T>(&mut self, key: &Q, f: impl FnOnce(&mut B::Value) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
         B::Key: Clone,
     {
-        <&mut Self as IndexedOpsMut<'_, TableStorage, D, B>>::mutate::<Q, T>(
+        <&mut Self as IndexedOpsMut<'_, TableStorage, D, B>>::with_mut::<Q, T>(
             self,
             key,
             f,
@@ -806,7 +806,7 @@ mod test {
         let store = KvStore::new();
         let result = store
             .table_by::<index::Users::name>(OWNER)
-            .mutate("Alice", |v| v.name.len());
+            .with_mut("Alice", |v| v.name.len());
         assert!(result.is_none());
     }
 
@@ -816,7 +816,7 @@ mod test {
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         store
             .table_by::<index::Users::name>(OWNER)
-            .mutate("Alice", |v| v.name.push_str(" Smith"));
+            .with_mut("Alice", |v| v.name.push_str(" Smith"));
         let value = store.table::<Users>(OWNER).get(&1).unwrap();
         assert_eq!(value.name, "Alice Smith");
     }
@@ -827,7 +827,7 @@ mod test {
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         store
             .table_by::<index::Users::name>(OWNER)
-            .mutate("Alice", |v| {
+            .with_mut("Alice", |v| {
                 v.name = "Charlie".to_owned();
             });
         assert!(
@@ -1445,7 +1445,7 @@ mod test_transactional_index {
         let mut txn = store.begin_transaction(OWNER);
         txn.table_by::<index::Users::name>().insert(1, row("Alice"));
         txn.table_by::<index::Users::name>()
-            .mutate("Alice", |v| v.name = "Bob".to_owned());
+            .with_mut("Alice", |v| v.name = "Bob".to_owned());
         assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
         assert_eq!(
             txn.table_by::<index::Users::name>().get("Bob"),
@@ -1462,7 +1462,7 @@ mod test_transactional_index {
         let mut txn = store.begin_transaction(OWNER);
         txn.table_by::<index::Users::name>().insert(1, row("Alice"));
         txn.table_by::<index::Users::name>()
-            .mutate("Alice", |v| v.age = 42);
+            .with_mut("Alice", |v| v.age = 42);
         assert_eq!(
             txn.table_by::<index::Users::name>().get("Alice"),
             Some(Row {
@@ -1537,7 +1537,7 @@ mod test_transactional_index {
         let mut txn = store.begin_transaction(OWNER);
         txn.table::<Users>().insert(1, row("Alice"));
         txn.table::<Users>()
-            .mutate(&1, |v| v.name = "Bob".to_owned());
+            .with_mut(&1, |v| v.name = "Bob".to_owned());
         assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
         assert_eq!(
             txn.table_by::<index::Users::name>().get("Bob"),

--- a/ts_kv_store/src/index.rs
+++ b/ts_kv_store/src/index.rs
@@ -1,10 +1,10 @@
-use std::{borrow::Borrow, hash::Hash, marker::PhantomData};
+use std::{borrow::Borrow, hash::Hash};
 
 use crate::{
     KvStore, Owner, RefReadGuard, RefWriteGuard, RefWriteGuardMut, Result, RoTransaction,
     Transaction,
     operations::{IndexedOps, IndexedOpsMut, Ops, OpsMut},
-    schema::{self, IndexDesc, TableDesc},
+    schema::{IndexDesc, TableDesc},
     storage::Storage,
 };
 
@@ -18,73 +18,42 @@ use crate::{
 ///
 /// SAFETY: `D` and `B` must describe different tables (this is enforced by the macros, but possible
 /// to violate if building a schema by hand).
-pub struct KvTableIndex<
-    'store,
-    TableStorage: schema::GeneratedStorage,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B>,
-    B: TableDesc<Storage = TableStorage>,
-> {
-    pub(crate) store: &'store KvStore<TableStorage>,
+pub struct KvTableIndex<'store, D: IndexDesc> {
+    pub(crate) store: &'store KvStore<D::Storage>,
     pub(crate) owner: Owner,
-    pub(crate) index: PhantomData<D>,
-    pub(crate) base: PhantomData<B>,
 }
 
-impl<
-    'store: 'idx,
-    'idx,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> Ops<'store, TableStorage> for &'idx KvTableIndex<'store, TableStorage, D, B>
-{
-    type ReadLock = std::sync::RwLockReadGuard<'idx, crate::storage::Storage<TableStorage>>;
+impl<'idx, D: IndexDesc> Ops for &'idx KvTableIndex<'_, D> {
+    type ReadLock = std::sync::RwLockReadGuard<'idx, Self::Storage>;
+    type Storage = Storage<D::Storage>;
 
     fn read_lock(self) -> Self::ReadLock {
         self.store.storage.read().unwrap()
     }
 }
 
-impl<
-    'store: 'idx,
-    'idx,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> OpsMut<'store, TableStorage> for &'idx KvTableIndex<'store, TableStorage, D, B>
-{
-    type WriteLock = std::sync::RwLockWriteGuard<'idx, crate::storage::Storage<TableStorage>>;
+impl<'idx, D: IndexDesc> OpsMut for &'idx KvTableIndex<'_, D> {
+    type WriteLock = std::sync::RwLockWriteGuard<'idx, Self::StorageMut>;
+    type StorageMut = Storage<D::Storage>;
 
     fn write_lock(self) -> Self::WriteLock {
         self.store.storage.write().unwrap()
     }
 }
 
-impl<
-    'store,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> IndexedOps<'store, TableStorage, D, B> for &KvTableIndex<'store, TableStorage, D, B>
-{
+impl<D: IndexDesc> IndexedOps for &KvTableIndex<'_, D> {
+    type Index = D;
+}
+impl<D: IndexDesc> IndexedOpsMut for &KvTableIndex<'_, D> {
+    type IndexMut = D;
 }
 
-impl<
-    'store,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> IndexedOpsMut<'store, TableStorage, D, B> for &KvTableIndex<'store, TableStorage, D, B>
-{
-}
+type Base<T> = <T as IndexDesc>::BaseTable;
+type BaseKey<T> = <<T as IndexDesc>::BaseTable as TableDesc>::Key;
+type BaseVal<T> = <<T as IndexDesc>::BaseTable as TableDesc>::Value;
+type IVal<T> = <T as TableDesc>::Value;
 
-impl<
-    'store,
-    TableStorage: schema::GeneratedStorage,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> KvTableIndex<'store, TableStorage, D, B>
-{
+impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     /// Initialize the base table by setting its owner (indexes don't have an owner).
     ///
     /// Calling this function is optional, a table can be used without initialization in which case,
@@ -93,110 +62,124 @@ impl<
     /// Returns an error (containing the current owner of the table) if the table has already been
     /// initialized. In this case, the table will be in a consistent state and can be used as normal.
     pub fn init(&self) -> Result<()> {
-        <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::init(self, self.owner)
+        <&Self as IndexedOpsMut>::init(self, self.owner)
     }
 
     /// The number of key/value pairs in the base table.
     pub fn len(&self) -> usize {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::len(self)
+        <&Self as IndexedOps>::len(self)
     }
 
     /// True if the table is empty.
     pub fn is_empty(&self) -> bool {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::is_empty(self)
+        <&Self as IndexedOps>::is_empty(self)
     }
 
     /// Clear the base table by removing all its KVs, but preserving ownership.
-    pub fn clear(&self) {
-        <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::clear(self, self.owner)
+    pub fn clear(&self)
+    where
+        IVal<D>: Eq + Hash,
+    {
+        <&Self as IndexedOpsMut>::clear(self, self.owner)
     }
 
     /// Get a row of the table from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<Q>(&self, key: &Q) -> Option<B::Value>
+    pub fn get<Q>(&self, key: &Q) -> Option<BaseVal<D>>
     where
-        B::Value: Clone,
+        BaseVal<D>: Clone,
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::get(self, key, self.owner)
+        <&Self as IndexedOps>::get(self, key, self.owner)
     }
 
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&B::Value) -> T) -> Option<T>
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseVal<D>) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::with::<Q, T>(self, key, f, self.owner)
+        <&Self as IndexedOps>::with::<Q, T>(self, key, f, self.owner)
     }
 
     /// Insert a value into the table using the base table's key.
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
-    pub fn insert(&self, key: B::Key, value: B::Value) -> Option<B::Value>
+    pub fn insert(&self, key: BaseKey<D>, value: BaseVal<D>) -> Option<BaseVal<D>>
     where
-        B::Key: Clone,
+        <<D as IndexDesc>::BaseTable as TableDesc>::Key: Clone,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::insert(self, key, value, self.owner)
+        <&Self as IndexedOpsMut>::insert(self, key, value, self.owner)
     }
 
     /// Get mutable access to a row of the table in the store in the store.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with_mut<Q, T>(&self, key: &Q, f: impl FnOnce(&mut B::Value) -> T) -> Option<T>
+    pub fn with_mut<Q, T>(&self, key: &Q, f: impl FnOnce(&mut BaseVal<D>) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
-        B::Key: Clone,
+        BaseKey<D>: Clone,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::with_mut(self, key, f, self.owner)
+        <&Self as IndexedOpsMut>::with_mut(self, key, f, self.owner)
     }
 
     /// Remove a row from the table.
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
-    pub fn remove<Q>(&self, key: &Q) -> Option<B::Value>
+    pub fn remove<Q>(&self, key: &Q) -> Option<BaseVal<D>>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::remove(self, key, self.owner)
+        <&Self as IndexedOpsMut>::remove(self, key, self.owner)
     }
 
     /// Iterate all the keys in the index and value in the base table.
-    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &B::Value)>
+    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &BaseVal<D>)>
     where
         D: 'store,
-        B: 'store,
+        Base<D>: 'store,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter(self, self.owner)
+        <&Self as IndexedOps>::iter(self, self.owner)
     }
 
     /// Iterate all the keys in the index.
     pub fn keys(&self) -> impl Iterator<Item = &D::Key>
     where
         D: 'store,
-        B: 'store,
+        Base<D>: 'store,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::keys(self, self.owner)
+        <&Self as IndexedOps>::keys(self, self.owner)
     }
 
     /// Iterate all the values in the base table.
-    pub fn values(&self) -> impl Iterator<Item = &B::Value>
+    pub fn values(&self) -> impl Iterator<Item = &BaseVal<D>>
     where
         D: 'store,
-        B: 'store,
+        Base<D>: 'store,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::values(self, self.owner)
+        <&Self as IndexedOps>::values(self, self.owner)
     }
 
     /// Iterate all the key/value pairs in a table. Values are mutable.
-    pub fn for_each_mut(&self, f: impl FnMut(&D::Key, &mut B::Value)) {
-        <&Self as IndexedOpsMut<'_, TableStorage, D, B>>::for_each_mut(self, f, self.owner)
+    pub fn for_each_mut(&self, f: impl FnMut(&D::Key, &mut BaseVal<D>))
+    where
+        IVal<D>: Eq + Hash,
+    {
+        <&Self as IndexedOpsMut>::for_each_mut(self, f, self.owner)
     }
 }
 
@@ -207,86 +190,37 @@ impl<
 ///
 /// SAFETY: `D` and `B` must describe different tables (this is enforced by the macros, but possible
 /// to violate if building a schema by hand).
-pub struct KvTableTransactionalIndex<
-    'guard: 'tx,
-    'tx,
-    TableStorage: schema::GeneratedStorage,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B>,
-    B: TableDesc<Storage = TableStorage>,
-> {
-    pub(crate) txn: &'tx mut Transaction<'guard, TableStorage>,
-    pub(crate) index: PhantomData<D>,
-    pub(crate) base: PhantomData<B>,
+pub struct KvTableTransactionalIndex<'guard, 'tx, D: IndexDesc> {
+    pub(crate) txn: &'tx mut Transaction<'guard, Storage<D::Storage>>,
 }
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx: 'r,
-    'r,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> Ops<'store, TableStorage> for &'r KvTableTransactionalIndex<'guard, 'tx, TableStorage, D, B>
-{
-    type ReadLock = RefWriteGuard<'r, 'guard, Storage<TableStorage>>;
+impl<'guard, 'tx, 'r, D: IndexDesc> Ops for &'r KvTableTransactionalIndex<'guard, 'tx, D> {
+    type ReadLock = RefWriteGuard<'r, 'guard, Self::Storage>;
+    type Storage = Storage<D::Storage>;
 
     fn read_lock(self) -> Self::ReadLock {
         RefWriteGuard(&self.txn.guard)
     }
 }
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx: 'r,
-    'r,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> OpsMut<'store, TableStorage>
-    for &'r mut KvTableTransactionalIndex<'guard, 'tx, TableStorage, D, B>
-{
-    type WriteLock = RefWriteGuardMut<'r, 'guard, Storage<TableStorage>>;
+impl<'guard, 'tx, 'r, D: IndexDesc> OpsMut for &'r mut KvTableTransactionalIndex<'guard, 'tx, D> {
+    type WriteLock = RefWriteGuardMut<'r, 'guard, Self::StorageMut>;
+    type StorageMut = Storage<D::Storage>;
 
     fn write_lock(self) -> Self::WriteLock {
         RefWriteGuardMut(&mut self.txn.guard)
     }
 }
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> IndexedOps<'store, TableStorage, D, B>
-    for &KvTableTransactionalIndex<'guard, 'tx, TableStorage, D, B>
-{
+impl<'guard, 'tx, D: IndexDesc> IndexedOps for &KvTableTransactionalIndex<'guard, 'tx, D> {
+    type Index = D;
 }
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> IndexedOpsMut<'store, TableStorage, D, B>
-    for &mut KvTableTransactionalIndex<'guard, 'tx, TableStorage, D, B>
-{
+impl<'guard, 'tx, D: IndexDesc> IndexedOpsMut for &mut KvTableTransactionalIndex<'guard, 'tx, D> {
+    type IndexMut = D;
 }
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> KvTableTransactionalIndex<'guard, 'tx, TableStorage, D, B>
-{
+impl<'guard, 'tx, D: IndexDesc> KvTableTransactionalIndex<'guard, 'tx, D> {
     /// Initialize the base table by setting its owner (indexes don't have an owner).
     ///
     /// Calling this function is optional, a table can be used without initialization in which case,
@@ -295,120 +229,123 @@ impl<
     /// Returns an error (containing the current owner of the table) if the table has already been
     /// initialized. In this case, the table will be in a consistent state and can be used as normal.
     pub fn init(&mut self) -> Result<()> {
-        <&mut Self as IndexedOpsMut<'_, TableStorage, D, B>>::init(self, self.txn.owner)
+        <&mut Self as IndexedOpsMut>::init(self, self.txn.owner)
     }
 
     /// The number of key/value pairs in the base table.
     pub fn len(&self) -> usize {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::len(self)
+        <&Self as IndexedOps>::len(self)
     }
 
     /// True if the table is empty.
     pub fn is_empty(&self) -> bool {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::is_empty(self)
+        <&Self as IndexedOps>::is_empty(self)
     }
 
     /// Clear the base table by removing all its KVs, but preserving ownership.
-    pub fn clear(&mut self) {
-        <&mut Self as IndexedOpsMut<'_, TableStorage, D, B>>::clear(self, self.txn.owner)
+    pub fn clear(&mut self)
+    where
+        IVal<D>: Eq + Hash,
+    {
+        <&mut Self as IndexedOpsMut>::clear(self, self.txn.owner)
     }
 
     /// Get a row of the table from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<Q>(&self, key: &Q) -> Option<B::Value>
+    pub fn get<Q>(&self, key: &Q) -> Option<BaseVal<D>>
     where
-        B::Value: Clone,
+        BaseVal<D>: Clone,
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::get::<Q>(self, key, self.txn.owner)
+        <&Self as IndexedOps>::get::<Q>(self, key, self.txn.owner)
     }
 
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&B::Value) -> T) -> Option<T>
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseVal<D>) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::with::<Q, T>(self, key, f, self.txn.owner)
+        <&Self as IndexedOps>::with::<Q, T>(self, key, f, self.txn.owner)
     }
 
     /// Insert a value into the table using the base table's key.
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
-    pub fn insert(&mut self, key: B::Key, value: B::Value) -> Option<B::Value>
+    pub fn insert(&mut self, key: BaseKey<D>, value: BaseVal<D>) -> Option<BaseVal<D>>
     where
-        B::Key: Clone,
+        BaseKey<D>: Clone,
+        IVal<D>: Eq + Hash,
     {
-        <&mut Self as IndexedOpsMut<'_, TableStorage, D, B>>::insert(
-            self,
-            key,
-            value,
-            self.txn.owner,
-        )
+        <&mut Self as IndexedOpsMut>::insert(self, key, value, self.txn.owner)
     }
 
     /// Get mutable access to a row of the table in the store in the store.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with_mut<Q, T>(&mut self, key: &Q, f: impl FnOnce(&mut B::Value) -> T) -> Option<T>
+    pub fn with_mut<Q, T>(&mut self, key: &Q, f: impl FnOnce(&mut BaseVal<D>) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
-        B::Key: Clone,
+        BaseKey<D>: Clone,
+        IVal<D>: Eq + Hash,
     {
-        <&mut Self as IndexedOpsMut<'_, TableStorage, D, B>>::with_mut::<Q, T>(
-            self,
-            key,
-            f,
-            self.txn.owner,
-        )
+        <&mut Self as IndexedOpsMut>::with_mut::<Q, T>(self, key, f, self.txn.owner)
     }
 
     /// Remove a row from the table.
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
-    pub fn remove<Q>(&mut self, key: &Q) -> Option<B::Value>
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<BaseVal<D>>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
+        IVal<D>: Eq + Hash,
     {
-        <&mut Self as IndexedOpsMut<'_, TableStorage, D, B>>::remove::<Q>(self, key, self.txn.owner)
+        <&mut Self as IndexedOpsMut>::remove::<Q>(self, key, self.txn.owner)
     }
 
     /// Iterate all the keys in the index and value in the base table.
-    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &B::Value)>
+    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &BaseVal<D>)>
     where
-        D: 'store,
-        B: 'store,
+        D: 'guard,
+        Base<D>: 'guard,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter(self, self.txn.owner)
+        <&Self as IndexedOps>::iter(self, self.txn.owner)
     }
 
     /// Iterate all the keys in the index.
     pub fn keys(&self) -> impl Iterator<Item = &D::Key>
     where
-        D: 'store,
-        B: 'store,
+        D: 'guard,
+        Base<D>: 'guard,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::keys(self, self.txn.owner)
+        <&Self as IndexedOps>::keys(self, self.txn.owner)
     }
 
     /// Iterate all the values in the base table.
-    pub fn values(&self) -> impl Iterator<Item = &B::Value>
+    pub fn values(&self) -> impl Iterator<Item = &BaseVal<D>>
     where
-        D: 'store,
-        B: 'store,
+        D: 'guard,
+        Base<D>: 'guard,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::values(self, self.txn.owner)
+        <&Self as IndexedOps>::values(self, self.txn.owner)
     }
 
     /// Iterate all the key/value pairs in a table. Values are mutable.
-    pub fn for_each_mut(&mut self, f: impl FnMut(&D::Key, &mut B::Value)) {
-        <&mut Self as IndexedOpsMut<'_, TableStorage, D, B>>::for_each_mut(self, f, self.txn.owner)
+    pub fn for_each_mut(&mut self, f: impl FnMut(&D::Key, &mut BaseVal<D>))
+    where
+        IVal<D>: Eq + Hash,
+    {
+        <&mut Self as IndexedOpsMut>::for_each_mut(self, f, self.txn.owner)
     }
 }
 
@@ -419,114 +356,83 @@ impl<
 ///
 /// SAFETY: `D` and `B` must describe different tables (this is enforced by the macros, but possible
 /// to violate if building a schema by hand).
-pub struct KvTableRoTransactionalIndex<
-    'guard: 'tx,
-    'tx,
-    TableStorage: schema::GeneratedStorage,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B>,
-    B: TableDesc<Storage = TableStorage>,
-> {
-    pub(crate) txn: &'tx RoTransaction<'guard, TableStorage>,
-    pub(crate) index: PhantomData<D>,
-    pub(crate) base: PhantomData<B>,
+pub struct KvTableRoTransactionalIndex<'guard, 'tx, D: IndexDesc> {
+    pub(crate) txn: &'tx RoTransaction<'guard, Storage<D::Storage>>,
 }
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx: 'r,
-    'r,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> Ops<'store, TableStorage> for &'r KvTableRoTransactionalIndex<'guard, 'tx, TableStorage, D, B>
-{
-    type ReadLock = RefReadGuard<'r, 'guard, Storage<TableStorage>>;
+impl<'guard, 'tx, 'r, D: IndexDesc> Ops for &'r KvTableRoTransactionalIndex<'guard, 'tx, D> {
+    type ReadLock = RefReadGuard<'r, 'guard, Self::Storage>;
+    type Storage = Storage<D::Storage>;
 
     fn read_lock(self) -> Self::ReadLock {
         RefReadGuard(&self.txn.guard)
     }
 }
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> IndexedOps<'store, TableStorage, D, B>
-    for &KvTableRoTransactionalIndex<'guard, 'tx, TableStorage, D, B>
-{
+impl<'guard, 'tx, D: IndexDesc> IndexedOps for &KvTableRoTransactionalIndex<'guard, 'tx, D> {
+    type Index = D;
 }
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> KvTableRoTransactionalIndex<'guard, 'tx, TableStorage, D, B>
-{
+impl<'guard, 'tx, D: IndexDesc> KvTableRoTransactionalIndex<'guard, 'tx, D> {
     /// The number of key/value pairs in the base table.
     pub fn len(&self) -> usize {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::len(self)
+        <&Self as IndexedOps>::len(self)
     }
 
     /// True if the table is empty.
     pub fn is_empty(&self) -> bool {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::is_empty(self)
+        <&Self as IndexedOps>::is_empty(self)
     }
 
     /// Get a row of the table from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<Q>(&self, key: &Q) -> Option<B::Value>
+    pub fn get<Q>(&self, key: &Q) -> Option<BaseVal<D>>
     where
-        B::Value: Clone,
+        BaseVal<D>: Clone,
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::get::<Q>(self, key, self.txn.owner)
+        <&Self as IndexedOps>::get::<Q>(self, key, self.txn.owner)
     }
 
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&B::Value) -> T) -> Option<T>
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseVal<D>) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::with::<Q, T>(self, key, f, self.txn.owner)
+        <&Self as IndexedOps>::with::<Q, T>(self, key, f, self.txn.owner)
     }
 
     /// Iterate all the keys in the index and value in the base table.
-    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &B::Value)>
+    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &BaseVal<D>)>
     where
-        D: 'store,
-        B: 'store,
+        D: 'guard,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::iter(self, self.txn.owner)
+        <&Self as IndexedOps>::iter(self, self.txn.owner)
     }
 
     /// Iterate all the keys in the index.
     pub fn keys(&self) -> impl Iterator<Item = &D::Key>
     where
-        D: 'store,
-        B: 'store,
+        D: 'guard,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::keys(self, self.txn.owner)
+        <&Self as IndexedOps>::keys(self, self.txn.owner)
     }
 
     /// Iterate all the values in the base table.
-    pub fn values(&self) -> impl Iterator<Item = &B::Value>
+    pub fn values(&self) -> impl Iterator<Item = &BaseVal<D>>
     where
-        D: 'store,
-        B: 'store,
+        D: 'guard,
+        IVal<D>: Eq + Hash,
     {
-        <&Self as IndexedOps<'_, TableStorage, D, B>>::values(self, self.txn.owner)
+        <&Self as IndexedOps>::values(self, self.txn.owner)
     }
 }
 
@@ -631,10 +537,8 @@ mod test {
     fn index_get_returns_value_after_base_insert() {
         let store = KvStore::new();
         store.table::<Users>(OWNER).insert(1, row("Alice"));
-        let value = store
-            .table_by::<index::Users::name>(OWNER)
-            .get("Alice")
-            .unwrap();
+        let table = store.table_by::<index::Users::name>(OWNER);
+        let value = table.get("Alice").unwrap();
         assert_eq!(value, row("Alice"));
     }
 
@@ -644,10 +548,10 @@ mod test {
         store
             .table_by::<index::Users::name>(OWNER)
             .insert(1, row("Alice"));
-        let value = store
-            .table_by::<index::Users::name>(OWNER)
-            .get("Alice")
-            .unwrap();
+
+        let table = store.table_by::<index::Users::name>(OWNER);
+
+        let value = table.get("Alice").unwrap();
         assert_eq!(value, row("Alice"));
     }
 
@@ -1595,7 +1499,7 @@ mod test_transactional_index {
 
         let table = txn.table_by::<index::Users::name>();
         let mut rows: Vec<_> = table.iter().collect();
-        rows.sort_by(|a, b| a.0.cmp(&b.0));
+        rows.sort_by(|a, b| a.0.cmp(b.0));
         assert_eq!(
             rows,
             vec![

--- a/ts_kv_store/src/iter.rs
+++ b/ts_kv_store/src/iter.rs
@@ -1,0 +1,274 @@
+//! Iterate over a table
+
+use std::{marker::PhantomData, ops::Deref};
+
+use crate::{
+    schema::{self, IndexDesc, TableDesc},
+    storage::Storage,
+};
+
+/// Phantom type to iterate over keys.
+#[doc(hidden)]
+pub struct Keys;
+/// Phantom type to iterate over Values.
+#[doc(hidden)]
+pub struct Values;
+/// Phantom type to iterate over key/value pairs.
+#[doc(hidden)]
+pub struct KeysAndValues;
+
+/// An iterator for a single table (described by the generic parameter `D`) in the KV store.
+///
+/// Clones the key and value as we iterate. This is necessary to avoid returning references which
+/// might outlive the iterator, and thus its lock on the store being dropped.
+///
+/// This is basically just a wrapper for an iterator over the `HashMap` representing the table.
+/// However, we must hold a guard for the `KvStore`'s storage for the lifetime of the iterator.
+pub struct TableIterator<
+    'a,
+    Guard: Deref<Target = Storage<TableStorage>> + 'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: TableDesc<Storage = TableStorage> + 'a,
+    Kind,
+> {
+    /// Guard on the KV store's storage (all of it).
+    guard: Guard,
+    /// An iterator over the `HashMap` representing the table.
+    ///
+    /// Invariants:
+    ///   - `inner.is_some()` once `new` has completed.
+    inner: Option<std::collections::hash_map::Iter<'a, D::Key, D::Value>>,
+    _kind: PhantomData<Kind>,
+}
+
+impl<
+    'a,
+    Guard: Deref<Target = Storage<TableStorage>> + 'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: TableDesc<Storage = TableStorage> + 'a,
+    Kind,
+> TableIterator<'a, Guard, TableStorage, D, Kind>
+{
+    /// Create an iterator over the table described by `D`.
+    pub(crate) fn new(guard: Guard) -> Self {
+        let mut result = TableIterator {
+            guard,
+            inner: None,
+            _kind: PhantomData,
+        };
+        result.inner = Some(inner_iter::<_, _, D>(&result.guard));
+        result
+    }
+
+    fn inner_next(&mut self) -> Option<(&D::Key, &D::Value)> {
+        self.inner.as_mut().unwrap().next()
+    }
+}
+
+impl<
+    'a,
+    Guard: Deref<Target = Storage<TableStorage>> + 'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: TableDesc<Storage = TableStorage> + 'a,
+> Iterator for TableIterator<'a, Guard, TableStorage, D, KeysAndValues>
+where
+    D::Key: Clone,
+    D::Value: Clone,
+{
+    type Item = (D::Key, D::Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Iterate by delegating to the `HashMap` iterator.
+        self.inner_next().map(|(k, v)| (k.clone(), v.clone()))
+    }
+}
+
+impl<
+    'a,
+    Guard: Deref<Target = Storage<TableStorage>> + 'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: TableDesc<Storage = TableStorage> + 'a,
+> Iterator for TableIterator<'a, Guard, TableStorage, D, Keys>
+where
+    D::Key: Clone,
+{
+    type Item = D::Key;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Iterate by delegating to the `HashMap` iterator.
+        self.inner_next().map(|(k, _)| k.clone())
+    }
+}
+
+impl<
+    'a,
+    Guard: Deref<Target = Storage<TableStorage>> + 'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: TableDesc<Storage = TableStorage> + 'a,
+> Iterator for TableIterator<'a, Guard, TableStorage, D, Values>
+where
+    D::Value: Clone,
+{
+    type Item = D::Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Iterate by delegating to the `HashMap` iterator.
+        self.inner_next().map(|(_, v)| v.clone())
+    }
+}
+impl<
+    'a,
+    Guard: Deref<Target = Storage<TableStorage>> + 'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: TableDesc<Storage = TableStorage> + 'a,
+    Kind,
+> Drop for TableIterator<'a, Guard, TableStorage, D, Kind>
+{
+    fn drop(&mut self) {
+        // Ensure that `self.inner` is dropped before `self.guard`.
+        self.inner = None;
+    }
+}
+
+/// An iterator for an indexed table (described by the generic parameter `B`, the index is described
+/// by `D`) in the KV store.
+///
+/// Clones the key and value as we iterate. This is necessary to avoid returning references which
+/// might outlive the iterator, and thus its lock on the store being dropped.
+pub struct IndexIterator<
+    'a,
+    Guard: Deref<Target = Storage<TableStorage>> + 'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B> + 'a,
+    B: TableDesc<Storage = TableStorage>,
+    Kind,
+> {
+    /// Guard on the KV store's storage (all of it).
+    guard: Guard,
+    /// An iterator over the `HashMap` representing the index.
+    ///
+    /// Invariants:
+    ///   - `inner.is_some()` once `new` has completed.
+    inner: Option<std::collections::hash_map::Iter<'a, D::Key, D::Value>>,
+    _kind: PhantomData<Kind>,
+}
+
+impl<
+    'a,
+    Guard: Deref<Target = Storage<TableStorage>> + 'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B> + 'a,
+    B: TableDesc<Storage = TableStorage>,
+    Kind,
+> IndexIterator<'a, Guard, TableStorage, D, B, Kind>
+{
+    /// Create an iterator over the table described by `D` (the index).
+    pub(crate) fn new(guard: Guard) -> Self {
+        let mut result = IndexIterator {
+            guard,
+            inner: None,
+            _kind: PhantomData,
+        };
+        result.inner = Some(inner_iter::<_, _, D>(&result.guard));
+        result
+    }
+}
+
+impl<
+    'a,
+    Guard: Deref<Target = Storage<TableStorage>> + 'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
+    B: TableDesc<Storage = TableStorage>,
+> Iterator for IndexIterator<'a, Guard, TableStorage, D, B, KeysAndValues>
+where
+    D::Key: Clone,
+    B::Value: Clone,
+{
+    type Item = (D::Key, B::Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Iterate by delegating to the `HashMap` iterator.
+        self.inner.as_mut().unwrap().next().and_then(|(k, bk)| {
+            let tables = &self.guard.tables;
+            let base = B::get_table(tables);
+            Some((k.clone(), base.data.get(bk)?.clone()))
+        })
+    }
+}
+
+impl<
+    'a,
+    Guard: Deref<Target = Storage<TableStorage>> + 'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
+    B: TableDesc<Storage = TableStorage>,
+> Iterator for IndexIterator<'a, Guard, TableStorage, D, B, Keys>
+where
+    D::Key: Clone,
+{
+    type Item = D::Key;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Iterate by delegating to the `HashMap` iterator.
+        self.inner.as_mut().unwrap().next().map(|(k, _)| k.clone())
+    }
+}
+
+impl<
+    'a,
+    Guard: Deref<Target = Storage<TableStorage>> + 'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
+    B: TableDesc<Storage = TableStorage>,
+> Iterator for IndexIterator<'a, Guard, TableStorage, D, B, Values>
+where
+    B::Value: Clone,
+{
+    type Item = B::Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Iterate by delegating to the `HashMap` iterator.
+        self.inner.as_mut().unwrap().next().and_then(|(_, bk)| {
+            let tables = &self.guard.tables;
+            let base = B::get_table(tables);
+            Some(base.data.get(bk)?.clone())
+        })
+    }
+}
+
+impl<
+    'a,
+    Guard: Deref<Target = Storage<TableStorage>> + 'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B> + 'a,
+    B: TableDesc<Storage = TableStorage>,
+    Kind,
+> Drop for IndexIterator<'a, Guard, TableStorage, D, B, Kind>
+{
+    fn drop(&mut self) {
+        // Ensure that `self.inner` is dropped before `self.guard`.
+        self.inner = None;
+    }
+}
+
+// Create an iterator over a table's data to use as a base for these iterators.
+fn inner_iter<
+    'a,
+    Guard: Deref<Target = Storage<TableStorage>> + 'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: TableDesc<Storage = TableStorage> + 'a,
+>(
+    guard: &Guard,
+) -> std::collections::hash_map::Iter<'a, D::Key, D::Value> {
+    let tables: *const _ = &guard.tables;
+    // SAFETY: here we're extending the lifetime of the reference to the KV storage to `'a`.
+    // We can't use a raw pointer because we won't be able to use that as input to create an
+    // iterator. To ensure safety we must ensure that `self.guard` outlives `self.inner`. We can
+    // outlive the temporary because guard holds a pointer to the storage and `tables` follows that
+    // pointer (via the `Deref` impl) to the tables field. So even if the temporary is dropped and
+    // `result` is moved, `&result.guard.tables` will point at the same address which is guaranteed
+    // to outlive `'a`.
+    let tables = unsafe { &*tables };
+    D::get_table(tables).data.iter()
+}

--- a/ts_kv_store/src/iter.rs
+++ b/ts_kv_store/src/iter.rs
@@ -1,10 +1,10 @@
 //! Iterate over a table
 
-use std::{marker::PhantomData, ops::Deref};
+use std::{hash::Hash, marker::PhantomData, ops::Deref};
 
 use crate::{
-    schema::{self, IndexDesc, TableDesc},
-    storage::Storage,
+    schema::{IndexDesc, TableDesc},
+    storage::{StorageLike, Table},
 };
 
 /// Phantom type to iterate over keys.
@@ -17,48 +17,41 @@ pub struct Values;
 #[doc(hidden)]
 pub struct KeysAndValues;
 
+type IndexHandle<'guard, D> =
+    &'guard Table<<D as IndexDesc>::BaseTable, <<D as IndexDesc>::BaseTable as TableDesc>::Indexes>;
+
+type TableIter<'guard, D> =
+    std::collections::hash_map::Iter<'guard, <D as TableDesc>::Key, <D as TableDesc>::Value>;
+
 /// An iterator for a single table (described by the generic parameter `D`) in the KV store.
-///
-/// Clones the key and value as we iterate. This is necessary to avoid returning references which
-/// might outlive the iterator, and thus its lock on the store being dropped.
 ///
 /// This is basically just a wrapper for an iterator over the `HashMap` representing the table.
 /// However, we must hold a guard for the `KvStore`'s storage for the lifetime of the iterator.
-pub struct TableIterator<
-    'store: 'guard,
-    'guard,
-    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
-    TableStorage: schema::GeneratedStorage,
-    D: TableDesc<Storage = TableStorage>,
-    Kind,
-> {
+pub struct TableIterator<'guard, Guard, D: TableDesc, Kind> {
     /// Guard on the KV store's storage (all of it).
     guard: Guard,
     /// An iterator over the `HashMap` representing the table.
     ///
     /// Invariants:
     ///   - `inner.is_some()` once `new` has completed.
-    inner: Option<std::collections::hash_map::Iter<'guard, D::Key, D::Value>>,
-    _kind: PhantomData<(Kind, &'store ())>,
+    inner: Option<TableIter<'guard, D>>,
+    _kind: PhantomData<Kind>,
 }
 
-impl<
-    'store: 'guard,
-    'guard,
-    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: TableDesc<Storage = TableStorage> + 'store,
-    Kind,
-> TableIterator<'store, 'guard, Guard, TableStorage, D, Kind>
-{
+impl<'guard, Guard, D: TableDesc, Kind> TableIterator<'guard, Guard, D, Kind> {
     /// Create an iterator over the table described by `D`.
-    pub(crate) fn new(guard: Guard) -> Self {
+    pub(crate) fn new(guard: Guard) -> Self
+    where
+        Guard: Deref + 'guard,
+        <Guard as Deref>::Target: StorageLike<Generated = D::Storage>,
+        D: 'guard,
+    {
         let mut result = TableIterator {
             guard,
             inner: None,
             _kind: PhantomData,
         };
-        result.inner = Some(inner_iter::<_, _, D>(&result.guard));
+        result.inner = Some(inner_iter::<D, Guard>(&result.guard));
         result
     }
 
@@ -67,14 +60,7 @@ impl<
     }
 }
 
-impl<
-    'store: 'guard,
-    'guard,
-    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: TableDesc<Storage = TableStorage> + 'store,
-> Iterator for TableIterator<'store, 'guard, Guard, TableStorage, D, KeysAndValues>
-{
+impl<'guard, Guard, D: TableDesc> Iterator for TableIterator<'guard, Guard, D, KeysAndValues> {
     type Item = (&'guard D::Key, &'guard D::Value);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -83,14 +69,7 @@ impl<
     }
 }
 
-impl<
-    'store: 'guard,
-    'guard,
-    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: TableDesc<Storage = TableStorage> + 'store,
-> Iterator for TableIterator<'store, 'guard, Guard, TableStorage, D, Keys>
-{
+impl<'guard, Guard, D: TableDesc> Iterator for TableIterator<'guard, Guard, D, Keys> {
     type Item = &'guard D::Key;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -99,14 +78,7 @@ impl<
     }
 }
 
-impl<
-    'store: 'guard,
-    'guard,
-    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: TableDesc<Storage = TableStorage> + 'store,
-> Iterator for TableIterator<'store, 'guard, Guard, TableStorage, D, Values>
-{
+impl<'guard, Guard, D: TableDesc> Iterator for TableIterator<'guard, Guard, D, Values> {
     type Item = &'guard D::Value;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -114,147 +86,96 @@ impl<
         self.inner_next().map(|(_, v)| v)
     }
 }
-impl<
-    'store: 'guard,
-    'guard,
-    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
-    TableStorage: schema::GeneratedStorage,
-    D: TableDesc<Storage = TableStorage>,
-    Kind,
-> Drop for TableIterator<'store, 'guard, Guard, TableStorage, D, Kind>
-{
+
+impl<Guard, D: TableDesc, Kind> Drop for TableIterator<'_, Guard, D, Kind> {
     fn drop(&mut self) {
         // Ensure that `self.inner` is dropped before `self.guard`.
         self.inner = None;
     }
 }
 
-/// An iterator for an indexed table (described by the generic parameter `B`, the index is described
-/// by `D`) in the KV store.
-///
-/// Clones the key and value as we iterate. This is necessary to avoid returning references which
-/// might outlive the iterator, and thus its lock on the store being dropped.
-pub struct IndexIterator<
-    'store: 'guard,
-    'guard,
-    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B>,
-    B: TableDesc<Storage = TableStorage>,
-    Kind,
-> where
-    Self: 'guard,
-{
+/// An iterator for an indexed table (described by the generic parameter `D`) in the KV
+/// store.
+pub struct IndexIterator<'guard, Guard, D: IndexDesc, Kind> {
     /// Guard on the KV store's storage (all of it).
     guard: Guard,
     /// An iterator over the `HashMap` representing the index.
     ///
     /// Invariants:
     ///   - `inner.is_some()` once `new` has completed.
-    inner: Option<std::collections::hash_map::Iter<'guard, D::Key, D::Value>>,
-    _kind: PhantomData<(Kind, &'store ())>,
+    inner: Option<(IndexHandle<'guard, D>, TableIter<'guard, D>)>,
+    _kind: PhantomData<Kind>,
 }
 
-impl<
-    'store: 'guard,
-    'guard,
-    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B>,
-    B: TableDesc<Storage = TableStorage>,
-    Kind,
-> IndexIterator<'store, 'guard, Guard, TableStorage, D, B, Kind>
-{
+impl<'guard, Guard, D: IndexDesc, Kind> IndexIterator<'guard, Guard, D, Kind> {
     /// Create an iterator over the table described by `D` (the index).
-    pub(crate) fn new(guard: Guard) -> Self {
+    pub(crate) fn new(guard: Guard) -> Self
+    where
+        Guard: Deref + 'guard,
+        <Guard as Deref>::Target: StorageLike<Generated = D::Storage>,
+        D: 'guard,
+    {
         let mut result = IndexIterator {
             guard,
             inner: None,
             _kind: PhantomData,
         };
-        result.inner = Some(inner_iter::<_, _, D>(&result.guard));
-        result
-    }
 
-    fn get_tables(&self) -> &'guard TableStorage {
-        let tables = &self.guard.tables as *const _;
-        unsafe { &*tables }
+        let base_table = <D::BaseTable as TableDesc>::get_table(result.guard.tables());
+
+        result.inner = Some((
+            // SAFETY: for the same reasoning as `inner_iter`, we're extending the lifetime of this
+            // internal reference to 'guard. This is safe for the same reasons, i.e. we ensure that
+            // guard is dropped first.
+            unsafe { &*(base_table as *const _) },
+            inner_iter::<D, Guard>(&result.guard),
+        ));
+
+        result
     }
 }
 
-impl<
-    'store: 'guard,
-    'guard,
-    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> Iterator for IndexIterator<'store, 'guard, Guard, TableStorage, D, B, KeysAndValues>
+impl<'guard, Guard, D: IndexDesc> Iterator for IndexIterator<'guard, Guard, D, KeysAndValues>
+where
+    D::Value: Hash + Eq,
 {
-    type Item = (&'guard D::Key, &'guard B::Value);
+    type Item = (&'guard D::Key, &'guard <D::BaseTable as TableDesc>::Value);
 
     fn next(&mut self) -> Option<Self::Item> {
         // Iterate by delegating to the `HashMap` iterator.
-        self.inner
-            .as_mut()
-            .unwrap()
-            .next()
-            .and_then(move |(k, bk)| {
-                let tables = self.get_tables();
-                let base = B::get_table(tables);
-                Some((k, base.data.get(bk)?))
-            })
+        let (base, iter) = self.inner.as_mut().unwrap();
+        let (k, bk) = iter.next()?;
+
+        Some((k, base.data.get(bk)?))
     }
 }
 
-impl<
-    'store: 'guard,
-    'guard,
-    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> Iterator for IndexIterator<'store, 'guard, Guard, TableStorage, D, B, Keys>
-{
+impl<'guard, Guard, D: IndexDesc> Iterator for IndexIterator<'guard, Guard, D, Keys> {
     type Item = &'guard D::Key;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Iterate by delegating to the `HashMap` iterator.
-        self.inner.as_mut().unwrap().next().map(|(k, _)| k)
+        let (_, iter) = self.inner.as_mut().unwrap();
+        iter.next().map(|(k, _)| k)
     }
 }
 
-impl<
-    'store: 'guard,
-    'guard,
-    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
-> Iterator for IndexIterator<'store, 'guard, Guard, TableStorage, D, B, Values>
+impl<'guard, Guard, D: IndexDesc> Iterator for IndexIterator<'guard, Guard, D, Values>
+where
+    D::Value: Hash + Eq,
 {
-    type Item = &'guard B::Value;
+    type Item = &'guard <D::BaseTable as TableDesc>::Value;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Iterate by delegating to the `HashMap` iterator.
-        self.inner.as_mut().unwrap().next().and_then(|(_, bk)| {
-            let tables = self.get_tables();
-            let base = B::get_table(tables);
-            base.data.get(bk)
-        })
+        let (base, iter) = self.inner.as_mut().unwrap();
+        let (_, bk) = iter.next()?;
+
+        base.data.get(bk)
     }
 }
 
-impl<
-    'store: 'guard,
-    'guard,
-    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B>,
-    B: TableDesc<Storage = TableStorage>,
-    Kind,
-> Drop for IndexIterator<'store, 'guard, Guard, TableStorage, D, B, Kind>
-{
+impl<Guard, D: IndexDesc, Kind> Drop for IndexIterator<'_, Guard, D, Kind> {
     fn drop(&mut self) {
         // Ensure that `self.inner` is dropped before `self.guard`.
         self.inner = None;
@@ -262,16 +183,15 @@ impl<
 }
 
 // Create an iterator over a table's data to use as a base for these iterators.
-fn inner_iter<
-    'store: 'guard,
-    'guard,
-    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: TableDesc<Storage = TableStorage> + 'store,
->(
+fn inner_iter<'guard, D, Guard>(
     guard: &Guard,
-) -> std::collections::hash_map::Iter<'guard, D::Key, D::Value> {
-    let tables: *const _ = &guard.tables;
+) -> std::collections::hash_map::Iter<'guard, D::Key, D::Value>
+where
+    D: TableDesc + 'guard,
+    Guard: Deref + 'guard,
+    <Guard as Deref>::Target: StorageLike<Generated = D::Storage>,
+{
+    let tables: *const _ = guard.tables();
     // SAFETY: here we're extending the lifetime of the reference to the KV storage to `'guard`.
     // We can't use a raw pointer because we won't be able to use that as input to create an
     // iterator. To ensure safety we must ensure that `self.guard` outlives `self.inner`. We can

--- a/ts_kv_store/src/iter.rs
+++ b/ts_kv_store/src/iter.rs
@@ -25,10 +25,11 @@ pub struct KeysAndValues;
 /// This is basically just a wrapper for an iterator over the `HashMap` representing the table.
 /// However, we must hold a guard for the `KvStore`'s storage for the lifetime of the iterator.
 pub struct TableIterator<
-    'a,
-    Guard: Deref<Target = Storage<TableStorage>> + 'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: TableDesc<Storage = TableStorage> + 'a,
+    'store: 'guard,
+    'guard,
+    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
+    TableStorage: schema::GeneratedStorage,
+    D: TableDesc<Storage = TableStorage>,
     Kind,
 > {
     /// Guard on the KV store's storage (all of it).
@@ -37,17 +38,18 @@ pub struct TableIterator<
     ///
     /// Invariants:
     ///   - `inner.is_some()` once `new` has completed.
-    inner: Option<std::collections::hash_map::Iter<'a, D::Key, D::Value>>,
-    _kind: PhantomData<Kind>,
+    inner: Option<std::collections::hash_map::Iter<'guard, D::Key, D::Value>>,
+    _kind: PhantomData<(Kind, &'store ())>,
 }
 
 impl<
-    'a,
-    Guard: Deref<Target = Storage<TableStorage>> + 'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: TableDesc<Storage = TableStorage> + 'a,
+    'store: 'guard,
+    'guard,
+    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: TableDesc<Storage = TableStorage> + 'store,
     Kind,
-> TableIterator<'a, Guard, TableStorage, D, Kind>
+> TableIterator<'store, 'guard, Guard, TableStorage, D, Kind>
 {
     /// Create an iterator over the table described by `D`.
     pub(crate) fn new(guard: Guard) -> Self {
@@ -60,69 +62,66 @@ impl<
         result
     }
 
-    fn inner_next(&mut self) -> Option<(&D::Key, &D::Value)> {
+    fn inner_next(&mut self) -> Option<(&'guard D::Key, &'guard D::Value)> {
         self.inner.as_mut().unwrap().next()
     }
 }
 
 impl<
-    'a,
-    Guard: Deref<Target = Storage<TableStorage>> + 'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: TableDesc<Storage = TableStorage> + 'a,
-> Iterator for TableIterator<'a, Guard, TableStorage, D, KeysAndValues>
-where
-    D::Key: Clone,
-    D::Value: Clone,
+    'store: 'guard,
+    'guard,
+    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: TableDesc<Storage = TableStorage> + 'store,
+> Iterator for TableIterator<'store, 'guard, Guard, TableStorage, D, KeysAndValues>
 {
-    type Item = (D::Key, D::Value);
+    type Item = (&'guard D::Key, &'guard D::Value);
 
     fn next(&mut self) -> Option<Self::Item> {
         // Iterate by delegating to the `HashMap` iterator.
-        self.inner_next().map(|(k, v)| (k.clone(), v.clone()))
+        self.inner_next()
     }
 }
 
 impl<
-    'a,
-    Guard: Deref<Target = Storage<TableStorage>> + 'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: TableDesc<Storage = TableStorage> + 'a,
-> Iterator for TableIterator<'a, Guard, TableStorage, D, Keys>
-where
-    D::Key: Clone,
+    'store: 'guard,
+    'guard,
+    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: TableDesc<Storage = TableStorage> + 'store,
+> Iterator for TableIterator<'store, 'guard, Guard, TableStorage, D, Keys>
 {
-    type Item = D::Key;
+    type Item = &'guard D::Key;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Iterate by delegating to the `HashMap` iterator.
-        self.inner_next().map(|(k, _)| k.clone())
+        self.inner_next().map(|(k, _)| k)
     }
 }
 
 impl<
-    'a,
-    Guard: Deref<Target = Storage<TableStorage>> + 'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: TableDesc<Storage = TableStorage> + 'a,
-> Iterator for TableIterator<'a, Guard, TableStorage, D, Values>
-where
-    D::Value: Clone,
+    'store: 'guard,
+    'guard,
+    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: TableDesc<Storage = TableStorage> + 'store,
+> Iterator for TableIterator<'store, 'guard, Guard, TableStorage, D, Values>
 {
-    type Item = D::Value;
+    type Item = &'guard D::Value;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Iterate by delegating to the `HashMap` iterator.
-        self.inner_next().map(|(_, v)| v.clone())
+        self.inner_next().map(|(_, v)| v)
     }
 }
 impl<
-    'a,
-    Guard: Deref<Target = Storage<TableStorage>> + 'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: TableDesc<Storage = TableStorage> + 'a,
+    'store: 'guard,
+    'guard,
+    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
+    TableStorage: schema::GeneratedStorage,
+    D: TableDesc<Storage = TableStorage>,
     Kind,
-> Drop for TableIterator<'a, Guard, TableStorage, D, Kind>
+> Drop for TableIterator<'store, 'guard, Guard, TableStorage, D, Kind>
 {
     fn drop(&mut self) {
         // Ensure that `self.inner` is dropped before `self.guard`.
@@ -136,31 +135,35 @@ impl<
 /// Clones the key and value as we iterate. This is necessary to avoid returning references which
 /// might outlive the iterator, and thus its lock on the store being dropped.
 pub struct IndexIterator<
-    'a,
-    Guard: Deref<Target = Storage<TableStorage>> + 'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B> + 'a,
+    'store: 'guard,
+    'guard,
+    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B>,
     B: TableDesc<Storage = TableStorage>,
     Kind,
-> {
+> where
+    Self: 'guard,
+{
     /// Guard on the KV store's storage (all of it).
     guard: Guard,
     /// An iterator over the `HashMap` representing the index.
     ///
     /// Invariants:
     ///   - `inner.is_some()` once `new` has completed.
-    inner: Option<std::collections::hash_map::Iter<'a, D::Key, D::Value>>,
-    _kind: PhantomData<Kind>,
+    inner: Option<std::collections::hash_map::Iter<'guard, D::Key, D::Value>>,
+    _kind: PhantomData<(Kind, &'store ())>,
 }
 
 impl<
-    'a,
-    Guard: Deref<Target = Storage<TableStorage>> + 'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B> + 'a,
+    'store: 'guard,
+    'guard,
+    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B>,
     B: TableDesc<Storage = TableStorage>,
     Kind,
-> IndexIterator<'a, Guard, TableStorage, D, B, Kind>
+> IndexIterator<'store, 'guard, Guard, TableStorage, D, B, Kind>
 {
     /// Create an iterator over the table described by `D` (the index).
     pub(crate) fn new(guard: Guard) -> Self {
@@ -172,79 +175,85 @@ impl<
         result.inner = Some(inner_iter::<_, _, D>(&result.guard));
         result
     }
-}
 
-impl<
-    'a,
-    Guard: Deref<Target = Storage<TableStorage>> + 'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
-    B: TableDesc<Storage = TableStorage>,
-> Iterator for IndexIterator<'a, Guard, TableStorage, D, B, KeysAndValues>
-where
-    D::Key: Clone,
-    B::Value: Clone,
-{
-    type Item = (D::Key, B::Value);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        // Iterate by delegating to the `HashMap` iterator.
-        self.inner.as_mut().unwrap().next().and_then(|(k, bk)| {
-            let tables = &self.guard.tables;
-            let base = B::get_table(tables);
-            Some((k.clone(), base.data.get(bk)?.clone()))
-        })
+    fn get_tables(&self) -> &'guard TableStorage {
+        let tables = &self.guard.tables as *const _;
+        unsafe { &*tables }
     }
 }
 
 impl<
-    'a,
-    Guard: Deref<Target = Storage<TableStorage>> + 'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
+    'store: 'guard,
+    'guard,
+    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
     B: TableDesc<Storage = TableStorage>,
-> Iterator for IndexIterator<'a, Guard, TableStorage, D, B, Keys>
-where
-    D::Key: Clone,
+> Iterator for IndexIterator<'store, 'guard, Guard, TableStorage, D, B, KeysAndValues>
 {
-    type Item = D::Key;
+    type Item = (&'guard D::Key, &'guard B::Value);
 
     fn next(&mut self) -> Option<Self::Item> {
         // Iterate by delegating to the `HashMap` iterator.
-        self.inner.as_mut().unwrap().next().map(|(k, _)| k.clone())
+        self.inner
+            .as_mut()
+            .unwrap()
+            .next()
+            .and_then(move |(k, bk)| {
+                let tables = self.get_tables();
+                let base = B::get_table(tables);
+                Some((k, base.data.get(bk)?))
+            })
     }
 }
 
 impl<
-    'a,
-    Guard: Deref<Target = Storage<TableStorage>> + 'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
+    'store: 'guard,
+    'guard,
+    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
     B: TableDesc<Storage = TableStorage>,
-> Iterator for IndexIterator<'a, Guard, TableStorage, D, B, Values>
-where
-    B::Value: Clone,
+> Iterator for IndexIterator<'store, 'guard, Guard, TableStorage, D, B, Keys>
 {
-    type Item = B::Value;
+    type Item = &'guard D::Key;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Iterate by delegating to the `HashMap` iterator.
+        self.inner.as_mut().unwrap().next().map(|(k, _)| k)
+    }
+}
+
+impl<
+    'store: 'guard,
+    'guard,
+    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+> Iterator for IndexIterator<'store, 'guard, Guard, TableStorage, D, B, Values>
+{
+    type Item = &'guard B::Value;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Iterate by delegating to the `HashMap` iterator.
         self.inner.as_mut().unwrap().next().and_then(|(_, bk)| {
-            let tables = &self.guard.tables;
+            let tables = self.get_tables();
             let base = B::get_table(tables);
-            Some(base.data.get(bk)?.clone())
+            base.data.get(bk)
         })
     }
 }
 
 impl<
-    'a,
-    Guard: Deref<Target = Storage<TableStorage>> + 'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B> + 'a,
+    'store: 'guard,
+    'guard,
+    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B>,
     B: TableDesc<Storage = TableStorage>,
     Kind,
-> Drop for IndexIterator<'a, Guard, TableStorage, D, B, Kind>
+> Drop for IndexIterator<'store, 'guard, Guard, TableStorage, D, B, Kind>
 {
     fn drop(&mut self) {
         // Ensure that `self.inner` is dropped before `self.guard`.
@@ -254,21 +263,22 @@ impl<
 
 // Create an iterator over a table's data to use as a base for these iterators.
 fn inner_iter<
-    'a,
-    Guard: Deref<Target = Storage<TableStorage>> + 'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: TableDesc<Storage = TableStorage> + 'a,
+    'store: 'guard,
+    'guard,
+    Guard: Deref<Target = Storage<TableStorage>> + 'guard,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: TableDesc<Storage = TableStorage> + 'store,
 >(
     guard: &Guard,
-) -> std::collections::hash_map::Iter<'a, D::Key, D::Value> {
+) -> std::collections::hash_map::Iter<'guard, D::Key, D::Value> {
     let tables: *const _ = &guard.tables;
-    // SAFETY: here we're extending the lifetime of the reference to the KV storage to `'a`.
+    // SAFETY: here we're extending the lifetime of the reference to the KV storage to `'guard`.
     // We can't use a raw pointer because we won't be able to use that as input to create an
     // iterator. To ensure safety we must ensure that `self.guard` outlives `self.inner`. We can
     // outlive the temporary because guard holds a pointer to the storage and `tables` follows that
     // pointer (via the `Deref` impl) to the tables field. So even if the temporary is dropped and
     // `result` is moved, `&result.guard.tables` will point at the same address which is guaranteed
-    // to outlive `'a`.
+    // to outlive `'guard`.
     let tables = unsafe { &*tables };
     D::get_table(tables).data.iter()
 }

--- a/ts_kv_store/src/lib.rs
+++ b/ts_kv_store/src/lib.rs
@@ -140,12 +140,12 @@ pub use raw::KvTable;
 pub use transactions::{KvTableRoTransactional, KvTableTransactional, RoTransaction, Transaction};
 
 /// A key-value store. See the crate docs for details. Its schema is described by `TableStorage`.
-pub struct KvStore<TableStorage: schema::GeneratedStorage> {
+pub struct KvStore<TableStorage> {
     /// All data is stored behind the RW lock (see `storage` and `schema` modules).
     storage: RwLock<storage::Storage<TableStorage>>,
 }
 
-impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
+impl<TableStorage> KvStore<TableStorage> {
     #[doc(hidden)]
     /// Constructor intended to be used by macros. Avoid using this and prefer to use the generated
     /// `new` for a specialized `KvStore`.
@@ -154,20 +154,18 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     }
 }
 
-impl<'store: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
-    operations::Ops<'store, TableStorage> for &'r KvStore<TableStorage>
-{
-    type ReadLock = std::sync::RwLockReadGuard<'r, storage::Storage<TableStorage>>;
+impl<'r, TableStorage: schema::GeneratedStorage> operations::Ops for &'r KvStore<TableStorage> {
+    type ReadLock = RwLockReadGuard<'r, storage::Storage<TableStorage>>;
+    type Storage = storage::Storage<TableStorage>;
 
     fn read_lock(self) -> Self::ReadLock {
         self.storage.read().unwrap()
     }
 }
 
-impl<'store: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
-    operations::OpsMut<'store, TableStorage> for &'r KvStore<TableStorage>
-{
-    type WriteLock = std::sync::RwLockWriteGuard<'r, storage::Storage<TableStorage>>;
+impl<'r, TableStorage: schema::GeneratedStorage> operations::OpsMut for &'r KvStore<TableStorage> {
+    type WriteLock = RwLockWriteGuard<'r, storage::Storage<TableStorage>>;
+    type StorageMut = storage::Storage<TableStorage>;
 
     fn write_lock(self) -> Self::WriteLock {
         self.storage.write().unwrap()

--- a/ts_kv_store/src/lib.rs
+++ b/ts_kv_store/src/lib.rs
@@ -1,0 +1,229 @@
+//! # ts-kvstore
+//!
+//! An in-memory, async, concurrent, and strongly-typed KV store for the Rust Tailscale client.
+//!
+//! # Example:
+//!
+//! ```rust
+//! # use ts_kv_store::{Owner, singleton, tables};
+//! # const OWNER: Owner = "owner";
+//! singleton!(foo(u64));
+//! tables!(Nodes(u32 => String));
+//!
+//! pub fn main() {
+//!     let store = KvStore::new();
+//!
+//!     store.insert::<foo>(OWNER, 42);
+//!
+//!     let nodes = store.table::<Nodes>(OWNER);
+//!     nodes.insert(4, "a".to_owned());
+//!     nodes.insert(0, "b".to_owned());
+//!     nodes.insert(10, "c".to_owned());
+//!     nodes.insert(400, "d".to_owned());
+//!
+//!     assert_eq!(nodes.len(), 4);
+//!
+//!     println!(
+//!         "singleton: {}, row 4: {}",
+//!         store.get::<foo>(OWNER).unwrap(),
+//!         nodes.get(&4).unwrap(),
+//!     );
+//! }
+//! ```
+//!
+//! # Concepts
+//!
+//! There are two broad kinds of data which can be stored in a KV store: singleton data and tabular
+//! data. The former are simple key/value pairs, the latter are tables of data where a key identifies
+//! a row in the table. Due to implementation details there are some differences in the APIs for each
+//! kind of data, but they have roughly the same operations available.
+//!
+//! The store is strongly typed. Both singletons and tables must be statically declared and both keys
+//! and values have types from these declarations. Macros for these declations are in the [`schema`]
+//! module. They expand into an empty type for each singleton or table, and trait impls for these
+//! types. The types are then used as type parameters for all operations.
+//!
+//! Each singleton KV pair has its own types. A table has a single key type and single value type
+//! for all rows in the table.
+//!
+//! The data store has raw and transactional APIs. The raw API guarantees that each operation is
+//! atomic, but has no guarantees across multiple operatons. The transactional API groups operations
+//! into transactions which are atomic and serializable. Both singleton and tabular data can be part
+//! of a transaction, and tables and transactions are orthogonal. Transactions may be read/write or
+//! read-only. Transactions don't need to be explicitly committed - the effect is 'commit on drop'
+//! but the implementation is that operations are individually committed.
+//!
+//! All data is owned. An owner is a simple token, its up to the user of the library to decide how
+//! to use these tokens and what rules to follow. Every KV pair has a single owner and can only be
+//! mutated by that owner. Reading data is not protected by ownership. A table has a single owner for
+//! all rows.
+//!
+//! An index is a table in the store that is derived from its base table and provides direct access
+//! to elements in the base table. Indexes are maintained by the store and are atomically updated
+//! when the base table is modified.
+//!
+//! For example, consider a table `Base` which maps `u64` keys to `Foo` values where `Foo` has a
+//! field `bar: Url` (and `bar` is a unique identifier for a `Foo` in `Base`). The schema would look
+//! like `tables!(Base(Base => Foo; index(bar: Url)));` which will create a `Base` table and an
+//! `index::Base::bar` table. The index table can be accessed directly like a normal table, but I
+//! don't recommend it. The key type is `Url` and the value type is `u64`. By using
+//! `store.table_by::<index::Base::bar>(...)` the `Base` table can be accessed as if it were a table
+//! mapping `Url`s to `Foo`s. The index is maintained whenever `Base` is modified (directly or via
+//! any index) by using the `bar` field of the values in `Base`.
+//!
+//! Index fields must uniquely identify a row in the base table. If multiple rows in the base table
+//! have the same key in the index, then behavior is unspecified (might give partial or incorrect
+//! result, might panic, etc.).
+//!
+//! # Async access
+//!
+//! ts-kvstore has a synchronous API and no async functions. It is safe to use it in an async, as
+//! long as there are **no `await` points inside a transaction** (which can lead to degraded
+//! performance or deadlock).
+//!
+//! A global lock is used internally and is held for the duration of a transaction. This is a `std`
+//! `RwLock` and so waiting for it will block the waiting thread (not just the async task). This is
+//! unlikely to be an issue as long as transactions are kept short and don't `await` (which could
+//! cause the task with the lock to yield to another task which might block waiting for that lock).
+//!
+//! # Implementation notes.
+//!
+//! The schema macros are an 'essential' component of the system, not just a convenience. Unfortunately
+//! Rust macros do not have visibility/privacy hygiene, so many internal types and traits are public.
+//! Anything marked as `doc(hidden)` is meant for internal use only and should not be considered
+//! part of the API.
+//!
+//! Part of the work of the macros is to generate an internal storage struct. To ensure an ergonomic
+//! API, the generic [`KvStore`] is wrapped in a local `KvStore` which can be deref-ed to the inner,
+//! generic type. Users of the library should only use the generated type, but see the generic type
+//! for documentation.
+//!
+//! The implementation of storage for tabular data is one HashMap per table, and otherwise
+//! straighforward. For singleton data, we use a single HashMap which maps `TypeId` to `(Owner, SinValue)`.
+//! Where the `TypeId` id the id of the type used to describe the singleton. Values can be
+//! stored in different ways (inline, via an `Arc`, etc.) each of which is a variant of `SinValue`.
+//! The store transparently converts keys and values to their declared types.
+//!
+//! The implementation of the storage operations (`get`, `insert`, etc.) is somewhat shared between
+//! the various types which support them (`KvStore`, the table types, the transaction types, index
+//! types, and transactional index types). These are implemented on traits in the `operations` module.
+//! For ease of use and documentation, the functions are implemented on each concrete type and
+//! delegated to the trait implementations meaning that the traits and impls are an internal
+//! implementation detail.
+
+use std::{
+    ops::{Deref, DerefMut},
+    sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
+
+mod index;
+mod iter;
+mod operations;
+mod raw;
+pub mod schema;
+mod singleton;
+#[doc(hidden)]
+pub mod storage;
+mod transactions;
+
+#[doc(inline)]
+pub use index::KvTableIndex;
+#[doc(inline)]
+pub use iter::{IndexIterator, TableIterator};
+#[doc(inline)]
+pub use raw::KvTable;
+#[doc(inline)]
+pub use transactions::{KvTableRoTransactional, KvTableTransactional, RoTransaction, Transaction};
+
+/// A key-value store. See the crate docs for details. Its schema is described by `TableStorage`.
+pub struct KvStore<TableStorage: schema::GeneratedStorage> {
+    /// All data is stored behind the RW lock (see `storage` and `schema` modules).
+    storage: RwLock<storage::Storage<TableStorage>>,
+}
+
+impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
+    #[doc(hidden)]
+    /// Constructor intended to be used by macros. Avoid using this and prefer to use the generated
+    /// `new` for a specialized `KvStore`.
+    pub fn new_with_storage(storage: RwLock<storage::Storage<TableStorage>>) -> Self {
+        KvStore { storage }
+    }
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage + 'a> operations::Ops<'a, TableStorage>
+    for &'a crate::KvStore<TableStorage>
+{
+    type ReadLock = std::sync::RwLockReadGuard<'a, storage::Storage<TableStorage>>;
+
+    fn read_lock(self) -> Self::ReadLock {
+        self.storage.read().unwrap()
+    }
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage + 'a> operations::OpsMut<'a, TableStorage>
+    for &'a crate::KvStore<TableStorage>
+{
+    type WriteLock = std::sync::RwLockWriteGuard<'a, storage::Storage<TableStorage>>;
+
+    fn write_lock(self) -> Self::WriteLock {
+        self.storage.write().unwrap()
+    }
+}
+
+/// A token indicating ownership of a KV singleton or table. See crate docs for what ownership means
+/// for a store.
+pub type Owner = &'static str;
+
+/// An error from a [`KvStore`].
+// TODO derive(Error)
+#[derive(Debug, Clone)]
+pub enum Error {
+    /// A table was expected to not be initialized, but was by the specifed `Owner`.
+    AlreadyInit(Owner),
+}
+
+/// `Result` alias for a KvStore [`Error`].
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Helper type for using a reference to a [`RwLockWriteGuard`] as a generic argument
+/// with a `Deref` bound. Required because checking trait bounds does not take into account
+/// transitivity of `Deref`.
+struct RefWriteGuard<'r, 'a, T>(&'r RwLockWriteGuard<'a, T>);
+
+impl<'r, 'a, T> Deref for RefWriteGuard<'r, 'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+/// Helper type for using a mut reference to a [`RwLockWriteGuard`] as a generic argument
+/// with `Deref` and `DerefMut` bounds. Required because checking trait bounds does not take into
+/// account transitivity of `Deref`.
+struct RefWriteGuardMut<'r, 'a, T>(&'r mut RwLockWriteGuard<'a, T>);
+
+impl<'r, 'a, T> Deref for RefWriteGuardMut<'r, 'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+impl<'r, 'a, T> DerefMut for RefWriteGuardMut<'r, 'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.deref_mut()
+    }
+}
+/// Helper type for using a reference to a [`RwLockReadGuard`] as a generic argument
+/// with a `Deref` bound. Required because checking trait bounds does not take into account
+/// transitivity of `Deref`.
+struct RefReadGuard<'a, T>(&'a RwLockReadGuard<'a, T>);
+
+impl<'a, T> Deref for RefReadGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}

--- a/ts_kv_store/src/lib.rs
+++ b/ts_kv_store/src/lib.rs
@@ -49,9 +49,13 @@
 //! The data store has raw and transactional APIs. The raw API guarantees that each operation is
 //! atomic, but has no guarantees across multiple operatons. The transactional API groups operations
 //! into transactions which are atomic and serializable. Both singleton and tabular data can be part
-//! of a transaction, and tables and transactions are orthogonal. Transactions may be read/write or
-//! read-only. Transactions don't need to be explicitly committed - the effect is 'commit on drop'
-//! but the implementation is that operations are individually committed.
+//! of a transaction. The `Table` types used for accessing tabular data do not add any transactional
+//! elements. That is, operations on a `Table` created from the main store are not part of a transaction,
+//! and operations on a `Table` created from a transaction are only part of that transacton.
+//!
+//! Transactions may be read/write or read-only. Transactions don't need to be explicitly committed,
+//! the effect is 'commit on drop' and currently operations are committed as they are called (with
+//! no rollback).
 //!
 //! All data is owned. An owner is a simple token, its up to the user of the library to decide how
 //! to use these tokens and what rules to follow. Every KV pair has a single owner and can only be
@@ -64,12 +68,13 @@
 //!
 //! For example, consider a table `Base` which maps `u64` keys to `Foo` values where `Foo` has a
 //! field `bar: Url` (and `bar` is a unique identifier for a `Foo` in `Base`). The schema would look
-//! like `tables!(Base(Base => Foo; index(bar: Url)));` which will create a `Base` table and an
-//! `index::Base::bar` table. The index table can be accessed directly like a normal table, but I
-//! don't recommend it. The key type is `Url` and the value type is `u64`. By using
-//! `store.table_by::<index::Base::bar>(...)` the `Base` table can be accessed as if it were a table
-//! mapping `Url`s to `Foo`s. The index is maintained whenever `Base` is modified (directly or via
-//! any index) by using the `bar` field of the values in `Base`.
+//! like `tables!(Base(u64 => Foo; index(bar: Url)));` which will create a `Base` table and an
+//! `index::Base::bar` table. By using `store.table_by::<index::Base::bar>(...)` the `Base` table
+//! can be accessed as if it were a table mapping `Url`s to `Foo`s. The index is maintained whenever
+//! `Base` is modified (directly or via any index) by using the `bar` field of the values in `Base`.
+//!
+//! The index table can be accessed directly like a normal table (`Url`), but I don't recommend it.
+//! The key type is `Url` and the value type is `u64`.
 //!
 //! Index fields must uniquely identify a row in the base table. If multiple rows in the base table
 //! have the same key in the index, then behavior is unspecified (might give partial or incorrect
@@ -108,8 +113,7 @@
 //! the various types which support them (`KvStore`, the table types, the transaction types, index
 //! types, and transactional index types). These are implemented on traits in the `operations` module.
 //! For ease of use and documentation, the functions are implemented on each concrete type and
-//! delegated to the trait implementations meaning that the traits and impls are an internal
-//! implementation detail.
+//! delegated to the trait implementations. I.e., the traits and impls are an implementation detail.
 
 use std::{
     ops::{Deref, DerefMut},
@@ -151,7 +155,7 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
 }
 
 impl<'a, TableStorage: schema::GeneratedStorage + 'a> operations::Ops<'a, TableStorage>
-    for &'a crate::KvStore<TableStorage>
+    for &'a KvStore<TableStorage>
 {
     type ReadLock = std::sync::RwLockReadGuard<'a, storage::Storage<TableStorage>>;
 
@@ -161,7 +165,7 @@ impl<'a, TableStorage: schema::GeneratedStorage + 'a> operations::Ops<'a, TableS
 }
 
 impl<'a, TableStorage: schema::GeneratedStorage + 'a> operations::OpsMut<'a, TableStorage>
-    for &'a crate::KvStore<TableStorage>
+    for &'a KvStore<TableStorage>
 {
     type WriteLock = std::sync::RwLockWriteGuard<'a, storage::Storage<TableStorage>>;
 

--- a/ts_kv_store/src/lib.rs
+++ b/ts_kv_store/src/lib.rs
@@ -154,20 +154,20 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     }
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage + 'a> operations::Ops<'a, TableStorage>
-    for &'a KvStore<TableStorage>
+impl<'store: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
+    operations::Ops<'store, TableStorage> for &'r KvStore<TableStorage>
 {
-    type ReadLock = std::sync::RwLockReadGuard<'a, storage::Storage<TableStorage>>;
+    type ReadLock = std::sync::RwLockReadGuard<'r, storage::Storage<TableStorage>>;
 
     fn read_lock(self) -> Self::ReadLock {
         self.storage.read().unwrap()
     }
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage + 'a> operations::OpsMut<'a, TableStorage>
-    for &'a KvStore<TableStorage>
+impl<'store: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
+    operations::OpsMut<'store, TableStorage> for &'r KvStore<TableStorage>
 {
-    type WriteLock = std::sync::RwLockWriteGuard<'a, storage::Storage<TableStorage>>;
+    type WriteLock = std::sync::RwLockWriteGuard<'r, storage::Storage<TableStorage>>;
 
     fn write_lock(self) -> Self::WriteLock {
         self.storage.write().unwrap()
@@ -192,9 +192,9 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Helper type for using a reference to a [`RwLockWriteGuard`] as a generic argument
 /// with a `Deref` bound. Required because checking trait bounds does not take into account
 /// transitivity of `Deref`.
-struct RefWriteGuard<'r, 'a, T>(&'r RwLockWriteGuard<'a, T>);
+struct RefWriteGuard<'r, 'inner, T>(&'r RwLockWriteGuard<'inner, T>);
 
-impl<'r, 'a, T> Deref for RefWriteGuard<'r, 'a, T> {
+impl<'r, 'inner, T> Deref for RefWriteGuard<'r, 'inner, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -205,16 +205,16 @@ impl<'r, 'a, T> Deref for RefWriteGuard<'r, 'a, T> {
 /// Helper type for using a mut reference to a [`RwLockWriteGuard`] as a generic argument
 /// with `Deref` and `DerefMut` bounds. Required because checking trait bounds does not take into
 /// account transitivity of `Deref`.
-struct RefWriteGuardMut<'r, 'a, T>(&'r mut RwLockWriteGuard<'a, T>);
+struct RefWriteGuardMut<'r, 'inner, T>(&'r mut RwLockWriteGuard<'inner, T>);
 
-impl<'r, 'a, T> Deref for RefWriteGuardMut<'r, 'a, T> {
+impl<'r, 'inner, T> Deref for RefWriteGuardMut<'r, 'inner, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
         self.0.deref()
     }
 }
-impl<'r, 'a, T> DerefMut for RefWriteGuardMut<'r, 'a, T> {
+impl<'r, 'inner, T> DerefMut for RefWriteGuardMut<'r, 'inner, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.deref_mut()
     }
@@ -222,9 +222,9 @@ impl<'r, 'a, T> DerefMut for RefWriteGuardMut<'r, 'a, T> {
 /// Helper type for using a reference to a [`RwLockReadGuard`] as a generic argument
 /// with a `Deref` bound. Required because checking trait bounds does not take into account
 /// transitivity of `Deref`.
-struct RefReadGuard<'a, T>(&'a RwLockReadGuard<'a, T>);
+struct RefReadGuard<'r, 'inner, T>(&'r RwLockReadGuard<'inner, T>);
 
-impl<'a, T> Deref for RefReadGuard<'a, T> {
+impl<'r, 'inner, T> Deref for RefReadGuard<'r, 'inner, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {

--- a/ts_kv_store/src/operations.rs
+++ b/ts_kv_store/src/operations.rs
@@ -23,13 +23,15 @@ use crate::{
     storage::{SinValue, Storage},
 };
 
-pub(crate) trait Ops<'a, TableStorage: schema::GeneratedStorage + 'a>: Sized {
+pub(crate) trait Ops<'store, TableStorage: schema::GeneratedStorage + 'store>:
+    Sized
+{
     type ReadLock: Deref<Target = Storage<TableStorage>>;
     fn read_lock(self) -> Self::ReadLock;
 }
 
-pub(crate) trait SingletonOps<'a, TableStorage: schema::GeneratedStorage + 'a>:
-    Ops<'a, TableStorage>
+pub(crate) trait SingletonOps<'store, TableStorage: schema::GeneratedStorage + 'store>:
+    Ops<'store, TableStorage>
 {
     fn get<D: schema::Singleton>(self, _owner: Owner) -> Option<D::Value>
     where
@@ -64,10 +66,10 @@ pub(crate) trait SingletonOps<'a, TableStorage: schema::GeneratedStorage + 'a>:
 }
 
 pub(crate) trait TabularOps<
-    'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: schema::TableDesc<Storage = TableStorage> + 'a,
->: Ops<'a, TableStorage>
+    'store,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: schema::TableDesc<Storage = TableStorage>,
+>: Ops<'store, TableStorage>
 {
     fn len(self) -> usize {
         let storage = self.read_lock();
@@ -104,52 +106,45 @@ pub(crate) trait TabularOps<
         Some(f(value))
     }
 
-    fn iter_cloned<'t>(self, _owner: Owner) -> impl Iterator<Item = (D::Key, D::Value)>
+    fn iter<'guard>(self, _owner: Owner) -> impl Iterator<Item = (&'guard D::Key, &'guard D::Value)>
     where
-        D::Key: Clone,
-        D::Value: Clone,
-        Self: 't,
-        'a: 't,
+        Self: 'guard,
+        'store: 'guard,
+        D: 'store,
     {
         let guard = self.read_lock();
-        TableIterator::<'t, Self::ReadLock, TableStorage, D, iter::KeysAndValues>::new(guard)
+        TableIterator::<'store, 'guard, Self::ReadLock, TableStorage, D, iter::KeysAndValues>::new(
+            guard,
+        )
     }
 
-    fn iter_keys_cloned<'t>(self, _owner: Owner) -> impl Iterator<Item = D::Key>
+    fn keys<'guard>(self, _owner: Owner) -> impl Iterator<Item = &'guard D::Key>
     where
-        D::Key: Clone,
-        Self: 't,
-        'a: 't,
+        Self: 'guard,
+        'store: 'guard,
+        D: 'store,
     {
         let guard = self.read_lock();
-        TableIterator::<'t, Self::ReadLock, TableStorage, D, iter::Keys>::new(guard)
+        TableIterator::<'store, 'guard, Self::ReadLock, TableStorage, D, iter::Keys>::new(guard)
     }
 
-    fn iter_values_cloned<'t>(self, _owner: Owner) -> impl Iterator<Item = D::Value>
+    fn values<'guard>(self, _owner: Owner) -> impl Iterator<Item = &'guard D::Value>
     where
-        D::Value: Clone,
-        Self: 't,
-        'a: 't,
+        Self: 'guard,
+        'store: 'guard,
+        D: 'store,
     {
         let guard = self.read_lock();
-        TableIterator::<'t, Self::ReadLock, TableStorage, D, iter::Values>::new(guard)
-    }
-
-    fn for_each(self, mut f: impl FnMut(&D::Key, &D::Value), _owner: Owner) {
-        let storage = self.read_lock();
-        let table = D::get_table(&storage.tables);
-        for (k, v) in &table.data {
-            f(k, v);
-        }
+        TableIterator::<'store, 'guard, Self::ReadLock, TableStorage, D, iter::Values>::new(guard)
     }
 }
 
 pub(crate) trait IndexedOps<
-    'a,
-    TableStorage: schema::GeneratedStorage + 'a,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
-    B: TableDesc<Storage = TableStorage> + 'a,
->: Ops<'a, TableStorage>
+    'store,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+>: Ops<'store, TableStorage>
 {
     fn len(self) -> usize {
         let storage = self.read_lock();
@@ -190,58 +185,52 @@ pub(crate) trait IndexedOps<
         Some(f(value))
     }
 
-    fn iter_cloned<'t>(self, _owner: Owner) -> impl Iterator<Item = (D::Key, B::Value)>
+    fn iter<'guard>(self, _owner: Owner) -> impl Iterator<Item = (&'guard D::Key, &'guard B::Value)>
     where
-        D::Key: Clone,
-        B::Value: Clone,
-        Self: 't,
-        'a: 't,
+        Self: 'guard,
+        'store: 'guard,
+        B: 'store,
+        D: 'store,
     {
         let guard = self.read_lock();
-        IndexIterator::<'t, Self::ReadLock, TableStorage, D, B, iter::KeysAndValues>::new(guard)
+        IndexIterator::<'store, 'guard, Self::ReadLock, TableStorage, D, B, iter::KeysAndValues>::new(guard)
     }
 
-    fn iter_keys_cloned<'t>(self, _owner: Owner) -> impl Iterator<Item = D::Key>
+    fn keys<'guard>(self, _owner: Owner) -> impl Iterator<Item = &'guard D::Key>
     where
-        D::Key: Clone,
-        Self: 't,
-        'a: 't,
+        Self: 'guard,
+        'store: 'guard,
+        B: 'store,
+        D: 'store,
     {
         let guard = self.read_lock();
-        IndexIterator::<'t, Self::ReadLock, TableStorage, D, B, iter::Keys>::new(guard)
+        IndexIterator::<'store, 'guard, Self::ReadLock, TableStorage, D, B, iter::Keys>::new(guard)
     }
 
-    fn iter_values_cloned<'t>(self, _owner: Owner) -> impl Iterator<Item = B::Value>
+    fn values<'guard>(self, _owner: Owner) -> impl Iterator<Item = &'guard B::Value>
     where
-        B::Value: Clone,
-        Self: 't,
-        'a: 't,
+        Self: 'guard,
+        'store: 'guard,
+        B: 'store,
+        D: 'store,
     {
         let guard = self.read_lock();
-        IndexIterator::<'t, Self::ReadLock, TableStorage, D, B, iter::Values>::new(guard)
-    }
-
-    fn for_each(self, mut f: impl FnMut(&D::Key, &B::Value), _owner: Owner) {
-        let storage = self.read_lock();
-        let base = B::get_table(&storage.tables);
-        let index = D::get_table(&storage.tables);
-        for (k, base_key) in &index.data {
-            let Some(v) = base.data.get(base_key) else {
-                continue;
-            };
-            f(k, v);
-        }
+        IndexIterator::<'store, 'guard, Self::ReadLock, TableStorage, D, B, iter::Values>::new(
+            guard,
+        )
     }
 }
 
-pub(crate) trait OpsMut<'a, TableStorage: schema::GeneratedStorage + 'a>: Sized {
+pub(crate) trait OpsMut<'store, TableStorage: schema::GeneratedStorage + 'store>:
+    Sized
+{
     type WriteLock: DerefMut<Target = Storage<TableStorage>>;
 
     fn write_lock(self) -> Self::WriteLock;
 }
 
-pub(crate) trait SingletonOpsMut<'a, 't, TableStorage: schema::GeneratedStorage + 'a>:
-    OpsMut<'a, TableStorage>
+pub(crate) trait SingletonOpsMut<'store, TableStorage: schema::GeneratedStorage + 'store>:
+    OpsMut<'store, TableStorage>
 {
     fn insert<D: schema::Singleton>(self, value: D::ArgValue, owner: Owner) -> Option<D::ArgValue> {
         let mut storage = self.write_lock();
@@ -288,10 +277,10 @@ pub(crate) trait SingletonOpsMut<'a, 't, TableStorage: schema::GeneratedStorage 
 }
 
 pub(crate) trait TabularOpsMut<
-    'a,
-    TableStorage: schema::GeneratedStorage + 'a,
+    'store,
+    TableStorage: schema::GeneratedStorage + 'store,
     D: schema::TableDesc<Storage = TableStorage>,
->: OpsMut<'a, TableStorage>
+>: OpsMut<'store, TableStorage>
 {
     fn init(self, owner: Owner) -> Result<()> {
         let mut storage = self.write_lock();
@@ -368,11 +357,11 @@ pub(crate) trait TabularOpsMut<
 }
 
 pub(crate) trait IndexedOpsMut<
-    'a,
-    TableStorage: schema::GeneratedStorage + 'a,
+    'store,
+    TableStorage: schema::GeneratedStorage + 'store,
     D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
     B: TableDesc<Storage = TableStorage>,
->: OpsMut<'a, TableStorage>
+>: OpsMut<'store, TableStorage>
 {
     fn init(self, owner: Owner) -> Result<()> {
         let mut storage = self.write_lock();

--- a/ts_kv_store/src/operations.rs
+++ b/ts_kv_store/src/operations.rs
@@ -253,7 +253,7 @@ pub(crate) trait SingletonOpsMut<'a, 't, TableStorage: schema::GeneratedStorage 
             .map_singleton_value(|v| D::from_value(v))
     }
 
-    fn mutate<D: schema::MutSingleton, T>(
+    fn with_mut<D: schema::MutSingleton, T>(
         self,
         f: impl FnOnce(&mut D::Value) -> T,
         owner: Owner,
@@ -322,7 +322,7 @@ pub(crate) trait TabularOpsMut<
     }
 
     // TODO if `f` panics then the indexes will be left in an inconsistent state.
-    fn mutate<Q, T>(self, key: &Q, f: impl FnOnce(&mut D::Value) -> T, owner: Owner) -> Option<T>
+    fn with_mut<Q, T>(self, key: &Q, f: impl FnOnce(&mut D::Value) -> T, owner: Owner) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
@@ -405,7 +405,7 @@ pub(crate) trait IndexedOpsMut<
     }
 
     // TODO if `f` panics then the indexes will be left in an inconsistent state.
-    fn mutate<Q, T>(self, key: &Q, f: impl FnOnce(&mut B::Value) -> T, owner: Owner) -> Option<T>
+    fn with_mut<Q, T>(self, key: &Q, f: impl FnOnce(&mut B::Value) -> T, owner: Owner) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,

--- a/ts_kv_store/src/operations.rs
+++ b/ts_kv_store/src/operations.rs
@@ -1,0 +1,474 @@
+//! Generic implementations of the various storage operations.
+//!
+//! The high-level setup is that `Ops` and `OpsMut` abstract access to the underlying storage of the
+//! KvStore. That access might be via a transaction or table or index or direct. The actual functionality
+//! is implemented on subtraits of these: `SingletonOps` and `SingletonOpsMut` for operating on singleton
+//! key/values, `TabularOps` and `TabularOpsMut` for operating on tables of data, and `IndexedOps` and
+//! `IndexedOpsMut` for operating on tables via an index.
+
+#![allow(clippy::wrong_self_convention)]
+
+use std::{
+    any::TypeId,
+    borrow::Borrow,
+    hash::Hash,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
+
+use crate::{
+    IndexIterator, Owner, Result, TableIterator, iter,
+    schema::{self, IndexDesc, IndexStorage, TableDesc},
+    singleton::{OptSingletonValue, assert_owner},
+    storage::{SinValue, Storage},
+};
+
+pub(crate) trait Ops<'a, TableStorage: schema::GeneratedStorage + 'a>: Sized {
+    type ReadLock: Deref<Target = Storage<TableStorage>>;
+    fn read_lock(self) -> Self::ReadLock;
+}
+
+pub(crate) trait SingletonOps<'a, TableStorage: schema::GeneratedStorage + 'a>:
+    Ops<'a, TableStorage>
+{
+    fn get<D: schema::Singleton>(self, _owner: Owner) -> Option<D::Value>
+    where
+        D::Value: Clone,
+    {
+        let storage = self.read_lock();
+        let key = TypeId::of::<D>();
+        storage
+            .get_singleton_value(&key)
+            .map_singleton_value(|v| D::Value::clone(D::from_value_ref(v)))
+    }
+
+    fn get_arc<D: schema::ArcSingleton>(self, _owner: Owner) -> Option<Arc<D::Value>> {
+        let storage = self.read_lock();
+        let key = TypeId::of::<D>();
+        storage
+            .get_singleton_value(&key)
+            .map_singleton_value(|v| D::from_value_arc(v))
+    }
+
+    fn with<D: schema::Singleton, T>(
+        self,
+        f: impl FnOnce(&D::Value) -> T,
+        _owner: Owner,
+    ) -> Option<T> {
+        let storage = self.read_lock();
+        let key = TypeId::of::<D>();
+        storage
+            .get_singleton_value(&key)
+            .map_singleton_value(|v| f(D::from_value_ref(v)))
+    }
+}
+
+pub(crate) trait TabularOps<
+    'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: schema::TableDesc<Storage = TableStorage> + 'a,
+>: Ops<'a, TableStorage>
+{
+    fn len(self) -> usize {
+        let storage = self.read_lock();
+        let table = D::get_table(&storage.tables);
+        table.data.len()
+    }
+
+    fn is_empty(self) -> bool {
+        let storage = self.read_lock();
+        let table = D::get_table(&storage.tables);
+        table.data.is_empty()
+    }
+
+    fn get<Q>(self, key: &Q, _owner: Owner) -> Option<D::Value>
+    where
+        D::Value: Clone,
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let storage = self.read_lock();
+        let table = D::get_table(&storage.tables);
+        table.data.get(key).cloned()
+    }
+
+    fn with<Q, T>(self, key: &Q, f: impl FnOnce(&D::Value) -> T, _owner: Owner) -> Option<T>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let storage = self.read_lock();
+        let table = D::get_table(&storage.tables);
+        let value = table.data.get(key)?;
+
+        Some(f(value))
+    }
+
+    fn iter_cloned<'t>(self, _owner: Owner) -> impl Iterator<Item = (D::Key, D::Value)>
+    where
+        D::Key: Clone,
+        D::Value: Clone,
+        Self: 't,
+        'a: 't,
+    {
+        let guard = self.read_lock();
+        TableIterator::<'t, Self::ReadLock, TableStorage, D, iter::KeysAndValues>::new(guard)
+    }
+
+    fn iter_keys_cloned<'t>(self, _owner: Owner) -> impl Iterator<Item = D::Key>
+    where
+        D::Key: Clone,
+        Self: 't,
+        'a: 't,
+    {
+        let guard = self.read_lock();
+        TableIterator::<'t, Self::ReadLock, TableStorage, D, iter::Keys>::new(guard)
+    }
+
+    fn iter_values_cloned<'t>(self, _owner: Owner) -> impl Iterator<Item = D::Value>
+    where
+        D::Value: Clone,
+        Self: 't,
+        'a: 't,
+    {
+        let guard = self.read_lock();
+        TableIterator::<'t, Self::ReadLock, TableStorage, D, iter::Values>::new(guard)
+    }
+
+    fn for_each(self, mut f: impl FnMut(&D::Key, &D::Value), _owner: Owner) {
+        let storage = self.read_lock();
+        let table = D::get_table(&storage.tables);
+        for (k, v) in &table.data {
+            f(k, v);
+        }
+    }
+}
+
+pub(crate) trait IndexedOps<
+    'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key> + 'a,
+    B: TableDesc<Storage = TableStorage> + 'a,
+>: Ops<'a, TableStorage>
+{
+    fn len(self) -> usize {
+        let storage = self.read_lock();
+        let base = B::get_table(&storage.tables);
+        base.data.len()
+    }
+
+    fn is_empty(self) -> bool {
+        let storage = self.read_lock();
+        let base = B::get_table(&storage.tables);
+        base.data.is_empty()
+    }
+
+    fn get<Q>(self, key: &Q, _owner: Owner) -> Option<B::Value>
+    where
+        B::Value: Clone,
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let storage = self.read_lock();
+        let base = B::get_table(&storage.tables);
+        let index = D::get_table(&storage.tables);
+        let base_key = index.data.get(key)?;
+        base.data.get(base_key).cloned()
+    }
+
+    fn with<Q, T>(self, key: &Q, f: impl FnOnce(&B::Value) -> T, _owner: Owner) -> Option<T>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let storage = self.read_lock();
+        let base = B::get_table(&storage.tables);
+        let index = D::get_table(&storage.tables);
+        let base_key = index.data.get(key)?;
+        let value = base.data.get(base_key)?;
+
+        Some(f(value))
+    }
+
+    fn iter_cloned<'t>(self, _owner: Owner) -> impl Iterator<Item = (D::Key, B::Value)>
+    where
+        D::Key: Clone,
+        B::Value: Clone,
+        Self: 't,
+        'a: 't,
+    {
+        let guard = self.read_lock();
+        IndexIterator::<'t, Self::ReadLock, TableStorage, D, B, iter::KeysAndValues>::new(guard)
+    }
+
+    fn iter_keys_cloned<'t>(self, _owner: Owner) -> impl Iterator<Item = D::Key>
+    where
+        D::Key: Clone,
+        Self: 't,
+        'a: 't,
+    {
+        let guard = self.read_lock();
+        IndexIterator::<'t, Self::ReadLock, TableStorage, D, B, iter::Keys>::new(guard)
+    }
+
+    fn iter_values_cloned<'t>(self, _owner: Owner) -> impl Iterator<Item = B::Value>
+    where
+        B::Value: Clone,
+        Self: 't,
+        'a: 't,
+    {
+        let guard = self.read_lock();
+        IndexIterator::<'t, Self::ReadLock, TableStorage, D, B, iter::Values>::new(guard)
+    }
+
+    fn for_each(self, mut f: impl FnMut(&D::Key, &B::Value), _owner: Owner) {
+        let storage = self.read_lock();
+        let base = B::get_table(&storage.tables);
+        let index = D::get_table(&storage.tables);
+        for (k, base_key) in &index.data {
+            let Some(v) = base.data.get(base_key) else {
+                continue;
+            };
+            f(k, v);
+        }
+    }
+}
+
+pub(crate) trait OpsMut<'a, TableStorage: schema::GeneratedStorage + 'a>: Sized {
+    type WriteLock: DerefMut<Target = Storage<TableStorage>>;
+
+    fn write_lock(self) -> Self::WriteLock;
+}
+
+pub(crate) trait SingletonOpsMut<'a, 't, TableStorage: schema::GeneratedStorage + 'a>:
+    OpsMut<'a, TableStorage>
+{
+    fn insert<D: schema::Singleton>(self, value: D::ArgValue, owner: Owner) -> Option<D::ArgValue> {
+        let mut storage = self.write_lock();
+        let key = TypeId::of::<D>();
+        assert_owner(owner, &key, &storage);
+        storage
+            .singletons
+            .insert(key, (owner, D::to_value(value)))
+            .map_singleton_value(|v| D::from_value(v))
+    }
+
+    fn mutate<D: schema::MutSingleton, T>(
+        self,
+        f: impl FnOnce(&mut D::Value) -> T,
+        owner: Owner,
+    ) -> Option<T> {
+        let mut storage = self.write_lock();
+        let key = TypeId::of::<D>();
+        assert_owner(owner, &key, &storage);
+        storage
+            .get_singleton_value_mut(&key)
+            .map_singleton_value(|v| f(D::from_value_mut(v)))
+    }
+
+    fn remove<D: schema::Singleton>(self, owner: Owner) -> Option<D::ArgValue> {
+        let mut storage = self.write_lock();
+        let key = TypeId::of::<D>();
+        assert_owner(owner, &key, &storage);
+        storage
+            .singletons
+            .remove(&key)
+            .map_singleton_value(|v| D::from_value(v))
+    }
+
+    fn clear<D: schema::Singleton>(self, owner: Owner) -> Option<D::ArgValue> {
+        let mut storage = self.write_lock();
+        let key = TypeId::of::<D>();
+        assert_owner(owner, &key, &storage);
+        storage
+            .singletons
+            .insert(key, (owner, SinValue::None))
+            .map_singleton_value(|v| D::from_value(v))
+    }
+}
+
+pub(crate) trait TabularOpsMut<
+    'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: schema::TableDesc<Storage = TableStorage>,
+>: OpsMut<'a, TableStorage>
+{
+    fn init(self, owner: Owner) -> Result<()> {
+        let mut storage = self.write_lock();
+        let table = D::get_table_mut(&mut storage.tables);
+        table.try_set_owner(owner)
+    }
+
+    fn clear(self, owner: Owner) {
+        let mut storage = self.write_lock();
+        let table = D::get_table_mut(&mut storage.tables);
+        table.assert_or_set_owner(owner);
+        table.indexes.clear();
+        table.data.clear();
+    }
+
+    fn insert(self, key: D::Key, value: D::Value, owner: Owner) -> Option<D::Value>
+    where
+        D::Key: Clone,
+    {
+        let mut storage = self.write_lock();
+        let table = D::get_table_mut(&mut storage.tables);
+        table.assert_or_set_owner(owner);
+        if let Some(old_value) = table.data.get(&key) {
+            table.indexes.on_remove(old_value);
+        }
+        table.indexes.on_insert(&key, &value);
+        table.data.insert(key, value)
+    }
+
+    // TODO if `f` panics then the indexes will be left in an inconsistent state.
+    fn mutate<Q, T>(self, key: &Q, f: impl FnOnce(&mut D::Value) -> T, owner: Owner) -> Option<T>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
+    {
+        let mut storage = self.write_lock();
+        let table = D::get_table_mut(&mut storage.tables);
+        table.assert_owner(owner);
+        let value = table.data.get_mut(key)?;
+
+        table.indexes.on_remove(value);
+        let result = f(value);
+        table.indexes.on_insert(key, value);
+
+        Some(result)
+    }
+
+    fn remove<Q>(self, key: &Q, owner: Owner) -> Option<D::Value>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let mut storage = self.write_lock();
+        let table = D::get_table_mut(&mut storage.tables);
+        table.assert_owner(owner);
+        let value = table.data.remove(key.borrow())?;
+        table.indexes.on_remove(&value);
+        Some(value)
+    }
+
+    // TODO if `f` panics then the indexes will be left in an inconsistent state.
+    fn for_each_mut(self, mut f: impl FnMut(&D::Key, &mut D::Value), owner: Owner) {
+        let mut storage = self.write_lock();
+        let table = D::get_table_mut(&mut storage.tables);
+        table.assert_owner(owner);
+
+        for (k, v) in &mut table.data {
+            f(k, v);
+        }
+
+        table.indexes.clear();
+        table.indexes.build(table.data.iter());
+    }
+}
+
+pub(crate) trait IndexedOpsMut<
+    'a,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
+    B: TableDesc<Storage = TableStorage>,
+>: OpsMut<'a, TableStorage>
+{
+    fn init(self, owner: Owner) -> Result<()> {
+        let mut storage = self.write_lock();
+        let base = B::get_table_mut(&mut storage.tables);
+        base.try_set_owner(owner)
+    }
+
+    fn clear(self, owner: Owner) {
+        let mut storage = self.write_lock();
+        let base: &mut crate::storage::Table<B, <B as TableDesc>::Indexes> =
+            B::get_table_mut(&mut storage.tables);
+        base.assert_or_set_owner(owner);
+        base.indexes.clear();
+        base.data.clear();
+    }
+
+    fn insert(self, key: B::Key, value: B::Value, owner: Owner) -> Option<B::Value>
+    where
+        B::Key: Clone,
+    {
+        let mut storage = self.write_lock();
+        let base = B::get_table_mut(&mut storage.tables);
+        base.assert_or_set_owner(owner);
+        if let Some(old_value) = base.data.get(&key) {
+            base.indexes.on_remove(old_value);
+        }
+        base.indexes.on_insert(&key, &value);
+
+        base.data.insert(key, value)
+    }
+
+    // TODO if `f` panics then the indexes will be left in an inconsistent state.
+    fn mutate<Q, T>(self, key: &Q, f: impl FnOnce(&mut B::Value) -> T, owner: Owner) -> Option<T>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+        B::Key: Clone,
+    {
+        let mut storage = self.write_lock();
+        let index = D::get_table(&storage.tables);
+        let base_key: *const <B as TableDesc>::Key = index.data.get(key)? as *const _;
+        // SAFETY: `B` and `D` are different tables, so `get_table[_mut]` will return pointers to
+        // different `Table` objects. `base_key` is a pointer into `index` and cannot be a pointer
+        // into `base`.
+        let base_key = unsafe { &*base_key };
+        let base = B::get_table_mut(&mut storage.tables);
+        base.assert_owner(owner);
+        let value = base.data.get_mut(base_key)?;
+        // TODO we could be more efficient and only update indexes if the foreign key changes
+        base.indexes.on_remove(value);
+        let result = f(value);
+        base.indexes.on_insert(base_key, value);
+
+        Some(result)
+    }
+
+    fn remove<Q>(self, key: &Q, owner: Owner) -> Option<B::Value>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let mut storage = self.write_lock();
+
+        // First check ownership, then do the operation.
+        let base = B::get_table_mut(&mut storage.tables);
+        base.assert_owner(owner);
+
+        let index = D::get_table_mut(&mut storage.tables);
+        let base_key = index.data.remove(key)?;
+        let base = B::get_table_mut(&mut storage.tables);
+        let value = base.data.remove(base_key.borrow())?;
+        base.indexes.on_remove(&value);
+        Some(value)
+    }
+
+    // TODO if `f` panics then the indexes will be left in an inconsistent state.
+    fn for_each_mut(self, mut f: impl FnMut(&D::Key, &mut B::Value), owner: Owner) {
+        let mut storage = self.write_lock();
+        let tables: *mut _ = &mut storage.tables;
+        // SAFETY: `B` and `D` are different tables, so `get_table[_mut]` will return pointers to
+        // different `Table` objects. Although the compiler treats `base` and `index` as having
+        // a reference to `storage.tables`, they do not, so the references here are transient and
+        // all mutable references are unique.
+        let base = B::get_table_mut(unsafe { &mut *tables });
+        base.assert_owner(owner);
+        let index = D::get_table(&storage.tables);
+
+        for (k, base_key) in &index.data {
+            let Some(v) = base.data.get_mut(base_key) else {
+                continue;
+            };
+            f(k, v);
+        }
+
+        // TODO we could be more efficient and only update indexes if the foreign key changes
+        base.indexes.clear();
+        base.indexes.build(base.data.iter());
+    }
+}

--- a/ts_kv_store/src/operations.rs
+++ b/ts_kv_store/src/operations.rs
@@ -20,19 +20,17 @@ use crate::{
     IndexIterator, Owner, Result, TableIterator, iter,
     schema::{self, IndexDesc, IndexStorage, TableDesc},
     singleton::{OptSingletonValue, assert_owner},
-    storage::{SinValue, Storage},
+    storage::{SinValue, StorageLike},
 };
 
-pub(crate) trait Ops<'store, TableStorage: schema::GeneratedStorage + 'store>:
-    Sized
-{
-    type ReadLock: Deref<Target = Storage<TableStorage>>;
+pub(crate) trait Ops: Sized {
+    type ReadLock: Deref<Target = Self::Storage>;
+    type Storage: StorageLike;
+
     fn read_lock(self) -> Self::ReadLock;
 }
 
-pub(crate) trait SingletonOps<'store, TableStorage: schema::GeneratedStorage + 'store>:
-    Ops<'store, TableStorage>
-{
+pub(crate) trait SingletonOps: Ops {
     fn get<D: schema::Singleton>(self, _owner: Owner) -> Option<D::Value>
     where
         D::Value: Clone,
@@ -64,181 +62,205 @@ pub(crate) trait SingletonOps<'store, TableStorage: schema::GeneratedStorage + '
             .map_singleton_value(|v| f(D::from_value_ref(v)))
     }
 }
+pub(crate) trait TabularOps: Ops {
+    type Desc: TableDesc<Storage = <Self::Storage as StorageLike>::Generated>;
 
-pub(crate) trait TabularOps<
-    'store,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: schema::TableDesc<Storage = TableStorage>,
->: Ops<'store, TableStorage>
-{
     fn len(self) -> usize {
         let storage = self.read_lock();
-        let table = D::get_table(&storage.tables);
+        let table = <Self::Desc as TableDesc>::get_table(storage.tables());
         table.data.len()
     }
 
     fn is_empty(self) -> bool {
         let storage = self.read_lock();
-        let table = D::get_table(&storage.tables);
+        let table = <Self::Desc as TableDesc>::get_table(storage.tables());
         table.data.is_empty()
     }
 
-    fn get<Q>(self, key: &Q, _owner: Owner) -> Option<D::Value>
+    fn get<Q>(self, key: &Q, _owner: Owner) -> Option<<Self::Desc as TableDesc>::Value>
     where
-        D::Value: Clone,
-        D::Key: Borrow<Q>,
+        <Self::Desc as TableDesc>::Value: Clone,
+        <Self::Desc as TableDesc>::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
     {
         let storage = self.read_lock();
-        let table = D::get_table(&storage.tables);
+        let table = <Self::Desc as TableDesc>::get_table(storage.tables());
         table.data.get(key).cloned()
     }
 
-    fn with<Q, T>(self, key: &Q, f: impl FnOnce(&D::Value) -> T, _owner: Owner) -> Option<T>
+    fn with<Q, T>(
+        self,
+        key: &Q,
+        f: impl FnOnce(&<Self::Desc as TableDesc>::Value) -> T,
+        _owner: Owner,
+    ) -> Option<T>
     where
-        D::Key: Borrow<Q>,
+        <Self::Desc as TableDesc>::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
     {
         let storage = self.read_lock();
-        let table = D::get_table(&storage.tables);
+        let table = <Self::Desc as TableDesc>::get_table(storage.tables());
         let value = table.data.get(key)?;
 
         Some(f(value))
     }
 
-    fn iter<'guard>(self, _owner: Owner) -> impl Iterator<Item = (&'guard D::Key, &'guard D::Value)>
+    fn iter<'guard>(
+        self,
+        _owner: Owner,
+    ) -> impl Iterator<
+        Item = (
+            &'guard <Self::Desc as TableDesc>::Key,
+            &'guard <Self::Desc as TableDesc>::Value,
+        ),
+    >
     where
-        Self: 'guard,
-        'store: 'guard,
-        D: 'store,
+        Self::ReadLock: 'guard,
+        Self::Desc: 'guard,
     {
         let guard = self.read_lock();
-        TableIterator::<'store, 'guard, Self::ReadLock, TableStorage, D, iter::KeysAndValues>::new(
-            guard,
-        )
+        TableIterator::<'guard, Self::ReadLock, Self::Desc, iter::KeysAndValues>::new(guard)
     }
 
-    fn keys<'guard>(self, _owner: Owner) -> impl Iterator<Item = &'guard D::Key>
+    fn keys<'guard>(
+        self,
+        _owner: Owner,
+    ) -> impl Iterator<Item = &'guard <Self::Desc as TableDesc>::Key>
     where
-        Self: 'guard,
-        'store: 'guard,
-        D: 'store,
+        Self::ReadLock: 'guard,
+        Self::Desc: 'guard,
     {
         let guard = self.read_lock();
-        TableIterator::<'store, 'guard, Self::ReadLock, TableStorage, D, iter::Keys>::new(guard)
+        TableIterator::<'guard, Self::ReadLock, Self::Desc, iter::Keys>::new(guard)
     }
 
-    fn values<'guard>(self, _owner: Owner) -> impl Iterator<Item = &'guard D::Value>
+    fn values<'guard>(
+        self,
+        _owner: Owner,
+    ) -> impl Iterator<Item = &'guard <Self::Desc as TableDesc>::Value>
     where
-        Self: 'guard,
-        'store: 'guard,
-        D: 'store,
+        Self::ReadLock: 'guard,
+        Self::Desc: 'guard,
     {
         let guard = self.read_lock();
-        TableIterator::<'store, 'guard, Self::ReadLock, TableStorage, D, iter::Values>::new(guard)
+        TableIterator::<'guard, Self::ReadLock, Self::Desc, iter::Values>::new(guard)
     }
 }
 
-pub(crate) trait IndexedOps<
-    'store,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
->: Ops<'store, TableStorage>
-{
+pub(crate) trait IndexedOps: Ops {
+    type Index: IndexDesc<Storage = <Self::Storage as StorageLike>::Generated>;
+
     fn len(self) -> usize {
         let storage = self.read_lock();
-        let base = B::get_table(&storage.tables);
+        let base =
+            <<Self::Index as IndexDesc>::BaseTable as TableDesc>::get_table(storage.tables());
         base.data.len()
     }
 
     fn is_empty(self) -> bool {
         let storage = self.read_lock();
-        let base = B::get_table(&storage.tables);
+        let base =
+            <<Self::Index as IndexDesc>::BaseTable as TableDesc>::get_table(storage.tables());
         base.data.is_empty()
     }
 
-    fn get<Q>(self, key: &Q, _owner: Owner) -> Option<B::Value>
+    fn get<Q>(self, key: &Q, _owner: Owner) -> Option<BaseVal<Self::Index>>
     where
-        B::Value: Clone,
-        D::Key: Borrow<Q>,
+        <Self::Index as TableDesc>::Key: Borrow<Q>,
+        <Self::Index as TableDesc>::Value: Hash + Eq,
+        BaseVal<Self::Index>: Clone,
         Q: ?Sized + Hash + Eq,
     {
         let storage = self.read_lock();
-        let base = B::get_table(&storage.tables);
-        let index = D::get_table(&storage.tables);
+        let base =
+            <<Self::Index as IndexDesc>::BaseTable as TableDesc>::get_table(storage.tables());
+        let index = <Self::Index as TableDesc>::get_table(storage.tables());
         let base_key = index.data.get(key)?;
         base.data.get(base_key).cloned()
     }
 
-    fn with<Q, T>(self, key: &Q, f: impl FnOnce(&B::Value) -> T, _owner: Owner) -> Option<T>
+    fn with<Q, T>(
+        self,
+        key: &Q,
+        f: impl FnOnce(&<<Self::Index as IndexDesc>::BaseTable as TableDesc>::Value) -> T,
+        _owner: Owner,
+    ) -> Option<T>
     where
-        D::Key: Borrow<Q>,
+        <Self::Index as TableDesc>::Key: Borrow<Q>,
+        <Self::Index as TableDesc>::Value: Hash + Eq,
         Q: ?Sized + Hash + Eq,
     {
         let storage = self.read_lock();
-        let base = B::get_table(&storage.tables);
-        let index = D::get_table(&storage.tables);
+        let base =
+            <<Self::Index as IndexDesc>::BaseTable as TableDesc>::get_table(storage.tables());
+        let index = <Self::Index>::get_table(storage.tables());
         let base_key = index.data.get(key)?;
         let value = base.data.get(base_key)?;
 
         Some(f(value))
     }
 
-    fn iter<'guard>(self, _owner: Owner) -> impl Iterator<Item = (&'guard D::Key, &'guard B::Value)>
+    fn iter<'guard>(
+        self,
+        _owner: Owner,
+    ) -> impl Iterator<
+        Item = (
+            &'guard <Self::Index as TableDesc>::Key,
+            &'guard <<Self::Index as IndexDesc>::BaseTable as TableDesc>::Value,
+        ),
+    >
     where
-        Self: 'guard,
-        'store: 'guard,
-        B: 'store,
-        D: 'store,
+        Self::ReadLock: 'guard,
+        Self::Index: 'guard,
+        <Self::Index as TableDesc>::Value: Hash + Eq,
     {
         let guard = self.read_lock();
-        IndexIterator::<'store, 'guard, Self::ReadLock, TableStorage, D, B, iter::KeysAndValues>::new(guard)
-    }
-
-    fn keys<'guard>(self, _owner: Owner) -> impl Iterator<Item = &'guard D::Key>
-    where
-        Self: 'guard,
-        'store: 'guard,
-        B: 'store,
-        D: 'store,
-    {
-        let guard = self.read_lock();
-        IndexIterator::<'store, 'guard, Self::ReadLock, TableStorage, D, B, iter::Keys>::new(guard)
-    }
-
-    fn values<'guard>(self, _owner: Owner) -> impl Iterator<Item = &'guard B::Value>
-    where
-        Self: 'guard,
-        'store: 'guard,
-        B: 'store,
-        D: 'store,
-    {
-        let guard = self.read_lock();
-        IndexIterator::<'store, 'guard, Self::ReadLock, TableStorage, D, B, iter::Values>::new(
+        IndexIterator::<'guard, <Self as Ops>::ReadLock, Self::Index, iter::KeysAndValues>::new(
             guard,
         )
     }
+
+    fn keys<'guard>(
+        self,
+        _owner: Owner,
+    ) -> impl Iterator<Item = &'guard <Self::Index as TableDesc>::Key>
+    where
+        Self::ReadLock: 'guard,
+        Self::Index: 'guard,
+    {
+        let guard = self.read_lock();
+        IndexIterator::<'guard, <Self as Ops>::ReadLock, Self::Index, iter::Keys>::new(guard)
+    }
+
+    fn values<'guard>(
+        self,
+        _owner: Owner,
+    ) -> impl Iterator<Item = &'guard <<Self::Index as IndexDesc>::BaseTable as TableDesc>::Value>
+    where
+        Self::ReadLock: 'guard,
+        Self::Index: 'guard,
+        <Self::Index as TableDesc>::Value: Hash + Eq,
+    {
+        let guard = self.read_lock();
+        IndexIterator::<'guard, <Self as Ops>::ReadLock, Self::Index, iter::Values>::new(guard)
+    }
 }
 
-pub(crate) trait OpsMut<'store, TableStorage: schema::GeneratedStorage + 'store>:
-    Sized
-{
-    type WriteLock: DerefMut<Target = Storage<TableStorage>>;
+pub(crate) trait OpsMut: Sized {
+    type WriteLock: DerefMut<Target = Self::StorageMut>;
+    type StorageMut: StorageLike;
 
     fn write_lock(self) -> Self::WriteLock;
 }
 
-pub(crate) trait SingletonOpsMut<'store, TableStorage: schema::GeneratedStorage + 'store>:
-    OpsMut<'store, TableStorage>
-{
+pub(crate) trait SingletonOpsMut: OpsMut {
     fn insert<D: schema::Singleton>(self, value: D::ArgValue, owner: Owner) -> Option<D::ArgValue> {
         let mut storage = self.write_lock();
         let key = TypeId::of::<D>();
-        assert_owner(owner, &key, &storage);
+        assert_owner(owner, &key, &*storage);
+
         storage
-            .singletons
-            .insert(key, (owner, D::to_value(value)))
+            .insert_singleton(key, owner, D::to_value(value))
             .map_singleton_value(|v| D::from_value(v))
     }
 
@@ -249,7 +271,7 @@ pub(crate) trait SingletonOpsMut<'store, TableStorage: schema::GeneratedStorage 
     ) -> Option<T> {
         let mut storage = self.write_lock();
         let key = TypeId::of::<D>();
-        assert_owner(owner, &key, &storage);
+        assert_owner(owner, &key, &*storage);
         storage
             .get_singleton_value_mut(&key)
             .map_singleton_value(|v| f(D::from_value_mut(v)))
@@ -258,50 +280,53 @@ pub(crate) trait SingletonOpsMut<'store, TableStorage: schema::GeneratedStorage 
     fn remove<D: schema::Singleton>(self, owner: Owner) -> Option<D::ArgValue> {
         let mut storage = self.write_lock();
         let key = TypeId::of::<D>();
-        assert_owner(owner, &key, &storage);
+        assert_owner(owner, &key, &*storage);
+
         storage
-            .singletons
-            .remove(&key)
+            .remove_singleton(&key)
             .map_singleton_value(|v| D::from_value(v))
     }
 
     fn clear<D: schema::Singleton>(self, owner: Owner) -> Option<D::ArgValue> {
         let mut storage = self.write_lock();
         let key = TypeId::of::<D>();
-        assert_owner(owner, &key, &storage);
+        assert_owner(owner, &key, &*storage);
+
         storage
-            .singletons
-            .insert(key, (owner, SinValue::None))
+            .insert_singleton(key, owner, SinValue::None)
             .map_singleton_value(|v| D::from_value(v))
     }
 }
 
-pub(crate) trait TabularOpsMut<
-    'store,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: schema::TableDesc<Storage = TableStorage>,
->: OpsMut<'store, TableStorage>
-{
+pub(crate) trait TabularOpsMut: OpsMut {
+    type DescMut: TableDesc<Storage = <Self::StorageMut as StorageLike>::Generated>;
+
     fn init(self, owner: Owner) -> Result<()> {
         let mut storage = self.write_lock();
-        let table = D::get_table_mut(&mut storage.tables);
+
+        let table = Self::DescMut::get_table_mut(storage.tables_mut());
         table.try_set_owner(owner)
     }
 
     fn clear(self, owner: Owner) {
         let mut storage = self.write_lock();
-        let table = D::get_table_mut(&mut storage.tables);
+        let table = Self::DescMut::get_table_mut(storage.tables_mut());
         table.assert_or_set_owner(owner);
         table.indexes.clear();
         table.data.clear();
     }
 
-    fn insert(self, key: D::Key, value: D::Value, owner: Owner) -> Option<D::Value>
+    fn insert(
+        self,
+        key: <Self::DescMut as TableDesc>::Key,
+        value: <Self::DescMut as TableDesc>::Value,
+        owner: Owner,
+    ) -> Option<<Self::DescMut as TableDesc>::Value>
     where
-        D::Key: Clone,
+        <Self::DescMut as TableDesc>::Key: Clone,
     {
         let mut storage = self.write_lock();
-        let table = D::get_table_mut(&mut storage.tables);
+        let table = Self::DescMut::get_table_mut(storage.tables_mut());
         table.assert_or_set_owner(owner);
         if let Some(old_value) = table.data.get(&key) {
             table.indexes.on_remove(old_value);
@@ -311,13 +336,18 @@ pub(crate) trait TabularOpsMut<
     }
 
     // TODO if `f` panics then the indexes will be left in an inconsistent state.
-    fn with_mut<Q, T>(self, key: &Q, f: impl FnOnce(&mut D::Value) -> T, owner: Owner) -> Option<T>
+    fn with_mut<Q, T>(
+        self,
+        key: &Q,
+        f: impl FnOnce(&mut <Self::DescMut as TableDesc>::Value) -> T,
+        owner: Owner,
+    ) -> Option<T>
     where
-        D::Key: Borrow<Q>,
-        Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
+        <Self::DescMut as TableDesc>::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq + ToOwned<Owned = <Self::DescMut as TableDesc>::Key>,
     {
         let mut storage = self.write_lock();
-        let table = D::get_table_mut(&mut storage.tables);
+        let table = Self::DescMut::get_table_mut(storage.tables_mut());
         table.assert_owner(owner);
         let value = table.data.get_mut(key)?;
 
@@ -328,13 +358,13 @@ pub(crate) trait TabularOpsMut<
         Some(result)
     }
 
-    fn remove<Q>(self, key: &Q, owner: Owner) -> Option<D::Value>
+    fn remove<Q>(self, key: &Q, owner: Owner) -> Option<<Self::DescMut as TableDesc>::Value>
     where
-        D::Key: Borrow<Q>,
+        <Self::DescMut as TableDesc>::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
     {
         let mut storage = self.write_lock();
-        let table = D::get_table_mut(&mut storage.tables);
+        let table = Self::DescMut::get_table_mut(storage.tables_mut());
         table.assert_owner(owner);
         let value = table.data.remove(key.borrow())?;
         table.indexes.on_remove(&value);
@@ -342,9 +372,13 @@ pub(crate) trait TabularOpsMut<
     }
 
     // TODO if `f` panics then the indexes will be left in an inconsistent state.
-    fn for_each_mut(self, mut f: impl FnMut(&D::Key, &mut D::Value), owner: Owner) {
+    fn for_each_mut(
+        self,
+        mut f: impl FnMut(&<Self::DescMut as TableDesc>::Key, &mut <Self::DescMut as TableDesc>::Value),
+        owner: Owner,
+    ) {
         let mut storage = self.write_lock();
-        let table = D::get_table_mut(&mut storage.tables);
+        let table = Self::DescMut::get_table_mut(storage.tables_mut());
         table.assert_owner(owner);
 
         for (k, v) in &mut table.data {
@@ -356,34 +390,47 @@ pub(crate) trait TabularOpsMut<
     }
 }
 
-pub(crate) trait IndexedOpsMut<
-    'store,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: IndexDesc<Storage = TableStorage, BaseTable = B, Value = B::Key>,
-    B: TableDesc<Storage = TableStorage>,
->: OpsMut<'store, TableStorage>
-{
+type Base<T> = <T as IndexDesc>::BaseTable;
+type BaseKey<T> = <<T as IndexDesc>::BaseTable as TableDesc>::Key;
+type BaseVal<T> = <<T as IndexDesc>::BaseTable as TableDesc>::Value;
+type IKey<T> = <T as TableDesc>::Key;
+type IVal<T> = <T as TableDesc>::Value;
+
+pub(crate) trait IndexedOpsMut: OpsMut {
+    type IndexMut: IndexDesc<Storage = <Self::StorageMut as StorageLike>::Generated>;
+
     fn init(self, owner: Owner) -> Result<()> {
         let mut storage = self.write_lock();
-        let base = B::get_table_mut(&mut storage.tables);
+        let base = Base::<Self::IndexMut>::get_table_mut(storage.tables_mut());
         base.try_set_owner(owner)
     }
 
-    fn clear(self, owner: Owner) {
+    fn clear(self, owner: Owner)
+    where
+        <Self::IndexMut as TableDesc>::Value: Hash + Eq,
+    {
         let mut storage = self.write_lock();
-        let base: &mut crate::storage::Table<B, <B as TableDesc>::Indexes> =
-            B::get_table_mut(&mut storage.tables);
+        let base: &mut crate::storage::Table<
+            <Self::IndexMut as IndexDesc>::BaseTable,
+            <<Self::IndexMut as IndexDesc>::BaseTable as TableDesc>::Indexes,
+        > = <Self::IndexMut as IndexDesc>::BaseTable::get_table_mut(storage.tables_mut());
         base.assert_or_set_owner(owner);
         base.indexes.clear();
         base.data.clear();
     }
 
-    fn insert(self, key: B::Key, value: B::Value, owner: Owner) -> Option<B::Value>
+    fn insert(
+        self,
+        key: BaseKey<Self::IndexMut>,
+        value: BaseVal<Self::IndexMut>,
+        owner: Owner,
+    ) -> Option<BaseVal<Self::IndexMut>>
     where
-        B::Key: Clone,
+        BaseKey<Self::IndexMut>: Clone,
+        IVal<Self::IndexMut>: Hash + Eq,
     {
         let mut storage = self.write_lock();
-        let base = B::get_table_mut(&mut storage.tables);
+        let base = <<Self::IndexMut as IndexDesc>::BaseTable>::get_table_mut(storage.tables_mut());
         base.assert_or_set_owner(owner);
         if let Some(old_value) = base.data.get(&key) {
             base.indexes.on_remove(old_value);
@@ -394,20 +441,27 @@ pub(crate) trait IndexedOpsMut<
     }
 
     // TODO if `f` panics then the indexes will be left in an inconsistent state.
-    fn with_mut<Q, T>(self, key: &Q, f: impl FnOnce(&mut B::Value) -> T, owner: Owner) -> Option<T>
+    fn with_mut<Q, T>(
+        self,
+        key: &Q,
+        f: impl FnOnce(&mut <<Self::IndexMut as IndexDesc>::BaseTable as TableDesc>::Value) -> T,
+        owner: Owner,
+    ) -> Option<T>
     where
-        D::Key: Borrow<Q>,
+        IKey<Self::IndexMut>: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
-        B::Key: Clone,
+        BaseKey<Self::IndexMut>: Clone,
+        IVal<Self::IndexMut>: Hash + Eq,
     {
         let mut storage = self.write_lock();
-        let index = D::get_table(&storage.tables);
-        let base_key: *const <B as TableDesc>::Key = index.data.get(key)? as *const _;
+        let index = <Self::IndexMut as TableDesc>::get_table(storage.tables_mut());
+        let base_key: *const <<Self::IndexMut as IndexDesc>::BaseTable as TableDesc>::Key =
+            index.data.get(key)? as *const _;
         // SAFETY: `B` and `D` are different tables, so `get_table[_mut]` will return pointers to
         // different `Table` objects. `base_key` is a pointer into `index` and cannot be a pointer
         // into `base`.
         let base_key = unsafe { &*base_key };
-        let base = B::get_table_mut(&mut storage.tables);
+        let base = <<Self::IndexMut as IndexDesc>::BaseTable>::get_table_mut(storage.tables_mut());
         base.assert_owner(owner);
         let value = base.data.get_mut(base_key)?;
         // TODO we could be more efficient and only update indexes if the foreign key changes
@@ -418,36 +472,47 @@ pub(crate) trait IndexedOpsMut<
         Some(result)
     }
 
-    fn remove<Q>(self, key: &Q, owner: Owner) -> Option<B::Value>
+    fn remove<Q>(self, key: &Q, owner: Owner) -> Option<BaseVal<Self::IndexMut>>
     where
-        D::Key: Borrow<Q>,
+        IKey<Self::IndexMut>: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
+        IVal<Self::IndexMut>: Hash + Eq,
     {
         let mut storage = self.write_lock();
 
         // First check ownership, then do the operation.
-        let base = B::get_table_mut(&mut storage.tables);
+        let base = <<Self::IndexMut as IndexDesc>::BaseTable>::get_table_mut(storage.tables_mut());
         base.assert_owner(owner);
 
-        let index = D::get_table_mut(&mut storage.tables);
+        let index = <Self::IndexMut as TableDesc>::get_table_mut(storage.tables_mut());
         let base_key = index.data.remove(key)?;
-        let base = B::get_table_mut(&mut storage.tables);
+        let base = <<Self::IndexMut as IndexDesc>::BaseTable>::get_table_mut(storage.tables_mut());
         let value = base.data.remove(base_key.borrow())?;
         base.indexes.on_remove(&value);
         Some(value)
     }
 
     // TODO if `f` panics then the indexes will be left in an inconsistent state.
-    fn for_each_mut(self, mut f: impl FnMut(&D::Key, &mut B::Value), owner: Owner) {
+    fn for_each_mut(
+        self,
+        mut f: impl FnMut(
+            &<Self::IndexMut as TableDesc>::Key,
+            &mut <<Self::IndexMut as IndexDesc>::BaseTable as TableDesc>::Value,
+        ),
+        owner: Owner,
+    ) where
+        IVal<Self::IndexMut>: Hash + Eq,
+    {
         let mut storage = self.write_lock();
-        let tables: *mut _ = &mut storage.tables;
+        let tables: *mut _ = storage.tables_mut();
         // SAFETY: `B` and `D` are different tables, so `get_table[_mut]` will return pointers to
         // different `Table` objects. Although the compiler treats `base` and `index` as having
         // a reference to `storage.tables`, they do not, so the references here are transient and
         // all mutable references are unique.
-        let base = B::get_table_mut(unsafe { &mut *tables });
+        let base =
+            <<Self::IndexMut as IndexDesc>::BaseTable>::get_table_mut(unsafe { &mut *tables });
         base.assert_owner(owner);
-        let index = D::get_table(&storage.tables);
+        let index = <Self::IndexMut as TableDesc>::get_table(storage.tables_mut());
 
         for (k, base_key) in &index.data {
             let Some(v) = base.data.get_mut(base_key) else {

--- a/ts_kv_store/src/raw.rs
+++ b/ts_kv_store/src/raw.rs
@@ -10,43 +10,59 @@ use crate::{
     storage::Storage,
 };
 
-impl<'a, TableStorage: schema::GeneratedStorage + 'a> SingletonOps<'a, TableStorage>
-    for &'a crate::KvStore<TableStorage>
+impl<'store: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
+    SingletonOps<'store, TableStorage> for &'r crate::KvStore<TableStorage>
 {
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage + 'a> SingletonOpsMut<'a, 'a, TableStorage>
-    for &'a crate::KvStore<TableStorage>
+impl<'store: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
+    SingletonOpsMut<'store, TableStorage> for &'r crate::KvStore<TableStorage>
 {
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage + 'a, D: schema::TableDesc<Storage = TableStorage>>
-    Ops<'a, TableStorage> for &'a KvTable<'a, TableStorage, D>
+impl<
+    'store: 'r,
+    'r,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: schema::TableDesc<Storage = TableStorage>,
+> Ops<'store, TableStorage> for &'r KvTable<'store, TableStorage, D>
 {
-    type ReadLock = std::sync::RwLockReadGuard<'a, Storage<TableStorage>>;
+    type ReadLock = std::sync::RwLockReadGuard<'r, Storage<TableStorage>>;
 
     fn read_lock(self) -> Self::ReadLock {
         self.store.storage.read().unwrap()
     }
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage + 'a, D: schema::TableDesc<Storage = TableStorage>>
-    TabularOps<'a, TableStorage, D> for &'a KvTable<'a, TableStorage, D>
+impl<
+    'store: 'r,
+    'r,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: schema::TableDesc<Storage = TableStorage>,
+> TabularOps<'store, TableStorage, D> for &'r KvTable<'store, TableStorage, D>
 {
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage + 'a, D: schema::TableDesc<Storage = TableStorage>>
-    OpsMut<'a, TableStorage> for &'a KvTable<'a, TableStorage, D>
+impl<
+    'store: 'r,
+    'r,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: schema::TableDesc<Storage = TableStorage>,
+> OpsMut<'store, TableStorage> for &'r KvTable<'store, TableStorage, D>
 {
-    type WriteLock = std::sync::RwLockWriteGuard<'a, Storage<TableStorage>>;
+    type WriteLock = std::sync::RwLockWriteGuard<'r, Storage<TableStorage>>;
 
     fn write_lock(self) -> Self::WriteLock {
         self.store.storage.write().unwrap()
     }
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage + 'a, D: schema::TableDesc<Storage = TableStorage>>
-    TabularOpsMut<'a, TableStorage, D> for &'a KvTable<'a, TableStorage, D>
+impl<
+    'store: 'r,
+    'r,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: schema::TableDesc<Storage = TableStorage>,
+> TabularOpsMut<'store, TableStorage, D> for &'r KvTable<'store, TableStorage, D>
 {
 }
 
@@ -58,10 +74,10 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     /// ```rust,ignore
     /// let value = store.table::<Foo>(OWNER).get(key).unwrap();
     /// ```
-    pub fn table<'a, D: schema::TableDesc<Storage = TableStorage>>(
-        &'a self,
+    pub fn table<D: schema::TableDesc<Storage = TableStorage>>(
+        &self,
         owner: Owner,
-    ) -> KvTable<'a, TableStorage, D> {
+    ) -> KvTable<'_, TableStorage, D> {
         KvTable {
             store: self,
             owner,
@@ -79,10 +95,10 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     ///
     /// Here `Foo` describes a tables and `bar` describes an index over `Foo` using the `bar` field
     /// as foreign key.
-    pub fn table_by<'a, D: schema::IndexDesc<Storage = TableStorage>>(
-        &'a self,
+    pub fn table_by<D: schema::IndexDesc<Storage = TableStorage>>(
+        &self,
         owner: Owner,
-    ) -> KvTableIndex<'a, TableStorage, D, D::BaseTable> {
+    ) -> KvTableIndex<'_, TableStorage, D, D::BaseTable> {
         KvTableIndex {
             store: self,
             owner,
@@ -128,7 +144,7 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
         owner: Owner,
         value: D::ArgValue,
     ) -> Option<D::ArgValue> {
-        <&Self as SingletonOpsMut<'_, '_, TableStorage>>::insert::<D>(self, value, owner)
+        <&Self as SingletonOpsMut<'_, TableStorage>>::insert::<D>(self, value, owner)
     }
 
     /// Get mutable access to a value in the store.
@@ -139,14 +155,14 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
         owner: Owner,
         f: impl FnOnce(&mut D::Value) -> T,
     ) -> Option<T> {
-        <&Self as SingletonOpsMut<'_, '_, TableStorage>>::with_mut::<D, T>(self, f, owner)
+        <&Self as SingletonOpsMut<'_, TableStorage>>::with_mut::<D, T>(self, f, owner)
     }
 
     /// Remove a single value from the store.
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn remove<D: schema::Singleton>(&self, owner: Owner) -> Option<D::ArgValue> {
-        <&Self as SingletonOpsMut<'_, '_, TableStorage>>::remove::<D>(self, owner)
+        <&Self as SingletonOpsMut<'_, TableStorage>>::remove::<D>(self, owner)
     }
 
     /// Remove a single value from the store while preserving ownership of the key/value.
@@ -155,7 +171,7 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn clear<D: schema::Singleton>(&self, owner: Owner) -> Option<D::ArgValue> {
-        <&Self as SingletonOpsMut<'_, '_, TableStorage>>::clear::<D>(self, owner)
+        <&Self as SingletonOpsMut<'_, TableStorage>>::clear::<D>(self, owner)
     }
 }
 
@@ -164,17 +180,20 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
 /// `KvTable` has no transactional semantics and only exists as a convenience for accessing
 /// tabular data.
 pub struct KvTable<
-    'a,
+    'store,
     TableStorage: schema::GeneratedStorage,
     D: schema::TableDesc<Storage = TableStorage>,
 > {
-    store: &'a KvStore<TableStorage>,
+    store: &'store KvStore<TableStorage>,
     owner: Owner,
     table: PhantomData<D>,
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage, D: schema::TableDesc<Storage = TableStorage>>
-    KvTable<'a, TableStorage, D>
+impl<
+    'store,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: schema::TableDesc<Storage = TableStorage>,
+> KvTable<'store, TableStorage, D>
 {
     /// Initialize a table by setting its owner.
     ///
@@ -183,29 +202,29 @@ impl<'a, TableStorage: schema::GeneratedStorage, D: schema::TableDesc<Storage = 
     ///
     /// Returns an error (containing the current owner of the table) if the table has already been
     /// initialized. In this case, the table will be in a consistent state and can be used as normal.
-    pub fn init(&'a self) -> Result<()> {
+    pub fn init(&self) -> Result<()> {
         <&Self as TabularOpsMut<'_, TableStorage, D>>::init(self, self.owner)
     }
 
     /// The number of key/value pairs in the table.
-    pub fn len(&'a self) -> usize {
+    pub fn len(&self) -> usize {
         <&Self as TabularOps<'_, TableStorage, D>>::len(self)
     }
 
     /// True if the table is empty.
-    pub fn is_empty(&'a self) -> bool {
+    pub fn is_empty(&self) -> bool {
         <&Self as TabularOps<'_, TableStorage, D>>::is_empty(self)
     }
 
     /// Clear a table by removing all its KVs, but preserve ownership.
-    pub fn clear(&'a self) {
+    pub fn clear(&self) {
         <&Self as TabularOpsMut<'_, TableStorage, D>>::clear(self, self.owner)
     }
 
     /// Get a row of the table from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<Q>(&'a self, key: &Q) -> Option<D::Value>
+    pub fn get<Q>(&self, key: &Q) -> Option<D::Value>
     where
         D::Value: Clone,
         D::Key: Borrow<Q>,
@@ -217,7 +236,7 @@ impl<'a, TableStorage: schema::GeneratedStorage, D: schema::TableDesc<Storage = 
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&'a self, key: &Q, f: impl FnOnce(&D::Value) -> T) -> Option<T>
+    pub fn with<Q, T>(&'store self, key: &Q, f: impl FnOnce(&D::Value) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -228,7 +247,7 @@ impl<'a, TableStorage: schema::GeneratedStorage, D: schema::TableDesc<Storage = 
     /// Insert a value into the table.
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
-    pub fn insert(&'a self, key: D::Key, value: D::Value) -> Option<D::Value>
+    pub fn insert(&'store self, key: D::Key, value: D::Value) -> Option<D::Value>
     where
         D::Key: Clone,
     {
@@ -238,7 +257,7 @@ impl<'a, TableStorage: schema::GeneratedStorage, D: schema::TableDesc<Storage = 
     /// Get mutable access to a row of the table in the store in the store.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with_mut<Q, T>(&'a self, key: &Q, f: impl FnOnce(&mut D::Value) -> T) -> Option<T>
+    pub fn with_mut<Q, T>(&'store self, key: &Q, f: impl FnOnce(&mut D::Value) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
@@ -249,7 +268,7 @@ impl<'a, TableStorage: schema::GeneratedStorage, D: schema::TableDesc<Storage = 
     /// Remove a row from the table.
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
-    pub fn remove<Q>(&'a self, key: &Q) -> Option<D::Value>
+    pub fn remove<Q>(&'store self, key: &Q) -> Option<D::Value>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -258,49 +277,25 @@ impl<'a, TableStorage: schema::GeneratedStorage, D: schema::TableDesc<Storage = 
     }
 
     /// Iterate all the key/value pairs in a table.
-    ///
-    /// Clones both keys and values and provides them by-value. To iterate without cloning, see
-    /// [`Self::for_each`].
-    pub fn iter_cloned(&'a self) -> impl Iterator<Item = (D::Key, D::Value)>
-    where
-        D::Key: Clone,
-        D::Value: Clone,
-    {
-        <&Self as TabularOps<'_, TableStorage, D>>::iter_cloned(self, self.owner)
+    pub fn iter(&'store self) -> impl Iterator<Item = (&'store D::Key, &'store D::Value)> {
+        <&Self as TabularOps<'_, TableStorage, D>>::iter(self, self.owner)
     }
 
     /// Iterate all the keys in a table.
-    ///
-    /// Clones the keys and provides them by-value. To iterate without cloning, see
-    /// [`Self::for_each`].
-    pub fn iter_keys_cloned(&'a self) -> impl Iterator<Item = D::Key>
-    where
-        D::Key: Clone,
-    {
-        <&Self as TabularOps<'_, TableStorage, D>>::iter_keys_cloned(self, self.owner)
+    pub fn keys(&'store self) -> impl Iterator<Item = &'store D::Key> {
+        <&Self as TabularOps<'_, TableStorage, D>>::keys(self, self.owner)
     }
 
     /// Iterate all the values in a table.
-    ///
-    /// Clones values and provides them by-value. To iterate without cloning, see
-    /// [`Self::for_each`].
-    pub fn iter_values_cloned(&'a self) -> impl Iterator<Item = D::Value>
+    pub fn values(&self) -> impl Iterator<Item = &D::Value>
     where
-        D::Value: Clone,
+        D: 'store,
     {
-        <&Self as TabularOps<'_, TableStorage, D>>::iter_values_cloned(self, self.owner)
-    }
-
-    /// Iterate all the key/value pairs in a table.
-    ///
-    /// We're not able to make this an iterator because we have to ensure that the references do
-    /// not outlive our lock on the store. For a (cloning) iterator see [`Self::iter_cloned`].
-    pub fn for_each(&'a self, f: impl FnMut(&D::Key, &D::Value)) {
-        <&Self as TabularOps<'_, TableStorage, D>>::for_each(self, f, self.owner)
+        <&Self as TabularOps<'_, TableStorage, D>>::values(self, self.owner)
     }
 
     /// Iterate all the key/value pairs in a table. Values are mutable.
-    pub fn for_each_mut(&'a self, f: impl FnMut(&D::Key, &mut D::Value)) {
+    pub fn for_each_mut(&self, f: impl FnMut(&D::Key, &mut D::Value)) {
         <&Self as TabularOpsMut<'_, TableStorage, D>>::for_each_mut(self, f, self.owner)
     }
 }
@@ -775,7 +770,7 @@ mod test {
     fn table_iter_empty_on_fresh_store() {
         let store = KvStore::new();
         let table = store.table::<Items>(OWNER);
-        let items: Vec<_> = table.iter_cloned().collect();
+        let items: Vec<_> = table.iter().collect();
         assert!(items.is_empty());
     }
 
@@ -785,11 +780,11 @@ mod test {
         let table = store.table::<Items>(OWNER);
         table.insert("a", "alpha".to_owned());
         table.insert("b", "beta".to_owned());
-        let mut items: Vec<_> = table.iter_cloned().collect();
+        let mut items: Vec<_> = table.iter().collect();
         items.sort();
         assert_eq!(
             items,
-            vec![("a", "alpha".to_owned()), ("b", "beta".to_owned())]
+            vec![(&"a", &"alpha".to_owned()), (&"b", &"beta".to_owned())]
         );
     }
 
@@ -802,8 +797,8 @@ mod test {
             v.clear();
             v.push_str("v2");
         });
-        let items: Vec<_> = table.iter_cloned().collect();
-        assert_eq!(items, vec![("k", "v2".to_owned())]);
+        let items: Vec<_> = table.iter().collect();
+        assert_eq!(items, vec![(&"k", &"v2".to_owned())]);
     }
 
     #[test]
@@ -811,7 +806,7 @@ mod test {
         let store = KvStore::new();
         let table = store.table::<Items>(OWNER);
         let mut count = 0;
-        table.for_each(|_, _| count += 1);
+        table.iter().for_each(|_| count += 1);
         assert_eq!(count, 0);
     }
 
@@ -822,7 +817,7 @@ mod test {
         table.insert("a", "alpha".to_owned());
         table.insert("b", "beta".to_owned());
         let mut items: Vec<_> = Vec::new();
-        table.for_each(|k, v| items.push((*k, v.clone())));
+        table.iter().for_each(|(k, v)| items.push((*k, v.clone())));
         items.sort();
         assert_eq!(
             items,
@@ -852,7 +847,7 @@ mod test {
     fn table_iter_keys_cloned_empty() {
         let store = KvStore::new();
         let table = store.table::<Items>(OWNER);
-        let keys: Vec<_> = table.iter_keys_cloned().collect();
+        let keys: Vec<_> = table.keys().collect();
         assert!(keys.is_empty());
     }
 
@@ -862,7 +857,7 @@ mod test {
         let table = store.table::<Items>(OWNER);
         table.insert("a", "alpha".to_owned());
         table.insert("b", "beta".to_owned());
-        let mut keys: Vec<_> = table.iter_keys_cloned().collect();
+        let mut keys: Vec<_> = table.keys().copied().collect();
         keys.sort();
         assert_eq!(keys, vec!["a", "b"]);
     }
@@ -871,7 +866,7 @@ mod test {
     fn table_iter_values_cloned_empty() {
         let store = KvStore::new();
         let table = store.table::<Items>(OWNER);
-        let values: Vec<_> = table.iter_values_cloned().collect();
+        let values: Vec<_> = table.values().collect();
         assert!(values.is_empty());
     }
 
@@ -881,9 +876,9 @@ mod test {
         let table = store.table::<Items>(OWNER);
         table.insert("a", "alpha".to_owned());
         table.insert("b", "beta".to_owned());
-        let mut values: Vec<_> = table.iter_values_cloned().collect();
+        let mut values: Vec<_> = table.values().collect();
         values.sort();
-        assert_eq!(values, vec!["alpha".to_owned(), "beta".to_owned()]);
+        assert_eq!(values, vec!["alpha", "beta"]);
     }
 
     #[test]

--- a/ts_kv_store/src/raw.rs
+++ b/ts_kv_store/src/raw.rs
@@ -1,0 +1,924 @@
+//! KvStore non-transactional API.
+
+use std::{borrow::Borrow, hash::Hash, marker::PhantomData, sync::Arc};
+
+use crate::{
+    KvStore, Owner, Result,
+    index::KvTableIndex,
+    operations::{Ops, OpsMut, SingletonOps, SingletonOpsMut, TabularOps, TabularOpsMut},
+    schema,
+    storage::Storage,
+};
+
+impl<'a, TableStorage: schema::GeneratedStorage + 'a> SingletonOps<'a, TableStorage>
+    for &'a crate::KvStore<TableStorage>
+{
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage + 'a> SingletonOpsMut<'a, 'a, TableStorage>
+    for &'a crate::KvStore<TableStorage>
+{
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage + 'a, D: schema::TableDesc<Storage = TableStorage>>
+    Ops<'a, TableStorage> for &'a KvTable<'a, TableStorage, D>
+{
+    type ReadLock = std::sync::RwLockReadGuard<'a, Storage<TableStorage>>;
+
+    fn read_lock(self) -> Self::ReadLock {
+        self.store.storage.read().unwrap()
+    }
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage + 'a, D: schema::TableDesc<Storage = TableStorage>>
+    TabularOps<'a, TableStorage, D> for &'a KvTable<'a, TableStorage, D>
+{
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage + 'a, D: schema::TableDesc<Storage = TableStorage>>
+    OpsMut<'a, TableStorage> for &'a KvTable<'a, TableStorage, D>
+{
+    type WriteLock = std::sync::RwLockWriteGuard<'a, Storage<TableStorage>>;
+
+    fn write_lock(self) -> Self::WriteLock {
+        self.store.storage.write().unwrap()
+    }
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage + 'a, D: schema::TableDesc<Storage = TableStorage>>
+    TabularOpsMut<'a, TableStorage, D> for &'a KvTable<'a, TableStorage, D>
+{
+}
+
+impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
+    /// Operate on tables of key/values in the store.
+    ///
+    /// # Example:
+    ///
+    /// ```rust,ignore
+    /// let value = store.table::<Foo>(OWNER).get(key).unwrap();
+    /// ```
+    pub fn table<'a, D: schema::TableDesc<Storage = TableStorage>>(
+        &'a self,
+        owner: Owner,
+    ) -> KvTable<'a, TableStorage, D> {
+        KvTable {
+            store: self,
+            owner,
+            table: PhantomData,
+        }
+    }
+
+    /// Access a table via an index.
+    ///
+    /// # Example:
+    ///
+    /// ```rust,ignore
+    /// let value = store.table_by::<index::Foo::bar>(OWNER).get(key).unwrap();
+    /// ```
+    ///
+    /// Here `Foo` describes a tables and `bar` describes an index over `Foo` using the `bar` field
+    /// as foreign key.
+    pub fn table_by<'a, D: schema::IndexDesc<Storage = TableStorage>>(
+        &'a self,
+        owner: Owner,
+    ) -> KvTableIndex<'a, TableStorage, D, D::BaseTable> {
+        KvTableIndex {
+            store: self,
+            owner,
+            index: PhantomData,
+            base: PhantomData,
+        }
+    }
+
+    /// Get a single value from the store by cloning the value.
+    ///
+    /// Returns `None` if there is no value for the specified key.
+    pub fn get<D: schema::Singleton>(&self, owner: Owner) -> Option<D::Value>
+    where
+        D::Value: Clone,
+    {
+        <&Self as SingletonOps<'_, TableStorage>>::get::<D>(self, owner)
+    }
+
+    /// Get a single value from the store by cloning an `Arc`.
+    ///
+    /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
+    pub fn get_arc<D: schema::ArcSingleton>(&self, owner: Owner) -> Option<Arc<D::Value>> {
+        <&Self as SingletonOps<'_, TableStorage>>::get_arc::<D>(self, owner)
+    }
+
+    /// Get immutable access to a value in the store by reference.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn with<D: schema::Singleton, T>(
+        &self,
+        owner: Owner,
+        f: impl FnOnce(&D::Value) -> T,
+    ) -> Option<T> {
+        <&Self as SingletonOps<'_, TableStorage>>::with::<D, T>(self, f, owner)
+    }
+
+    /// Insert a single value into the store.
+    ///
+    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
+    // Question: do we need separate insert/update/upsert methods?
+    pub fn insert<D: schema::Singleton>(
+        &self,
+        owner: Owner,
+        value: D::ArgValue,
+    ) -> Option<D::ArgValue> {
+        <&Self as SingletonOpsMut<'_, '_, TableStorage>>::insert::<D>(self, value, owner)
+    }
+
+    /// Get mutable access to a value in the store.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn mutate<D: schema::MutSingleton, T>(
+        &self,
+        owner: Owner,
+        f: impl FnOnce(&mut D::Value) -> T,
+    ) -> Option<T> {
+        <&Self as SingletonOpsMut<'_, '_, TableStorage>>::mutate::<D, T>(self, f, owner)
+    }
+
+    /// Remove a single value from the store.
+    ///
+    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
+    pub fn remove<D: schema::Singleton>(&self, owner: Owner) -> Option<D::ArgValue> {
+        <&Self as SingletonOpsMut<'_, '_, TableStorage>>::remove::<D>(self, owner)
+    }
+
+    /// Remove a single value from the store while preserving ownership of the key/value.
+    ///
+    /// Can also be used to initialize a key/value with a key but without a value.
+    ///
+    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
+    pub fn clear<D: schema::Singleton>(&self, owner: Owner) -> Option<D::ArgValue> {
+        <&Self as SingletonOpsMut<'_, '_, TableStorage>>::clear::<D>(self, owner)
+    }
+}
+
+/// Abstracts a table of key/values pairs in the store.
+///
+/// `KvTable` has no transactional semantics and only exists as a convenience for accessing
+/// tabular data.
+pub struct KvTable<
+    'a,
+    TableStorage: schema::GeneratedStorage,
+    D: schema::TableDesc<Storage = TableStorage>,
+> {
+    store: &'a KvStore<TableStorage>,
+    owner: Owner,
+    table: PhantomData<D>,
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage, D: schema::TableDesc<Storage = TableStorage>>
+    KvTable<'a, TableStorage, D>
+{
+    /// Initialize a table by setting its owner.
+    ///
+    /// Calling this function is optional, a table can be used without initialization in which case,
+    /// its owner is set to the owner specifed in the first write.
+    ///
+    /// Returns an error (containing the current owner of the table) if the table has already been
+    /// initialized. In this case, the table will be in a consistent state and can be used as normal.
+    pub fn init(&'a self) -> Result<()> {
+        <&Self as TabularOpsMut<'_, TableStorage, D>>::init(self, self.owner)
+    }
+
+    /// The number of key/value pairs in the table.
+    pub fn len(&'a self) -> usize {
+        <&Self as TabularOps<'_, TableStorage, D>>::len(self)
+    }
+
+    /// True if the table is empty.
+    pub fn is_empty(&'a self) -> bool {
+        <&Self as TabularOps<'_, TableStorage, D>>::is_empty(self)
+    }
+
+    /// Clear a table by removing all its KVs, but preserve ownership.
+    pub fn clear(&'a self) {
+        <&Self as TabularOpsMut<'_, TableStorage, D>>::clear(self, self.owner)
+    }
+
+    /// Get a row of the table from the store by cloning the value.
+    ///
+    /// Returns `None` if there is no value for the specified key.
+    pub fn get<Q>(&'a self, key: &Q) -> Option<D::Value>
+    where
+        D::Value: Clone,
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&Self as TabularOps<'_, TableStorage, D>>::get(self, key, self.owner)
+    }
+
+    /// Get immutable access to a row of the table in the store by reference.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn with<Q, T>(&'a self, key: &Q, f: impl FnOnce(&D::Value) -> T) -> Option<T>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&Self as TabularOps<'_, TableStorage, D>>::with(self, key, f, self.owner)
+    }
+
+    /// Insert a value into the table.
+    ///
+    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
+    pub fn insert(&'a self, key: D::Key, value: D::Value) -> Option<D::Value>
+    where
+        D::Key: Clone,
+    {
+        <&Self as TabularOpsMut<'_, TableStorage, D>>::insert(self, key, value, self.owner)
+    }
+
+    /// Get mutable access to a row of the table in the store in the store.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn mutate<Q, T>(&'a self, key: &Q, f: impl FnOnce(&mut D::Value) -> T) -> Option<T>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
+    {
+        <&Self as TabularOpsMut<'_, TableStorage, D>>::mutate(self, key, f, self.owner)
+    }
+
+    /// Remove a row from the table.
+    ///
+    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
+    pub fn remove<Q>(&'a self, key: &Q) -> Option<D::Value>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&Self as TabularOpsMut<'_, TableStorage, D>>::remove(self, key, self.owner)
+    }
+
+    /// Iterate all the key/value pairs in a table.
+    ///
+    /// Clones both keys and values and provides them by-value. To iterate without cloning, see
+    /// [`Self::for_each`].
+    pub fn iter_cloned(&'a self) -> impl Iterator<Item = (D::Key, D::Value)>
+    where
+        D::Key: Clone,
+        D::Value: Clone,
+    {
+        <&Self as TabularOps<'_, TableStorage, D>>::iter_cloned(self, self.owner)
+    }
+
+    /// Iterate all the keys in a table.
+    ///
+    /// Clones the keys and provides them by-value. To iterate without cloning, see
+    /// [`Self::for_each`].
+    pub fn iter_keys_cloned(&'a self) -> impl Iterator<Item = D::Key>
+    where
+        D::Key: Clone,
+    {
+        <&Self as TabularOps<'_, TableStorage, D>>::iter_keys_cloned(self, self.owner)
+    }
+
+    /// Iterate all the values in a table.
+    ///
+    /// Clones values and provides them by-value. To iterate without cloning, see
+    /// [`Self::for_each`].
+    pub fn iter_values_cloned(&'a self) -> impl Iterator<Item = D::Value>
+    where
+        D::Value: Clone,
+    {
+        <&Self as TabularOps<'_, TableStorage, D>>::iter_values_cloned(self, self.owner)
+    }
+
+    /// Iterate all the key/value pairs in a table.
+    ///
+    /// We're not able to make this an iterator because we have to ensure that the references do
+    /// not outlive our lock on the store. For a (cloning) iterator see [`Self::iter_cloned`].
+    pub fn for_each(&'a self, f: impl FnMut(&D::Key, &D::Value)) {
+        <&Self as TabularOps<'_, TableStorage, D>>::for_each(self, f, self.owner)
+    }
+
+    /// Iterate all the key/value pairs in a table. Values are mutable.
+    pub fn for_each_mut(&'a self, f: impl FnMut(&D::Key, &mut D::Value)) {
+        <&Self as TabularOpsMut<'_, TableStorage, D>>::for_each_mut(self, f, self.owner)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{any::Any, sync::Arc};
+
+    use crate::{Error, singleton, tables};
+
+    singleton!(Count(u64));
+    singleton!(Name(String as Box));
+    singleton!(Shared(String as Arc));
+    singleton!(Label(u64 as Ref));
+
+    tables!(Items(&'static str => String), Counters(u32 => u64));
+
+    const OWNER: &str = "owner";
+    const OTHER: &str = "other";
+
+    #[test]
+    fn get_returns_none_when_absent() {
+        let store = KvStore::new();
+        assert!(store.get::<Count>(OWNER).is_none());
+    }
+
+    #[test]
+    fn get_returns_value_after_insert() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 42);
+        assert_eq!(store.get::<Count>(OWNER), Some(42));
+    }
+
+    #[test]
+    fn get_returns_none_after_clear() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        store.clear::<Count>(OWNER);
+        assert!(store.get::<Count>(OWNER).is_none());
+    }
+
+    #[test]
+    fn get_returns_none_after_remove() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        store.remove::<Count>(OWNER);
+        assert!(store.get::<Count>(OWNER).is_none());
+    }
+
+    #[test]
+    fn get_ref_singleton() {
+        static STATIC_LABEL: u64 = 99;
+        let store = KvStore::new();
+        store.insert::<Label>(OWNER, &STATIC_LABEL);
+        assert_eq!(store.get::<Label>(OWNER), Some(99));
+    }
+
+    #[test]
+    fn get_arc_returns_none_when_absent() {
+        let store = KvStore::new();
+        assert!(store.get_arc::<Shared>(OWNER).is_none());
+    }
+
+    #[test]
+    fn get_arc_returns_arc_after_insert() {
+        let store = KvStore::new();
+        store.insert::<Shared>(OWNER, Arc::new("hello".to_owned()));
+        let arc = store.get_arc::<Shared>(OWNER).unwrap();
+        assert_eq!(*arc, "hello");
+    }
+
+    #[test]
+    fn get_arc_shares_allocation() {
+        let store = KvStore::new();
+        store.insert::<Shared>(OWNER, Arc::new("hello".to_owned()));
+        let arc1 = store.get_arc::<Shared>(OWNER).unwrap();
+        let arc2 = store.get_arc::<Shared>(OWNER).unwrap();
+        assert!(Arc::ptr_eq(&arc1, &arc2));
+    }
+
+    #[test]
+    fn with_returns_none_and_does_not_call_f_when_absent() {
+        let store = KvStore::new();
+        let mut called = false;
+        let result = store.with::<Count, ()>(OWNER, |_| {
+            called = true;
+        });
+        assert!(result.is_none());
+        assert!(!called);
+    }
+
+    #[test]
+    fn with_returns_result_of_f() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 5);
+        assert_eq!(store.with::<Count, _>(OWNER, |v| v * 2), Some(10));
+    }
+
+    #[test]
+    fn insert_returns_none_on_first_insert() {
+        let store = KvStore::new();
+        assert!(store.insert::<Count>(OWNER, 1).is_none());
+    }
+
+    #[test]
+    fn insert_returns_previous_value() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        assert_eq!(store.insert::<Count>(OWNER, 2), Some(1));
+    }
+
+    #[test]
+    fn insert_over_tombstone_returns_none() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        store.clear::<Count>(OWNER);
+        assert!(store.insert::<Count>(OWNER, 2).is_none());
+    }
+
+    #[test]
+    fn insert_over_removed_returns_none() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        store.remove::<Count>(OWNER);
+        assert!(store.insert::<Count>(OWNER, 2).is_none());
+    }
+
+    #[test]
+    fn mutate_returns_none_and_does_not_call_f_when_absent() {
+        let store = KvStore::new();
+        let mut called = false;
+        let result = store.mutate::<Count, ()>(OWNER, |_| {
+            called = true;
+        });
+        assert!(result.is_none());
+        assert!(!called);
+    }
+
+    #[test]
+    fn mutate_modifies_value_in_place() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 10);
+        assert_eq!(
+            store.mutate::<Count, _>(OWNER, |v| {
+                *v += 5;
+                *v
+            }),
+            Some(15)
+        );
+        assert_eq!(store.get::<Count>(OWNER), Some(15));
+    }
+
+    #[test]
+    fn mutate_on_tombstone_returns_none() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        store.clear::<Count>(OWNER);
+        assert!(store.mutate::<Count, ()>(OWNER, |_| {}).is_none());
+    }
+
+    #[test]
+    fn mutate_box_singleton() {
+        let store = KvStore::new();
+        store.insert::<Name>(OWNER, "hello".to_owned());
+        store.mutate::<Name, ()>(OWNER, |s| s.push_str(" world"));
+        assert_eq!(store.get::<Name>(OWNER), Some("hello world".to_owned()));
+    }
+
+    #[test]
+    fn remove_returns_none_when_absent() {
+        let store = KvStore::new();
+        assert!(store.remove::<Count>(OWNER).is_none());
+    }
+
+    #[test]
+    fn remove_returns_previous_value() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 7);
+        assert_eq!(store.remove::<Count>(OWNER), Some(7));
+    }
+
+    #[test]
+    fn remove_makes_entry_absent() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        store.remove::<Count>(OWNER);
+        assert!(store.get::<Count>(OWNER).is_none());
+    }
+
+    #[test]
+    fn remove_allows_reinsert_by_other_owner() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        store.remove::<Count>(OWNER);
+        // Entry is fully gone — any owner can insert
+        store.insert::<Count>(OTHER, 2);
+        assert_eq!(store.get::<Count>(OTHER), Some(2));
+    }
+
+    #[test]
+    fn clear_returns_none_when_absent() {
+        let store = KvStore::new();
+        assert!(store.clear::<Count>(OWNER).is_none());
+    }
+
+    #[test]
+    fn clear_returns_previous_value() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 3);
+        assert_eq!(store.clear::<Count>(OWNER), Some(3));
+    }
+
+    #[test]
+    fn clear_makes_get_return_none() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        store.clear::<Count>(OWNER);
+        assert!(store.get::<Count>(OWNER).is_none());
+    }
+
+    #[test]
+    fn double_clear_returns_none() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        store.clear::<Count>(OWNER);
+        assert!(store.clear::<Count>(OWNER).is_none());
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn singleton_insert_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        store.insert::<Count>(OTHER, 2);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn singleton_mutate_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        store.mutate::<Count, ()>(OTHER, |_| {});
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn singleton_remove_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        store.remove::<Count>(OTHER);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn singleton_clear_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        store.clear::<Count>(OTHER);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn singleton_clear_blocks_other_owner() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        store.clear::<Count>(OWNER);
+        // Tombstone preserves OWNER — OTHER cannot insert
+        store.insert::<Count>(OTHER, 2);
+    }
+
+    #[test]
+    fn table_init_succeeds_on_fresh_table() {
+        let store = KvStore::new();
+        assert!(store.table::<Items>(OWNER).init().is_ok());
+    }
+
+    #[test]
+    fn table_init_second_call_returns_err() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).init().unwrap();
+        let err = store.table::<Items>(OWNER).init().unwrap_err();
+        assert!(matches!(err, Error::AlreadyInit(o) if o == OWNER));
+    }
+
+    #[test]
+    fn table_init_with_different_owner_returns_err() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).init().unwrap();
+        let err = store.table::<Items>(OTHER).init().unwrap_err();
+        assert!(matches!(err, Error::AlreadyInit(o) if o == OWNER));
+    }
+
+    #[test]
+    fn table_init_is_optional() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "v".to_owned());
+        assert_eq!(store.table::<Items>(OWNER).get("k"), Some("v".to_owned()));
+    }
+
+    #[test]
+    fn table_get_returns_none_when_absent() {
+        let store = KvStore::new();
+        assert!(store.table::<Items>(OWNER).get("missing").is_none());
+    }
+
+    #[test]
+    fn table_insert_returns_none_on_first() {
+        let store = KvStore::new();
+        assert!(
+            store
+                .table::<Items>(OWNER)
+                .insert("k", "v".to_owned())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn table_insert_returns_previous_value() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "v1".to_owned());
+        assert_eq!(
+            store.table::<Items>(OWNER).insert("k", "v2".to_owned()),
+            Some("v1".to_owned()),
+        );
+    }
+
+    #[test]
+    fn table_get_returns_value_after_insert() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "val".to_owned());
+        assert_eq!(store.table::<Items>(OWNER).get("k"), Some("val".to_owned()));
+    }
+
+    #[test]
+    fn table_get_with_borrow_type() {
+        let store = KvStore::new();
+        store.table::<Counters>(OWNER).insert(42u32, 100u64);
+        assert_eq!(store.table::<Counters>(OWNER).get(&42u32), Some(100u64));
+    }
+
+    #[test]
+    fn table_with_returns_none_and_does_not_call_f_when_absent() {
+        let store = KvStore::new();
+        let mut called = false;
+        let result = store.table::<Items>(OWNER).with("missing", |_| {
+            called = true;
+        });
+        assert!(result.is_none());
+        assert!(!called);
+    }
+
+    #[test]
+    fn table_with_returns_some_after_insert() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "val".to_owned());
+        assert_eq!(store.table::<Items>(OWNER).with("k", |s| s.len()), Some(3));
+    }
+
+    #[test]
+    fn table_mutate_returns_none_when_absent() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).init().unwrap();
+        assert!(
+            store
+                .table::<Items>(OWNER)
+                .mutate(&"missing", |v| v.len())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn table_mutate_modifies_value() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "hello".to_owned());
+        store.table::<Items>(OWNER).mutate(&"k", |v| v.push('!'));
+        assert_eq!(
+            store.table::<Items>(OWNER).get("k"),
+            Some("hello!".to_owned())
+        );
+    }
+
+    #[test]
+    fn table_remove_returns_none_when_absent() {
+        let store = KvStore::new();
+        assert!(store.table::<Items>(OWNER).remove("missing").is_none());
+    }
+
+    #[test]
+    fn table_remove_returns_previous_value() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "v".to_owned());
+        assert_eq!(
+            store.table::<Items>(OWNER).remove("k"),
+            Some("v".to_owned())
+        );
+    }
+
+    #[test]
+    fn table_remove_makes_get_return_none() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "v".to_owned());
+        store.table::<Items>(OWNER).remove("k");
+        assert!(store.table::<Items>(OWNER).get("k").is_none());
+    }
+
+    #[test]
+    fn table_clear_removes_all_rows() {
+        let store = KvStore::new();
+        let table = store.table::<Items>(OWNER);
+        table.insert("a", "alpha".to_owned());
+        table.insert("b", "beta".to_owned());
+        table.insert("c", "gamma".to_owned());
+        table.clear();
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn table_clear_preserves_ownership() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "v".to_owned());
+        store.table::<Items>(OWNER).clear();
+        // Same owner can still write after clear
+        store.table::<Items>(OWNER).insert("k2", "v2".to_owned());
+        assert_eq!(store.table::<Items>(OWNER).get("k2"), Some("v2".to_owned()));
+    }
+
+    #[test]
+    fn table_is_empty_on_fresh_store() {
+        let store = KvStore::new();
+        assert!(store.table::<Items>(OWNER).is_empty());
+    }
+
+    #[test]
+    fn table_len_zero_on_fresh_store() {
+        let store = KvStore::new();
+        assert_eq!(store.table::<Items>(OWNER).len(), 0);
+    }
+
+    #[test]
+    fn table_len_increases_with_inserts() {
+        let store = KvStore::new();
+        let table = store.table::<Items>(OWNER);
+        table.insert("a", "alpha".to_owned());
+        table.insert("b", "beta".to_owned());
+        table.insert("c", "gamma".to_owned());
+        assert_eq!(table.len(), 3);
+    }
+
+    #[test]
+    fn table_len_decreases_after_remove() {
+        let store = KvStore::new();
+        let table = store.table::<Items>(OWNER);
+        table.insert("a", "alpha".to_owned());
+        table.insert("b", "beta".to_owned());
+        table.remove("a");
+        assert_eq!(table.len(), 1);
+    }
+
+    #[test]
+    fn table_is_empty_false_after_insert() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "v".to_owned());
+        assert!(!store.table::<Items>(OWNER).is_empty());
+    }
+
+    #[test]
+    fn table_iter_empty_on_fresh_store() {
+        let store = KvStore::new();
+        let table = store.table::<Items>(OWNER);
+        let items: Vec<_> = table.iter_cloned().collect();
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn table_iter_yields_all_rows() {
+        let store = KvStore::new();
+        let table = store.table::<Items>(OWNER);
+        table.insert("a", "alpha".to_owned());
+        table.insert("b", "beta".to_owned());
+        let mut items: Vec<_> = table.iter_cloned().collect();
+        items.sort();
+        assert_eq!(
+            items,
+            vec![("a", "alpha".to_owned()), ("b", "beta".to_owned())]
+        );
+    }
+
+    #[test]
+    fn table_iter_reflects_mutations() {
+        let store = KvStore::new();
+        let table = store.table::<Items>(OWNER);
+        table.insert("k", "v1".to_owned());
+        table.mutate(&"k", |v| {
+            v.clear();
+            v.push_str("v2");
+        });
+        let items: Vec<_> = table.iter_cloned().collect();
+        assert_eq!(items, vec![("k", "v2".to_owned())]);
+    }
+
+    #[test]
+    fn table_for_each_empty_calls_closure_zero_times() {
+        let store = KvStore::new();
+        let table = store.table::<Items>(OWNER);
+        let mut count = 0;
+        table.for_each(|_, _| count += 1);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn table_for_each_yields_all_rows() {
+        let store = KvStore::new();
+        let table = store.table::<Items>(OWNER);
+        table.insert("a", "alpha".to_owned());
+        table.insert("b", "beta".to_owned());
+        let mut items: Vec<_> = Vec::new();
+        table.for_each(|k, v| items.push((*k, v.clone())));
+        items.sort();
+        assert_eq!(
+            items,
+            vec![("a", "alpha".to_owned()), ("b", "beta".to_owned())]
+        );
+    }
+
+    #[test]
+    fn table_for_each_mut_empty_calls_closure_zero_times() {
+        let store = KvStore::new();
+        let table = store.table::<Items>(OWNER);
+        let mut count = 0;
+        table.for_each_mut(|_, _| count += 1);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn table_for_each_mut_modifies_values() {
+        let store = KvStore::new();
+        let table = store.table::<Items>(OWNER);
+        table.insert("k", "hello".to_owned());
+        table.for_each_mut(|_, v| v.push('!'));
+        assert_eq!(table.get("k"), Some("hello!".to_owned()));
+    }
+
+    #[test]
+    fn table_iter_keys_cloned_empty() {
+        let store = KvStore::new();
+        let table = store.table::<Items>(OWNER);
+        let keys: Vec<_> = table.iter_keys_cloned().collect();
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn table_iter_keys_cloned_yields_all_keys() {
+        let store = KvStore::new();
+        let table = store.table::<Items>(OWNER);
+        table.insert("a", "alpha".to_owned());
+        table.insert("b", "beta".to_owned());
+        let mut keys: Vec<_> = table.iter_keys_cloned().collect();
+        keys.sort();
+        assert_eq!(keys, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn table_iter_values_cloned_empty() {
+        let store = KvStore::new();
+        let table = store.table::<Items>(OWNER);
+        let values: Vec<_> = table.iter_values_cloned().collect();
+        assert!(values.is_empty());
+    }
+
+    #[test]
+    fn table_iter_values_cloned_yields_all_values() {
+        let store = KvStore::new();
+        let table = store.table::<Items>(OWNER);
+        table.insert("a", "alpha".to_owned());
+        table.insert("b", "beta".to_owned());
+        let mut values: Vec<_> = table.iter_values_cloned().collect();
+        values.sort();
+        assert_eq!(values, vec!["alpha".to_owned(), "beta".to_owned()]);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn table_insert_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).init().unwrap();
+        store.table::<Items>(OTHER).insert("k", "v".to_owned());
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn table_mutate_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).init().unwrap();
+        store.table::<Items>(OTHER).mutate(&"k", |v| v.len());
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn table_remove_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).init().unwrap();
+        store.table::<Items>(OTHER).remove("k");
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn table_clear_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).init().unwrap();
+        store.table::<Items>(OTHER).clear();
+    }
+}

--- a/ts_kv_store/src/raw.rs
+++ b/ts_kv_store/src/raw.rs
@@ -134,12 +134,12 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     /// Get mutable access to a value in the store.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn mutate<D: schema::MutSingleton, T>(
+    pub fn with_mut<D: schema::MutSingleton, T>(
         &self,
         owner: Owner,
         f: impl FnOnce(&mut D::Value) -> T,
     ) -> Option<T> {
-        <&Self as SingletonOpsMut<'_, '_, TableStorage>>::mutate::<D, T>(self, f, owner)
+        <&Self as SingletonOpsMut<'_, '_, TableStorage>>::with_mut::<D, T>(self, f, owner)
     }
 
     /// Remove a single value from the store.
@@ -238,12 +238,12 @@ impl<'a, TableStorage: schema::GeneratedStorage, D: schema::TableDesc<Storage = 
     /// Get mutable access to a row of the table in the store in the store.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn mutate<Q, T>(&'a self, key: &Q, f: impl FnOnce(&mut D::Value) -> T) -> Option<T>
+    pub fn with_mut<Q, T>(&'a self, key: &Q, f: impl FnOnce(&mut D::Value) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
     {
-        <&Self as TabularOpsMut<'_, TableStorage, D>>::mutate(self, key, f, self.owner)
+        <&Self as TabularOpsMut<'_, TableStorage, D>>::with_mut(self, key, f, self.owner)
     }
 
     /// Remove a row from the table.
@@ -432,7 +432,7 @@ mod test {
     fn mutate_returns_none_and_does_not_call_f_when_absent() {
         let store = KvStore::new();
         let mut called = false;
-        let result = store.mutate::<Count, ()>(OWNER, |_| {
+        let result = store.with_mut::<Count, ()>(OWNER, |_| {
             called = true;
         });
         assert!(result.is_none());
@@ -444,7 +444,7 @@ mod test {
         let store = KvStore::new();
         store.insert::<Count>(OWNER, 10);
         assert_eq!(
-            store.mutate::<Count, _>(OWNER, |v| {
+            store.with_mut::<Count, _>(OWNER, |v| {
                 *v += 5;
                 *v
             }),
@@ -458,14 +458,14 @@ mod test {
         let store = KvStore::new();
         store.insert::<Count>(OWNER, 1);
         store.clear::<Count>(OWNER);
-        assert!(store.mutate::<Count, ()>(OWNER, |_| {}).is_none());
+        assert!(store.with_mut::<Count, ()>(OWNER, |_| {}).is_none());
     }
 
     #[test]
     fn mutate_box_singleton() {
         let store = KvStore::new();
         store.insert::<Name>(OWNER, "hello".to_owned());
-        store.mutate::<Name, ()>(OWNER, |s| s.push_str(" world"));
+        store.with_mut::<Name, ()>(OWNER, |s| s.push_str(" world"));
         assert_eq!(store.get::<Name>(OWNER), Some("hello world".to_owned()));
     }
 
@@ -544,7 +544,7 @@ mod test {
     fn singleton_mutate_wrong_owner_panics() {
         let store = KvStore::new();
         store.insert::<Count>(OWNER, 1);
-        store.mutate::<Count, ()>(OTHER, |_| {});
+        store.with_mut::<Count, ()>(OTHER, |_| {});
     }
 
     #[test]
@@ -671,7 +671,7 @@ mod test {
         assert!(
             store
                 .table::<Items>(OWNER)
-                .mutate(&"missing", |v| v.len())
+                .with_mut(&"missing", |v| v.len())
                 .is_none()
         );
     }
@@ -680,7 +680,7 @@ mod test {
     fn table_mutate_modifies_value() {
         let store = KvStore::new();
         store.table::<Items>(OWNER).insert("k", "hello".to_owned());
-        store.table::<Items>(OWNER).mutate(&"k", |v| v.push('!'));
+        store.table::<Items>(OWNER).with_mut(&"k", |v| v.push('!'));
         assert_eq!(
             store.table::<Items>(OWNER).get("k"),
             Some("hello!".to_owned())
@@ -798,7 +798,7 @@ mod test {
         let store = KvStore::new();
         let table = store.table::<Items>(OWNER);
         table.insert("k", "v1".to_owned());
-        table.mutate(&"k", |v| {
+        table.with_mut(&"k", |v| {
             v.clear();
             v.push_str("v2");
         });
@@ -901,7 +901,7 @@ mod test {
     fn table_mutate_wrong_owner_panics() {
         let store = KvStore::new();
         store.table::<Items>(OWNER).init().unwrap();
-        store.table::<Items>(OTHER).mutate(&"k", |v| v.len());
+        store.table::<Items>(OTHER).with_mut(&"k", |v| v.len());
     }
 
     #[test]

--- a/ts_kv_store/src/raw.rs
+++ b/ts_kv_store/src/raw.rs
@@ -1,6 +1,6 @@
 //! KvStore non-transactional API.
 
-use std::{borrow::Borrow, hash::Hash, marker::PhantomData, sync::Arc};
+use std::{borrow::Borrow, hash::Hash, sync::Arc};
 
 use crate::{
     KvStore, Owner, Result,
@@ -10,60 +10,33 @@ use crate::{
     storage::Storage,
 };
 
-impl<'store: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
-    SingletonOps<'store, TableStorage> for &'r crate::KvStore<TableStorage>
-{
-}
+impl<TableStorage: schema::GeneratedStorage> SingletonOps for &KvStore<TableStorage> {}
+impl<TableStorage: schema::GeneratedStorage> SingletonOpsMut for &KvStore<TableStorage> {}
 
-impl<'store: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
-    SingletonOpsMut<'store, TableStorage> for &'r crate::KvStore<TableStorage>
-{
-}
-
-impl<
-    'store: 'r,
-    'r,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: schema::TableDesc<Storage = TableStorage>,
-> Ops<'store, TableStorage> for &'r KvTable<'store, TableStorage, D>
-{
-    type ReadLock = std::sync::RwLockReadGuard<'r, Storage<TableStorage>>;
+impl<'r, D: schema::TableDesc> Ops for &'r KvTable<'_, D> {
+    type ReadLock = std::sync::RwLockReadGuard<'r, Self::Storage>;
+    type Storage = Storage<D::Storage>;
 
     fn read_lock(self) -> Self::ReadLock {
         self.store.storage.read().unwrap()
     }
 }
 
-impl<
-    'store: 'r,
-    'r,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: schema::TableDesc<Storage = TableStorage>,
-> TabularOps<'store, TableStorage, D> for &'r KvTable<'store, TableStorage, D>
-{
+impl<D: schema::TableDesc> TabularOps for &KvTable<'_, D> {
+    type Desc = D;
 }
 
-impl<
-    'store: 'r,
-    'r,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: schema::TableDesc<Storage = TableStorage>,
-> OpsMut<'store, TableStorage> for &'r KvTable<'store, TableStorage, D>
-{
-    type WriteLock = std::sync::RwLockWriteGuard<'r, Storage<TableStorage>>;
+impl<'r, D: schema::TableDesc> OpsMut for &'r KvTable<'_, D> {
+    type WriteLock = std::sync::RwLockWriteGuard<'r, Self::StorageMut>;
+    type StorageMut = Storage<D::Storage>;
 
     fn write_lock(self) -> Self::WriteLock {
         self.store.storage.write().unwrap()
     }
 }
 
-impl<
-    'store: 'r,
-    'r,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: schema::TableDesc<Storage = TableStorage>,
-> TabularOpsMut<'store, TableStorage, D> for &'r KvTable<'store, TableStorage, D>
-{
+impl<D: schema::TableDesc> TabularOpsMut for &KvTable<'_, D> {
+    type DescMut = D;
 }
 
 impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
@@ -77,12 +50,8 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     pub fn table<D: schema::TableDesc<Storage = TableStorage>>(
         &self,
         owner: Owner,
-    ) -> KvTable<'_, TableStorage, D> {
-        KvTable {
-            store: self,
-            owner,
-            table: PhantomData,
-        }
+    ) -> KvTable<'_, D> {
+        KvTable { store: self, owner }
     }
 
     /// Access a table via an index.
@@ -98,13 +67,8 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     pub fn table_by<D: schema::IndexDesc<Storage = TableStorage>>(
         &self,
         owner: Owner,
-    ) -> KvTableIndex<'_, TableStorage, D, D::BaseTable> {
-        KvTableIndex {
-            store: self,
-            owner,
-            index: PhantomData,
-            base: PhantomData,
-        }
+    ) -> KvTableIndex<'_, D> {
+        KvTableIndex { store: self, owner }
     }
 
     /// Get a single value from the store by cloning the value.
@@ -114,14 +78,14 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     where
         D::Value: Clone,
     {
-        <&Self as SingletonOps<'_, TableStorage>>::get::<D>(self, owner)
+        <&Self as SingletonOps>::get::<D>(self, owner)
     }
 
     /// Get a single value from the store by cloning an `Arc`.
     ///
     /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
     pub fn get_arc<D: schema::ArcSingleton>(&self, owner: Owner) -> Option<Arc<D::Value>> {
-        <&Self as SingletonOps<'_, TableStorage>>::get_arc::<D>(self, owner)
+        <&Self as SingletonOps>::get_arc::<D>(self, owner)
     }
 
     /// Get immutable access to a value in the store by reference.
@@ -132,7 +96,7 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
         owner: Owner,
         f: impl FnOnce(&D::Value) -> T,
     ) -> Option<T> {
-        <&Self as SingletonOps<'_, TableStorage>>::with::<D, T>(self, f, owner)
+        <&Self as SingletonOps>::with::<D, T>(self, f, owner)
     }
 
     /// Insert a single value into the store.
@@ -144,7 +108,7 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
         owner: Owner,
         value: D::ArgValue,
     ) -> Option<D::ArgValue> {
-        <&Self as SingletonOpsMut<'_, TableStorage>>::insert::<D>(self, value, owner)
+        <&Self as SingletonOpsMut>::insert::<D>(self, value, owner)
     }
 
     /// Get mutable access to a value in the store.
@@ -155,14 +119,14 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
         owner: Owner,
         f: impl FnOnce(&mut D::Value) -> T,
     ) -> Option<T> {
-        <&Self as SingletonOpsMut<'_, TableStorage>>::with_mut::<D, T>(self, f, owner)
+        <&Self as SingletonOpsMut>::with_mut::<D, T>(self, f, owner)
     }
 
     /// Remove a single value from the store.
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn remove<D: schema::Singleton>(&self, owner: Owner) -> Option<D::ArgValue> {
-        <&Self as SingletonOpsMut<'_, TableStorage>>::remove::<D>(self, owner)
+        <&Self as SingletonOpsMut>::remove::<D>(self, owner)
     }
 
     /// Remove a single value from the store while preserving ownership of the key/value.
@@ -171,7 +135,7 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn clear<D: schema::Singleton>(&self, owner: Owner) -> Option<D::ArgValue> {
-        <&Self as SingletonOpsMut<'_, TableStorage>>::clear::<D>(self, owner)
+        <&Self as SingletonOpsMut>::clear::<D>(self, owner)
     }
 }
 
@@ -179,22 +143,12 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
 ///
 /// `KvTable` has no transactional semantics and only exists as a convenience for accessing
 /// tabular data.
-pub struct KvTable<
-    'store,
-    TableStorage: schema::GeneratedStorage,
-    D: schema::TableDesc<Storage = TableStorage>,
-> {
-    store: &'store KvStore<TableStorage>,
+pub struct KvTable<'store, D: schema::TableDesc> {
+    store: &'store KvStore<D::Storage>,
     owner: Owner,
-    table: PhantomData<D>,
 }
 
-impl<
-    'store,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: schema::TableDesc<Storage = TableStorage>,
-> KvTable<'store, TableStorage, D>
-{
+impl<D: schema::TableDesc> KvTable<'_, D> {
     /// Initialize a table by setting its owner.
     ///
     /// Calling this function is optional, a table can be used without initialization in which case,
@@ -203,22 +157,22 @@ impl<
     /// Returns an error (containing the current owner of the table) if the table has already been
     /// initialized. In this case, the table will be in a consistent state and can be used as normal.
     pub fn init(&self) -> Result<()> {
-        <&Self as TabularOpsMut<'_, TableStorage, D>>::init(self, self.owner)
+        <&Self as TabularOpsMut>::init(self, self.owner)
     }
 
     /// The number of key/value pairs in the table.
     pub fn len(&self) -> usize {
-        <&Self as TabularOps<'_, TableStorage, D>>::len(self)
+        <&Self as TabularOps>::len(self)
     }
 
     /// True if the table is empty.
     pub fn is_empty(&self) -> bool {
-        <&Self as TabularOps<'_, TableStorage, D>>::is_empty(self)
+        <&Self as TabularOps>::is_empty(self)
     }
 
     /// Clear a table by removing all its KVs, but preserve ownership.
     pub fn clear(&self) {
-        <&Self as TabularOpsMut<'_, TableStorage, D>>::clear(self, self.owner)
+        <&Self as TabularOpsMut>::clear(self, self.owner)
     }
 
     /// Get a row of the table from the store by cloning the value.
@@ -230,73 +184,70 @@ impl<
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
     {
-        <&Self as TabularOps<'_, TableStorage, D>>::get(self, key, self.owner)
+        <&Self as TabularOps>::get(self, key, self.owner)
     }
 
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&'store self, key: &Q, f: impl FnOnce(&D::Value) -> T) -> Option<T>
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&D::Value) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
     {
-        <&Self as TabularOps<'_, TableStorage, D>>::with(self, key, f, self.owner)
+        <&Self as TabularOps>::with(self, key, f, self.owner)
     }
 
     /// Insert a value into the table.
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
-    pub fn insert(&'store self, key: D::Key, value: D::Value) -> Option<D::Value>
+    pub fn insert(&self, key: D::Key, value: D::Value) -> Option<D::Value>
     where
         D::Key: Clone,
     {
-        <&Self as TabularOpsMut<'_, TableStorage, D>>::insert(self, key, value, self.owner)
+        <&Self as TabularOpsMut>::insert(self, key, value, self.owner)
     }
 
     /// Get mutable access to a row of the table in the store in the store.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with_mut<Q, T>(&'store self, key: &Q, f: impl FnOnce(&mut D::Value) -> T) -> Option<T>
+    pub fn with_mut<Q, T>(&self, key: &Q, f: impl FnOnce(&mut D::Value) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
     {
-        <&Self as TabularOpsMut<'_, TableStorage, D>>::with_mut(self, key, f, self.owner)
+        <&Self as TabularOpsMut>::with_mut(self, key, f, self.owner)
     }
 
     /// Remove a row from the table.
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
-    pub fn remove<Q>(&'store self, key: &Q) -> Option<D::Value>
+    pub fn remove<Q>(&self, key: &Q) -> Option<D::Value>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
     {
-        <&Self as TabularOpsMut<'_, TableStorage, D>>::remove(self, key, self.owner)
+        <&Self as TabularOpsMut>::remove(self, key, self.owner)
     }
 
     /// Iterate all the key/value pairs in a table.
-    pub fn iter(&'store self) -> impl Iterator<Item = (&'store D::Key, &'store D::Value)> {
-        <&Self as TabularOps<'_, TableStorage, D>>::iter(self, self.owner)
+    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &D::Value)> {
+        <&Self as TabularOps>::iter(self, self.owner)
     }
 
     /// Iterate all the keys in a table.
-    pub fn keys(&'store self) -> impl Iterator<Item = &'store D::Key> {
-        <&Self as TabularOps<'_, TableStorage, D>>::keys(self, self.owner)
+    pub fn keys(&self) -> impl Iterator<Item = &D::Key> {
+        <&Self as TabularOps>::keys(self, self.owner)
     }
 
     /// Iterate all the values in a table.
-    pub fn values(&self) -> impl Iterator<Item = &D::Value>
-    where
-        D: 'store,
-    {
-        <&Self as TabularOps<'_, TableStorage, D>>::values(self, self.owner)
+    pub fn values(&self) -> impl Iterator<Item = &D::Value> {
+        <&Self as TabularOps>::values(self, self.owner)
     }
 
     /// Iterate all the key/value pairs in a table. Values are mutable.
     pub fn for_each_mut(&self, f: impl FnMut(&D::Key, &mut D::Value)) {
-        <&Self as TabularOpsMut<'_, TableStorage, D>>::for_each_mut(self, f, self.owner)
+        <&Self as TabularOpsMut>::for_each_mut(self, f, self.owner)
     }
 }
 

--- a/ts_kv_store/src/schema.rs
+++ b/ts_kv_store/src/schema.rs
@@ -77,7 +77,7 @@ pub trait TableDesc: Sized {
 /// Describes a table used as an index.
 pub trait IndexDesc: TableDesc {
     /// The table which is indexed.
-    type BaseTable: TableDesc<Storage = Self::Storage>;
+    type BaseTable: TableDesc<Storage = Self::Storage, Key = Self::Value>;
 }
 
 /// Operations on an index.

--- a/ts_kv_store/src/schema.rs
+++ b/ts_kv_store/src/schema.rs
@@ -1,0 +1,502 @@
+//! Traits and macros for defining the KvStore schema.
+#![allow(private_interfaces, private_bounds, unused_macros)]
+
+use std::{any::Any, hash::Hash, sync::Arc};
+
+use crate::storage::{SinValue, Table};
+
+/// A singleton key/value.
+///
+/// Prefer to use the macros in this module rather than this trait directly.
+pub trait Singleton: 'static {
+    /// The type of the value.
+    type Value: Any + Send + Sync;
+    /// The type used to initialize and access the value. For values stored as `Arc`s this should be
+    /// `Arc<Self::Value>`, for values stored by reference, this should be `&'static Self::Value` and
+    ///
+    type ArgValue;
+
+    /// Unwrap a `SinValue` into a typed value.
+    fn from_value(value: SinValue) -> Self::ArgValue;
+    /// Unwrap a reference to a `SinValue` into a reference to a typed value.
+    fn from_value_ref(value: &SinValue) -> &Self::Value;
+    /// Wrap a typed value into a `SinValue`.
+    fn to_value(value: Self::ArgValue) -> SinValue;
+}
+
+/// A singleton key/value which is store as an `Arc`.
+///
+/// Implementing this trait for non-`Arc` values will cause [`crate::KvStore::get_arc`] to panic (but is
+/// not unsafe).
+///
+/// Prefer to use the macros in this module rather than this trait directly.
+pub trait ArcSingleton: Singleton {
+    /// Unwrap a reference to a `SinValue` into an `Arc` reference to a typed value.
+    fn from_value_arc(value: &SinValue) -> Arc<Self::Value> {
+        match value {
+            SinValue::Arc(a) => a.clone().downcast().unwrap(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Mark a singleton value as mutable (i.e., the value in the store is unique).
+///
+/// Prefer to use the macros in this module rather than this trait directly.
+pub trait MutSingleton: Singleton {
+    /// Unwrap a mutable reference to a `SinValue` into a mutable reference to a typed value.
+    fn from_value_mut(value: &mut SinValue) -> &mut Self::Value;
+}
+
+/// Describes tabular key/values in the store.
+///
+/// Prefer to use the macros in this module rather than this trait directly.
+pub trait TableDesc: Sized {
+    /// The type of the key.
+    type Key: Hash + Eq;
+    /// The type of the value.
+    type Value: Any + Send + Sync;
+    /// The storage for the table.
+    type Storage: GeneratedStorage;
+    /// The storage type for keeping this tables indexes.
+    type Indexes: IndexStorage<Self::Key, Self::Value>;
+
+    /// Get a reference to the table in storage.
+    fn get_table(storage: &Self::Storage) -> &Table<Self, Self::Indexes>;
+    /// Get a mutable reference to the table in storage.
+    fn get_table_mut(storage: &mut Self::Storage) -> &mut Table<Self, Self::Indexes>;
+}
+
+/// Describes a table used as an index.
+pub trait IndexDesc: TableDesc {
+    /// The table which is indexed.
+    type BaseTable: TableDesc<Storage = Self::Storage>;
+}
+
+/// Operations on an index.
+pub trait IndexStorage<K: Hash + Eq, V: Any + Send + Sync>: Default {
+    /// Clear the whole index.
+    fn clear(&mut self);
+    /// An item has been inserted into the index.
+    fn on_insert<Q>(&mut self, key: &Q, value: &V)
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: ?Sized + std::hash::Hash + Eq + std::borrow::ToOwned<Owned = K>;
+    /// An item has been removed from the index.
+    fn on_remove(&mut self, value: &V);
+    /// Build the index from the base table.
+    fn build<'a>(&mut self, kvs: impl Iterator<Item = (&'a K, &'a V)>)
+    where
+        K: 'a,
+        V: 'a;
+}
+
+impl<K: Hash + Eq, V: Any + Send + Sync> IndexStorage<K, V> for () {
+    fn clear(&mut self) {}
+    fn on_insert<Q>(&mut self, _key: &Q, _value: &V)
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: ?Sized + std::hash::Hash + Eq,
+    {
+    }
+    fn on_remove(&mut self, _value: &V) {}
+    fn build<'a>(&mut self, _kvs: impl Iterator<Item = (&'a K, &'a V)>)
+    where
+        K: 'a,
+        V: 'a,
+    {
+    }
+}
+
+/// Marker trait to indicate a storage implementation.
+///
+/// This should be considered a sealed trait and not implemented except by the macros in this module.
+/// Unfortunately it has to be public because of macro visibility hygiene.
+#[doc(hidden)]
+pub trait GeneratedStorage: Default {}
+
+/// Macro to declare a singleton key/value in the store.
+///
+/// Does not need to be used within or near the store declaration, but also is not linked to a specific
+/// store. Using a generated accessor on a store different to the store the key/value was stored in
+/// will have unpredictable results (panics, memory safety, etc.).
+///
+/// # Syntax:
+///
+/// - `singleton!(u64)` to declare a value with type `u64` and inline storage.
+/// - `singleton!(ValueType as Box)` to declare a value with type `Box<ValueType>`.
+/// - `singleton!(ValueType as Arc)` to declare a value with type `Arc<ValueType>`.
+/// - `singleton!(ValueType as Ref)` to declare a value with type `&'static ValueType`.
+///
+/// The storage class is separate to the value type since they have different representations in the
+/// store and slightly different APIs (e.g., whether mutable access is supported or access by cloning
+/// or copying a shared reference).
+#[macro_export]
+macro_rules! singleton {
+    ($name:ident(u64)) => {
+        singleton!($name(u64, u64, U64));
+
+        impl $crate::schema::MutSingleton for $name {
+            fn from_value_mut(value: &mut $crate::storage::SinValue) -> &mut Self::Value {
+                match value {
+                    $crate::match_helper_lhs!(U64, v) => $crate::match_helper_rhs_mut!(U64, v),
+                    _ => unreachable!(),
+                }
+            }
+        }
+    };
+    ($name:ident($value_ty:ty as Box)) => {
+        singleton!($name($value_ty, $value_ty, Box));
+
+        impl $crate::schema::MutSingleton for $name {
+            fn from_value_mut(value: &mut $crate::storage::SinValue) -> &mut Self::Value {
+                match value {
+                    $crate::match_helper_lhs!(Box, v) => $crate::match_helper_rhs_mut!(Box, v),
+                    _ => unreachable!(),
+                }
+            }
+        }
+    };
+    ($name:ident($value_ty:ty as Arc)) => {
+        singleton!($name($value_ty, std::sync::Arc<$value_ty>, Arc));
+
+        impl $crate::schema::ArcSingleton for $name {}
+    };
+    ($name:ident($value_ty:ty as Ref)) => {
+        singleton!($name($value_ty, &'static $value_ty, Ref));
+    };
+    ($name:ident($value_ty:ty, $arg_value_ty:ty, $variant:ident)) => {
+        /// Describes a singleton in the KV store.
+        #[allow(non_camel_case_types)]
+        pub struct $name;
+
+        impl $crate::schema::Singleton for $name {
+            type Value = $value_ty;
+            type ArgValue = $arg_value_ty;
+
+            fn from_value(value: $crate::storage::SinValue) -> Self::ArgValue {
+                match value {
+                    $crate::match_helper_lhs!($variant, v) => {
+                        $crate::match_helper_rhs!($variant, v)
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            fn from_value_ref(value: &$crate::storage::SinValue) -> &Self::Value {
+                match value {
+                    $crate::match_helper_lhs!($variant, v) => {
+                        $crate::match_helper_rhs_ref!($variant, v)
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            fn to_value(value: Self::ArgValue) -> $crate::storage::SinValue {
+                $crate::init_helper!($variant, value)
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! init_helper {
+    (U64, $value:ident) => {
+        $crate::storage::SinValue::U64($value)
+    };
+    (Box, $value:ident) => {
+        $crate::storage::SinValue::Box(Box::new($value) as Box<dyn Any + Send + Sync>)
+    };
+    (Arc, $value:ident) => {
+        $crate::storage::SinValue::Arc($value.clone() as Arc<dyn Any + Send + Sync>)
+    };
+    (Ref, $value:ident) => {
+        $crate::storage::SinValue::Ref($value as &'static (dyn Any + Send + Sync))
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! match_helper_lhs {
+    (U64, $value:ident) => {
+        $crate::storage::SinValue::U64($value)
+    };
+    ($variant:ident, $value:ident) => {
+        $crate::storage::SinValue::$variant($value)
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! match_helper_rhs {
+    (U64, $value:ident) => {
+        $value
+    };
+    (Box, $value:ident) => {
+        *$value.downcast().unwrap()
+    };
+    (Arc, $value:ident) => {
+        $value.downcast().unwrap()
+    };
+    (Ref, $value:ident) => {
+        $value.downcast_ref().unwrap()
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! match_helper_rhs_ref {
+    (U64, $value:ident) => {
+        $value
+    };
+    ($variant:ident, $value:ident) => {
+        $value.downcast_ref().unwrap()
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! match_helper_rhs_mut {
+    (U64, $value:ident) => {
+        $value
+    };
+    ($variant:ident, $value:ident) => {
+        $value.downcast_mut().unwrap()
+    };
+}
+
+/// Declare the tables in a key/value store. Generates the store itself with the specified tables.
+///
+/// The syntax is `tables!(Name(KeyType, ValueType indexes?),*)`, where `Name` is an identifier to name
+/// the table, and `KeyType` and `ValueType` are types. `Name` is used as a type argument to
+/// KvStore methods to identify the table. Use with an empty list of tables to generate a store
+/// for use only with singleton key/value pairs.
+///
+/// # Example:
+///
+/// ```rust
+/// # use ts_kv_store::tables;
+/// # pub struct Node;
+/// # pub trait Edge {}
+/// tables!(
+///   Nodes(&'static str => Node),
+///   Edges(u32 => Box<dyn Edge + Send + Sync>)
+/// );
+/// ```
+/// # Indexes
+///
+/// The syntax of an indexes is `index(field: Type)` where `field` is the name of a field in the value
+/// type of the base table and `Type` is the type of that field. You can specify multiple indexes
+/// for each table, separated with a semicolon. E.g.,
+///
+/// ```rust
+/// # use ts_kv_store::tables;
+/// # pub struct Node { a: u32, b: String};
+/// tables!(
+///   Nodes(&'static str => Node; index(a: u32); index(b: String))
+/// );
+/// ```
+///
+/// This will create two indexes on nodes for fields `a` and `b`.
+///
+/// Index fields must uniquely identify a row in the base table. If multiple rows in the base table
+/// have the same key in the index, then behavior is unspecified (might give partial or incorrect
+/// result, might panic, etc.).
+#[macro_export]
+macro_rules! tables {
+    ($($name: ident ($key_ty: ty => $value_ty: ty $(; index($field: ident: $field_ty: ty))*)),*) => {
+        $(
+            /// Describes a table in the KV store.
+            #[derive(Default)]
+            pub struct $name;
+
+            impl $crate::schema::TableDesc for $name {
+                type Key = $key_ty;
+                type Value = $value_ty;
+                type Storage = TableStorage;
+                type Indexes = index::$name::Indexes;
+
+                fn get_table(storage: &TableStorage) -> &$crate::storage::Table<Self, Self::Indexes> {
+                    &storage.$name
+                }
+                fn get_table_mut(storage: &mut TableStorage) -> &mut $crate::storage::Table<Self, Self::Indexes> {
+                    &mut storage.$name
+                }
+            }
+
+            $(
+                impl $crate::schema::TableDesc for index::$name::$field {
+                    type Key = $field_ty;
+                    type Value = $key_ty;
+                    type Storage = TableStorage;
+                    type Indexes = ();
+
+                    fn get_table(storage: &TableStorage) -> &$crate::storage::Table<Self, Self::Indexes> {
+                        &storage.$name.indexes.$field
+                    }
+                    fn get_table_mut(storage: &mut TableStorage) -> &mut $crate::storage::Table<Self, Self::Indexes> {
+                        &mut storage.$name.indexes.$field
+                    }
+                }
+
+                impl $crate::schema::IndexDesc for index::$name::$field {
+                    type BaseTable = $name;
+                }
+            )*
+        )*
+
+        /// Macro-generated storage for all tabular data.
+        #[derive(Default)]
+        #[allow(non_snake_case)]
+        pub struct TableStorage {
+            $($name: $crate::storage::Table<$name, index::$name::Indexes>),*
+        }
+        impl $crate::schema::GeneratedStorage for TableStorage {}
+
+        pub mod index {
+            $(
+                #[allow(non_snake_case)]
+                pub mod $name {
+                    $(
+                        #[allow(non_camel_case_types)]
+                        pub struct $field;
+                    )*
+
+                    #[derive(Default)]
+                    pub struct Indexes {
+                        $(
+                            pub $field: $crate::storage::Table<$field, ()>,
+                        )*
+                    }
+                }
+            )*
+        }
+
+        $(
+            impl $crate::schema::IndexStorage<$key_ty, $value_ty> for index::$name::Indexes {
+                fn clear(&mut self) {
+                    $(
+                        self.$field.data.clear();
+                    )*
+                }
+
+                fn on_insert<Q>(&mut self, _key: &Q, _value: &$value_ty)
+                where
+                    $key_ty: std::borrow::Borrow<Q>,
+                    Q: ?Sized + std::hash::Hash + Eq + std::borrow::ToOwned<Owned = $key_ty>
+                {
+                    $(
+                        self.$field.data.insert(_value.$field.clone(), _key.to_owned());
+                    )*
+                }
+
+                fn on_remove(&mut self, _value: &$value_ty) {
+                    $(
+                        self.$field.data.remove(&_value.$field);
+                    )*
+                }
+
+                fn build<'a>(&mut self, kvs: impl Iterator<Item = (&'a $key_ty, &'a $value_ty)>)
+                where
+                    $key_ty: 'a,
+                    $value_ty: 'a,
+                {
+                    for (_k, _v) in kvs {
+                        $(
+                            self.$field.data.insert(_v.$field.clone(), _k.to_owned());
+                        )*
+                    }
+                }
+            }
+        )*
+
+        /// A key-value store.
+        ///
+        /// See [`$crate::KvStore`] (which this type implicitly derefences to) for full docs.
+        pub struct KvStore($crate::KvStore<TableStorage>);
+
+        impl KvStore {
+            /// Create a new, empty KV store as described by the schema macros.
+            pub fn new() -> Self {
+                KvStore($crate::KvStore::new_with_storage(std::sync::RwLock::new($crate::storage::Storage::new())))
+            }
+        }
+
+        impl std::ops::Deref for KvStore {
+            type Target = $crate::KvStore<TableStorage>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[test]
+    fn single() {
+        singleton!(Foo(u64 as Box));
+        singleton!(Bar(u64 as Arc));
+        singleton!(Baz(u64 as Ref));
+        singleton!(Qux(u64));
+
+        assert_eq!(&42, Foo::from_value_ref(&Foo::to_value(42)));
+        assert_eq!(&42, Bar::from_value_ref(&Bar::to_value(Arc::new(42))));
+        assert_eq!(&42, Baz::from_value_ref(&Baz::to_value(&42)));
+        assert_eq!(&42, Qux::from_value_ref(&Qux::to_value(42)));
+
+        tables!();
+
+        let store = KvStore::new();
+        store.insert::<Foo>("owner", 42);
+        assert_eq!(store.get::<Foo>("owner").unwrap(), 42);
+    }
+
+    #[test]
+    fn table() {
+        tables!(Foo(&'static str => String), Bar(u32 => Vec<String>));
+
+        let store = KvStore::new();
+
+        store
+            .table::<Foo>("owner")
+            .insert("hello", "world".to_owned());
+        assert_eq!(store.table::<Foo>("owner").get("hello").unwrap(), "world");
+
+        store
+            .table::<Bar>("owner")
+            .insert(5, vec!["boo".to_owned(), "bang".to_owned()]);
+        assert_eq!(
+            store.table::<Bar>("owner").get(&5).unwrap(),
+            vec!["boo".to_owned(), "bang".to_owned()]
+        );
+    }
+
+    #[test]
+    fn table_with_indexes() {
+        #[derive(Clone, Debug)]
+        pub struct BarT {
+            a: String,
+        }
+        tables!(Foo(&'static str => String), Bar(u32 => BarT; index(a: String)));
+
+        let store = KvStore::new();
+        store.table::<Bar>("owner").insert(
+            5,
+            BarT {
+                a: "hello".to_owned(),
+            },
+        );
+        let value = store
+            .table_by::<index::Bar::a>("owner")
+            .get("hello")
+            .unwrap();
+        assert_eq!(value.a, "hello")
+    }
+}

--- a/ts_kv_store/src/schema.rs
+++ b/ts_kv_store/src/schema.rs
@@ -1,5 +1,4 @@
 //! Traits and macros for defining the KvStore schema.
-#![allow(private_interfaces, private_bounds, unused_macros)]
 
 use std::{any::Any, hash::Hash, sync::Arc};
 
@@ -12,13 +11,17 @@ pub trait Singleton: 'static {
     /// The type of the value.
     type Value: Any + Send + Sync;
     /// The type used to initialize and access the value. For values stored as `Arc`s this should be
-    /// `Arc<Self::Value>`, for values stored by reference, this should be `&'static Self::Value` and
-    ///
+    /// `Arc<Self::Value>`, for values stored by reference, this should be `&'static Self::Value`, and
+    /// for other types, it should be the same as `Self::Value`.
     type ArgValue;
 
     /// Unwrap a `SinValue` into a typed value.
+    ///
+    /// Panics if `value` is an unexpected variant.
     fn from_value(value: SinValue) -> Self::ArgValue;
     /// Unwrap a reference to a `SinValue` into a reference to a typed value.
+    ///
+    /// Panics if `value` is an unexpected variant.
     fn from_value_ref(value: &SinValue) -> &Self::Value;
     /// Wrap a typed value into a `SinValue`.
     fn to_value(value: Self::ArgValue) -> SinValue;
@@ -32,6 +35,8 @@ pub trait Singleton: 'static {
 /// Prefer to use the macros in this module rather than this trait directly.
 pub trait ArcSingleton: Singleton {
     /// Unwrap a reference to a `SinValue` into an `Arc` reference to a typed value.
+    ///
+    /// Panics if `value` is an unexpected variant.
     fn from_value_arc(value: &SinValue) -> Arc<Self::Value> {
         match value {
             SinValue::Arc(a) => a.clone().downcast().unwrap(),
@@ -45,6 +50,8 @@ pub trait ArcSingleton: Singleton {
 /// Prefer to use the macros in this module rather than this trait directly.
 pub trait MutSingleton: Singleton {
     /// Unwrap a mutable reference to a `SinValue` into a mutable reference to a typed value.
+    ///
+    /// Panics if `value` is an unexpected variant.
     fn from_value_mut(value: &mut SinValue) -> &mut Self::Value;
 }
 
@@ -134,7 +141,7 @@ pub trait GeneratedStorage: Default {}
 #[macro_export]
 macro_rules! singleton {
     ($name:ident(u64)) => {
-        singleton!($name(u64, u64, U64));
+        $crate::singleton_types!($name(u64, u64, U64));
 
         impl $crate::schema::MutSingleton for $name {
             fn from_value_mut(value: &mut $crate::storage::SinValue) -> &mut Self::Value {
@@ -146,7 +153,7 @@ macro_rules! singleton {
         }
     };
     ($name:ident($value_ty:ty as Box)) => {
-        singleton!($name($value_ty, $value_ty, Box));
+        $crate::singleton_types!($name($value_ty, $value_ty, Box));
 
         impl $crate::schema::MutSingleton for $name {
             fn from_value_mut(value: &mut $crate::storage::SinValue) -> &mut Self::Value {
@@ -158,13 +165,18 @@ macro_rules! singleton {
         }
     };
     ($name:ident($value_ty:ty as Arc)) => {
-        singleton!($name($value_ty, std::sync::Arc<$value_ty>, Arc));
+        $crate::singleton_types!($name($value_ty, std::sync::Arc<$value_ty>, Arc));
 
         impl $crate::schema::ArcSingleton for $name {}
     };
     ($name:ident($value_ty:ty as Ref)) => {
-        singleton!($name($value_ty, &'static $value_ty, Ref));
+        $crate::singleton_types!($name($value_ty, &'static $value_ty, Ref));
     };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! singleton_types {
     ($name:ident($value_ty:ty, $arg_value_ty:ty, $variant:ident)) => {
         /// Describes a singleton in the KV store.
         #[allow(non_camel_case_types)]
@@ -286,7 +298,7 @@ macro_rules! match_helper_rhs_mut {
 /// ```
 /// # Indexes
 ///
-/// The syntax of an indexes is `index(field: Type)` where `field` is the name of a field in the value
+/// The syntax of an index is `index(field: Type)` where `field` is the name of a field in the value
 /// type of the base table and `Type` is the type of that field. You can specify multiple indexes
 /// for each table, separated with a semicolon. E.g.,
 ///
@@ -302,7 +314,8 @@ macro_rules! match_helper_rhs_mut {
 ///
 /// Index fields must uniquely identify a row in the base table. If multiple rows in the base table
 /// have the same key in the index, then behavior is unspecified (might give partial or incorrect
-/// result, might panic, etc.).
+/// result, might panic, etc.). The type of an index key field and the type of the primary key of the
+/// data being indexed must both be `Clone` (since they will be cloned when inserted into the index).
 #[macro_export]
 macro_rules! tables {
     ($($name: ident ($key_ty: ty => $value_ty: ty $(; index($field: ident: $field_ty: ty))*)),*) => {

--- a/ts_kv_store/src/singleton.rs
+++ b/ts_kv_store/src/singleton.rs
@@ -1,0 +1,60 @@
+//! Helpers for working with singleton KVs.
+
+use std::any::TypeId;
+
+use crate::{
+    Owner,
+    storage::{SinValue, Storage},
+};
+
+/// Helper trait to handle `SinValue::None`
+pub trait OptSingletonValue {
+    type Value;
+    fn map_singleton_value<T>(self, f: impl FnOnce(Self::Value) -> T) -> Option<T>;
+}
+
+impl<'a> OptSingletonValue for Option<&'a SinValue> {
+    type Value = &'a SinValue;
+    fn map_singleton_value<T>(self, f: impl FnOnce(Self::Value) -> T) -> Option<T> {
+        match self? {
+            SinValue::None => None,
+            v => Some(f(v)),
+        }
+    }
+}
+
+impl<'a> OptSingletonValue for Option<&'a mut SinValue> {
+    type Value = &'a mut SinValue;
+    fn map_singleton_value<T>(self, f: impl FnOnce(Self::Value) -> T) -> Option<T> {
+        match self? {
+            SinValue::None => None,
+            v => Some(f(v)),
+        }
+    }
+}
+
+impl OptSingletonValue for Option<(Owner, SinValue)> {
+    type Value = SinValue;
+    fn map_singleton_value<T>(self, f: impl FnOnce(SinValue) -> T) -> Option<T> {
+        match self? {
+            (_, SinValue::None) => None,
+            (_, v) => Some(f(v)),
+        }
+    }
+}
+
+#[allow(unused_variables)]
+#[track_caller]
+pub fn assert_owner(
+    owner: Owner,
+    key: &TypeId,
+    storage: &Storage<impl crate::schema::GeneratedStorage>,
+) {
+    #[cfg(debug_assertions)]
+    if let Some(prev_owner) = storage.get_singleton_owner(key) {
+        assert_eq!(
+            prev_owner, owner,
+            "Ownership violation: expected {prev_owner}, found {owner}"
+        );
+    }
+}

--- a/ts_kv_store/src/singleton.rs
+++ b/ts_kv_store/src/singleton.rs
@@ -4,7 +4,7 @@ use std::any::TypeId;
 
 use crate::{
     Owner,
-    storage::{SinValue, Storage},
+    storage::{SinValue, StorageLike},
 };
 
 /// Helper trait to handle `SinValue::None`
@@ -45,11 +45,7 @@ impl OptSingletonValue for Option<(Owner, SinValue)> {
 
 #[allow(unused_variables)]
 #[track_caller]
-pub fn assert_owner(
-    owner: Owner,
-    key: &TypeId,
-    storage: &Storage<impl crate::schema::GeneratedStorage>,
-) {
+pub fn assert_owner(owner: Owner, key: &TypeId, storage: &impl StorageLike) {
     #[cfg(debug_assertions)]
     if let Some(prev_owner) = storage.get_singleton_owner(key) {
         assert_eq!(

--- a/ts_kv_store/src/storage.rs
+++ b/ts_kv_store/src/storage.rs
@@ -8,7 +8,7 @@ use crate::{Error, Owner, Result, schema};
 
 /// Where we store the data.
 #[doc(hidden)]
-pub struct Storage<TableStorage: schema::GeneratedStorage> {
+pub struct Storage<TableStorage> {
     /// The key is the TypeId of the generated marker type for the KV data. See [`SinValue`] for
     /// how values are represented in the store.
     pub(crate) singletons: HashMap<TypeId, (Owner, SinValue)>,
@@ -26,20 +26,74 @@ impl<TableStorage: schema::GeneratedStorage> Storage<TableStorage> {
             tables: TableStorage::default(),
         }
     }
+}
+
+pub(crate) trait StorageLike: Sized {
+    type Generated: schema::GeneratedStorage;
+
+    fn tables(&self) -> &Self::Generated;
+    fn tables_mut(&mut self) -> &mut Self::Generated;
+
+    fn insert_singleton(
+        &mut self,
+        key: TypeId,
+        owner: Owner,
+        value: SinValue,
+    ) -> Option<(Owner, SinValue)>;
+
+    fn remove_singleton(&mut self, key: &TypeId) -> Option<(Owner, SinValue)>;
 
     /// Retrieve a singleton value from the store using the given type-key.
-    pub(crate) fn get_singleton_value(&self, key: &TypeId) -> Option<&SinValue> {
+    fn get_singleton_value(&self, key: &TypeId) -> Option<&SinValue>;
+
+    /// Retrieve a singleton value from the store using the given type-key.
+    fn get_singleton_value_mut(&mut self, key: &TypeId) -> Option<&mut SinValue>;
+
+    /// Retrieve the owner of a singleton KV pair using the given type-key.
+    #[cfg(debug_assertions)]
+    fn get_singleton_owner(&self, key: &TypeId) -> Option<Owner>;
+}
+
+impl<T> StorageLike for Storage<T>
+where
+    T: schema::GeneratedStorage,
+{
+    type Generated = T;
+
+    fn tables(&self) -> &Self::Generated {
+        &self.tables
+    }
+
+    fn tables_mut(&mut self) -> &mut Self::Generated {
+        &mut self.tables
+    }
+
+    fn insert_singleton(
+        &mut self,
+        key: TypeId,
+        owner: Owner,
+        value: SinValue,
+    ) -> Option<(Owner, SinValue)> {
+        self.singletons.insert(key, (owner, value))
+    }
+
+    fn remove_singleton(&mut self, key: &TypeId) -> Option<(Owner, SinValue)> {
+        self.singletons.remove(key)
+    }
+
+    /// Retrieve a singleton value from the store using the given type-key.
+    fn get_singleton_value(&self, key: &TypeId) -> Option<&SinValue> {
         self.singletons.get(key).map(|(_, v)| v)
     }
 
     /// Retrieve a singleton value from the store using the given type-key.
-    pub(crate) fn get_singleton_value_mut(&mut self, key: &TypeId) -> Option<&mut SinValue> {
+    fn get_singleton_value_mut(&mut self, key: &TypeId) -> Option<&mut SinValue> {
         self.singletons.get_mut(key).map(|&mut (_, ref mut v)| v)
     }
 
     /// Retrieve the owner of a singleton KV pair using the given type-key.
     #[cfg(debug_assertions)]
-    pub(crate) fn get_singleton_owner(&self, key: &TypeId) -> Option<Owner> {
+    fn get_singleton_owner(&self, key: &TypeId) -> Option<Owner> {
         self.singletons.get(key).map(|(o, _)| *o)
     }
 }

--- a/ts_kv_store/src/storage.rs
+++ b/ts_kv_store/src/storage.rs
@@ -1,0 +1,118 @@
+use std::{
+    any::{Any, TypeId},
+    collections::HashMap,
+    sync::Arc,
+};
+
+use crate::{Error, Owner, Result, schema};
+
+/// Where we store the data.
+#[doc(hidden)]
+pub struct Storage<TableStorage: schema::GeneratedStorage> {
+    /// The key is the TypeId of the generated marker type for the KV data. See [`SinValue`] for
+    /// how values are represented in the store.
+    pub(crate) singletons: HashMap<TypeId, (Owner, SinValue)>,
+    /// Storage for tabular data. The concrete type will be macro-generated, see the [`crate::schema`]
+    /// module.
+    pub(crate) tables: TableStorage,
+}
+
+impl<TableStorage: schema::GeneratedStorage> Storage<TableStorage> {
+    /// Create a new storage with no data.
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Storage {
+            singletons: HashMap::new(),
+            tables: TableStorage::default(),
+        }
+    }
+
+    /// Retrieve a singleton value from the store using the given type-key.
+    pub(crate) fn get_singleton_value(&self, key: &TypeId) -> Option<&SinValue> {
+        self.singletons.get(key).map(|(_, v)| v)
+    }
+
+    /// Retrieve a singleton value from the store using the given type-key.
+    pub(crate) fn get_singleton_value_mut(&mut self, key: &TypeId) -> Option<&mut SinValue> {
+        self.singletons.get_mut(key).map(|&mut (_, ref mut v)| v)
+    }
+
+    /// Retrieve the owner of a singleton KV pair using the given type-key.
+    #[cfg(debug_assertions)]
+    pub(crate) fn get_singleton_owner(&self, key: &TypeId) -> Option<Owner> {
+        self.singletons.get(key).map(|(o, _)| *o)
+    }
+}
+
+/// Internal storage for singleton values.
+#[doc(hidden)]
+#[derive(Default)]
+pub enum SinValue {
+    /// Tombstone value. Used where we want to specify an owner but don't have value yet.
+    #[default]
+    None,
+    // TODO add other special cases
+    /// A single, inline `u64`.
+    U64(u64),
+    /// A boxed value (i.e., a pointer is stored in the store).
+    Box(Box<dyn Any + Send + Sync>),
+    /// A shared reference in the store.
+    Arc(Arc<dyn Any + Send + Sync>),
+    /// A static reference in the store.
+    Ref(&'static (dyn Any + Send + Sync)),
+}
+
+/// Tabular data in the KV store, there will be one of these for each logical table in the storage
+/// implementing `TableStorage` in [`Storage`].
+#[doc(hidden)]
+pub struct Table<D: schema::TableDesc, I: Default> {
+    /// Owner of the table.
+    pub(crate) owner: Option<Owner>,
+    /// KV data.
+    pub data: HashMap<D::Key, D::Value>,
+    /// All indexes of this table (empty if there are no indexes or this table itself is an index).
+    pub indexes: I,
+}
+
+impl<D: schema::TableDesc, I: Default> Default for Table<D, I> {
+    fn default() -> Self {
+        Self {
+            owner: None,
+            data: HashMap::new(),
+            indexes: I::default(),
+        }
+    }
+}
+
+impl<D: schema::TableDesc, I: Default> Table<D, I> {
+    pub(crate) fn try_set_owner(&mut self, owner: Owner) -> Result<()> {
+        match &self.owner {
+            Some(owner) => Err(Error::AlreadyInit(owner)),
+            None => {
+                self.owner = Some(owner);
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) fn assert_or_set_owner(&mut self, owner: Owner) {
+        match &self.owner {
+            Some(prev_owner) => debug_assert_eq!(
+                *prev_owner, owner,
+                "Ownership violation: expected {prev_owner}, found {owner}"
+            ),
+            None => {
+                self.owner = Some(owner);
+            }
+        }
+    }
+
+    pub(crate) fn assert_owner(&mut self, owner: Owner) {
+        if let Some(prev_owner) = &self.owner {
+            debug_assert_eq!(
+                *prev_owner, owner,
+                "Ownership violation: expected {prev_owner}, found {owner}"
+            );
+        }
+    }
+}

--- a/ts_kv_store/src/transactions.rs
+++ b/ts_kv_store/src/transactions.rs
@@ -195,11 +195,11 @@ impl<'a, TableStorage: schema::GeneratedStorage> Transaction<'a, TableStorage> {
     /// Get mutable access to a value in the store.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn mutate<D: schema::MutSingleton, T>(
+    pub fn with_mut<D: schema::MutSingleton, T>(
         &mut self,
         f: impl FnOnce(&mut D::Value) -> T,
     ) -> Option<T> {
-        <&mut Self as SingletonOpsMut<'_, '_, TableStorage>>::mutate::<D, T>(self, f, self.owner)
+        <&mut Self as SingletonOpsMut<'_, '_, TableStorage>>::with_mut::<D, T>(self, f, self.owner)
     }
 
     /// Remove a single value from the store.
@@ -329,12 +329,12 @@ impl<
     /// Get mutable access to a row of the table in the store in the store.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn mutate<Q, T>(&mut self, key: &Q, f: impl FnOnce(&mut D::Value) -> T) -> Option<T>
+    pub fn with_mut<Q, T>(&mut self, key: &Q, f: impl FnOnce(&mut D::Value) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
     {
-        <&mut Self as TabularOpsMut<'_, TableStorage, D>>::mutate(self, key, f, self.txn.owner)
+        <&mut Self as TabularOpsMut<'_, TableStorage, D>>::with_mut(self, key, f, self.txn.owner)
     }
 
     /// Remove a row from the table.
@@ -751,7 +751,7 @@ mod test {
         let store = KvStore::new();
         let mut txn = store.begin_transaction(OWNER);
         let mut called = false;
-        let result = txn.mutate::<Count, ()>(|_| {
+        let result = txn.with_mut::<Count, ()>(|_| {
             called = true;
         });
         assert!(result.is_none());
@@ -764,7 +764,7 @@ mod test {
         let mut txn = store.begin_transaction(OWNER);
         txn.insert::<Count>(10);
         assert_eq!(
-            txn.mutate::<Count, _>(|v| {
+            txn.with_mut::<Count, _>(|v| {
                 *v += 5;
                 *v
             }),
@@ -855,7 +855,7 @@ mod test {
         let store = KvStore::new();
         store.insert::<Count>(OWNER, 1);
         let mut txn = store.begin_transaction(OWNER);
-        txn.mutate::<Count, ()>(|v| *v = 100);
+        txn.with_mut::<Count, ()>(|v| *v = 100);
         txn.commit().unwrap();
 
         assert_eq!(store.get::<Count>(OWNER), Some(100));
@@ -878,7 +878,7 @@ mod test {
         let store = KvStore::new();
         store.insert::<Count>(OWNER, 1);
         let mut txn = store.begin_transaction(OTHER);
-        txn.mutate::<Count, ()>(|_| {});
+        txn.with_mut::<Count, ()>(|_| {});
     }
 
     #[test]
@@ -981,7 +981,7 @@ mod test {
         let mut txn = store.begin_transaction(OWNER);
         let mut table = txn.table::<Items>();
         table.init().unwrap();
-        assert!(table.mutate(&"missing", |v| v.len()).is_none());
+        assert!(table.with_mut(&"missing", |v| v.len()).is_none());
     }
 
     #[test]
@@ -990,7 +990,7 @@ mod test {
         let mut txn = store.begin_transaction(OWNER);
         let mut table = txn.table::<Items>();
         table.insert("k", "hello".to_owned());
-        table.mutate(&"k", |v| v.push('!'));
+        table.with_mut(&"k", |v| v.push('!'));
         assert_eq!(table.get("k"), Some("hello!".to_owned()));
     }
 
@@ -1179,7 +1179,8 @@ mod test {
         let store = KvStore::new();
         store.table::<Items>(OWNER).init().unwrap();
         let mut txn = store.begin_transaction(OTHER);
-        txn.table::<Items>().mutate(&"k", |v: &mut String| v.len());
+        txn.table::<Items>()
+            .with_mut(&"k", |v: &mut String| v.len());
     }
 
     #[test]

--- a/ts_kv_store/src/transactions.rs
+++ b/ts_kv_store/src/transactions.rs
@@ -3,7 +3,6 @@
 use std::{
     borrow::Borrow,
     hash::Hash,
-    marker::PhantomData,
     sync::{Arc, RwLockReadGuard, RwLockWriteGuard, TryLockError},
 };
 
@@ -12,14 +11,14 @@ use crate::{
     index::{KvTableRoTransactionalIndex, KvTableTransactionalIndex},
     operations::{Ops, OpsMut, SingletonOps, SingletonOpsMut, TabularOps, TabularOpsMut},
     schema::{self, TableDesc},
-    storage::Storage,
+    storage::{Storage, StorageLike},
 };
 
 impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     /// Start a transaction.
     ///
     /// Blocks until the store's global lock is available for write access.
-    pub fn begin_transaction(&self, owner: Owner) -> Transaction<'_, TableStorage> {
+    pub fn begin_transaction(&self, owner: Owner) -> Transaction<'_, Storage<TableStorage>> {
         Transaction {
             guard: self.storage.write().unwrap(),
             owner,
@@ -29,12 +28,16 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     /// Start a transaction.
     ///
     /// Returns `None` if the store's global lock is unavailable for write access.
-    pub fn try_begin_transaction(&self, owner: Owner) -> Option<Transaction<'_, TableStorage>> {
+    pub fn try_begin_transaction(
+        &self,
+        owner: Owner,
+    ) -> Option<Transaction<'_, Storage<TableStorage>>> {
         let guard = match self.storage.try_write() {
             Ok(g) => g,
             Err(TryLockError::WouldBlock) => return None,
             Err(TryLockError::Poisoned(_)) => panic!(),
         };
+
         Some(Transaction { guard, owner })
     }
 
@@ -42,7 +45,7 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     /// all reads are guaranteed to be atomic).
     ///
     /// Blocks until the store's global lock is available for read access.
-    pub fn begin_ro_transaction(&self, owner: Owner) -> RoTransaction<'_, TableStorage> {
+    pub fn begin_ro_transaction(&self, owner: Owner) -> RoTransaction<'_, Storage<TableStorage>> {
         RoTransaction {
             guard: self.storage.read().unwrap(),
             owner,
@@ -56,7 +59,7 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     pub fn try_begin_ro_transaction(
         &self,
         owner: Owner,
-    ) -> Option<RoTransaction<'_, TableStorage>> {
+    ) -> Option<RoTransaction<'_, Storage<TableStorage>>> {
         let guard = match self.storage.try_read() {
             Ok(g) => g,
             Err(TryLockError::WouldBlock) => return None,
@@ -77,42 +80,34 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
 ///
 /// A transaction must not be kept alive over an `await` point. This can lead to deadlock.
 // TODO do we need to be able to abort a transaction?
-pub struct Transaction<'guard, TableStorage: schema::GeneratedStorage> {
-    pub(crate) guard: RwLockWriteGuard<'guard, Storage<TableStorage>>,
+pub struct Transaction<'guard, Storage> {
+    pub(crate) guard: RwLockWriteGuard<'guard, Storage>,
     pub(crate) owner: Owner,
 }
 
-impl<'store: 'guard, 'guard: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
-    Ops<'r, TableStorage> for &'r Transaction<'guard, TableStorage>
-{
-    type ReadLock = RefWriteGuard<'r, 'guard, Storage<TableStorage>>;
+impl<'guard, 'r, Storage: StorageLike> Ops for &'r Transaction<'guard, Storage> {
+    type ReadLock = RefWriteGuard<'r, 'guard, Self::Storage>;
+    type Storage = Storage;
 
     fn read_lock(self) -> Self::ReadLock {
         RefWriteGuard(&self.guard)
     }
 }
 
-impl<'store: 'guard, 'guard: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
-    SingletonOps<'r, TableStorage> for &'r Transaction<'guard, TableStorage>
-{
-}
+impl<Storage: StorageLike> SingletonOps for &Transaction<'_, Storage> {}
 
-impl<'store: 'guard, 'guard: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
-    OpsMut<'r, TableStorage> for &'r mut Transaction<'guard, TableStorage>
-{
-    type WriteLock = RefWriteGuardMut<'r, 'guard, Storage<TableStorage>>;
+impl<'guard, 'r, Storage: StorageLike> OpsMut for &'r mut Transaction<'guard, Storage> {
+    type WriteLock = RefWriteGuardMut<'r, 'guard, Self::StorageMut>;
+    type StorageMut = Storage;
 
     fn write_lock(self) -> Self::WriteLock {
         RefWriteGuardMut(&mut self.guard)
     }
 }
 
-impl<'store: 'guard, 'guard: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
-    SingletonOpsMut<'r, TableStorage> for &'r mut Transaction<'guard, TableStorage>
-{
-}
+impl<Storage: StorageLike> SingletonOpsMut for &mut Transaction<'_, Storage> {}
 
-impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableStorage> {
+impl<'guard, Gen: schema::GeneratedStorage> Transaction<'guard, Storage<Gen>> {
     /// Commit this transaction.
     ///
     /// This simply moves and drops the `Transaction` object. It is optional to call and currently
@@ -130,13 +125,8 @@ impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableSt
     /// let txn = store.begin_ro_transaction(OWNER);
     /// let value = txn.table::<Foo>().get(key).unwrap();
     /// ```
-    pub fn table<'r, D: schema::TableDesc<Storage = TableStorage>>(
-        &'r mut self,
-    ) -> KvTableTransactional<'guard, 'r, TableStorage, D> {
-        KvTableTransactional {
-            txn: self,
-            table: PhantomData,
-        }
+    pub fn table<D: TableDesc<Storage = Gen>>(&mut self) -> KvTableTransactional<'guard, '_, D> {
+        KvTableTransactional { txn: self }
     }
 
     /// Access a table via an index.
@@ -150,14 +140,10 @@ impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableSt
     ///
     /// Here `Foo` describes a tables and `bar` describes an index over `Foo` using the `bar` field
     /// as foreign key.
-    pub fn table_by<'r, D: schema::IndexDesc<Storage = TableStorage>>(
+    pub fn table_by<'r, D: schema::IndexDesc<Storage = Gen>>(
         &'r mut self,
-    ) -> KvTableTransactionalIndex<'guard, 'r, TableStorage, D, D::BaseTable> {
-        KvTableTransactionalIndex {
-            txn: self,
-            index: PhantomData,
-            base: PhantomData,
-        }
+    ) -> KvTableTransactionalIndex<'guard, 'r, D> {
+        KvTableTransactionalIndex { txn: self }
     }
 
     /// Get a single value from the store by cloning the value.
@@ -167,21 +153,21 @@ impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableSt
     where
         D::Value: Clone,
     {
-        <&Self as SingletonOps<'_, TableStorage>>::get::<D>(self, self.owner)
+        <&Self as SingletonOps>::get::<D>(self, self.owner)
     }
 
     /// Get a single value from the store by cloning an `Arc`.
     ///
     /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
     pub fn get_arc<D: schema::ArcSingleton>(&self) -> Option<Arc<D::Value>> {
-        <&Self as SingletonOps<'_, TableStorage>>::get_arc::<D>(self, self.owner)
+        <&Self as SingletonOps>::get_arc::<D>(self, self.owner)
     }
 
     /// Get immutable access to a value in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
     pub fn with<D: schema::Singleton, T>(&self, f: impl FnOnce(&D::Value) -> T) -> Option<T> {
-        <&Self as SingletonOps<'_, TableStorage>>::with::<D, T>(self, f, self.owner)
+        <&Self as SingletonOps>::with::<D, T>(self, f, self.owner)
     }
 
     /// Insert a single value into the store.
@@ -189,7 +175,7 @@ impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableSt
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     // Question: do we need separate insert/update/upsert methods?
     pub fn insert<D: schema::Singleton>(&mut self, value: D::ArgValue) -> Option<D::ArgValue> {
-        <&mut Self as SingletonOpsMut<'_, TableStorage>>::insert::<D>(self, value, self.owner)
+        <&mut Self as SingletonOpsMut>::insert::<D>(self, value, self.owner)
     }
 
     /// Get mutable access to a value in the store.
@@ -199,14 +185,14 @@ impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableSt
         &mut self,
         f: impl FnOnce(&mut D::Value) -> T,
     ) -> Option<T> {
-        <&mut Self as SingletonOpsMut<'_, TableStorage>>::with_mut::<D, T>(self, f, self.owner)
+        <&mut Self as SingletonOpsMut>::with_mut::<D, T>(self, f, self.owner)
     }
 
     /// Remove a single value from the store.
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn remove<D: schema::Singleton>(&mut self) -> Option<D::ArgValue> {
-        <&mut Self as SingletonOpsMut<'_, TableStorage>>::remove::<D>(self, self.owner)
+        <&mut Self as SingletonOpsMut>::remove::<D>(self, self.owner)
     }
 
     /// Remove a single value from the store while preserving ownership of the key/value.
@@ -215,82 +201,44 @@ impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableSt
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn clear<D: schema::Singleton>(&mut self) -> Option<D::ArgValue> {
-        <&mut Self as SingletonOpsMut<'_, TableStorage>>::clear::<D>(self, self.owner)
+        <&mut Self as SingletonOpsMut>::clear::<D>(self, self.owner)
     }
 }
 
 /// Abstracts a table of key/values pairs in the store accessed as part of a transaction.
-pub struct KvTableTransactional<
-    'guard: 'tx,
-    'tx,
-    TableStorage: schema::GeneratedStorage,
-    D: schema::TableDesc<Storage = TableStorage>,
-> {
-    txn: &'tx mut Transaction<'guard, TableStorage>,
-    table: PhantomData<D>,
+pub struct KvTableTransactional<'guard, 'tx, D: TableDesc> {
+    txn: &'tx mut Transaction<'guard, Storage<D::Storage>>,
 }
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx: 'table,
-    'table,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: TableDesc<Storage = TableStorage> + 'store,
-> Ops<'store, TableStorage> for &'table KvTableTransactional<'guard, 'tx, TableStorage, D>
-{
-    type ReadLock = RefWriteGuard<'table, 'guard, Storage<TableStorage>>;
+impl<'guard, 'tx, 'table, D: TableDesc> Ops for &'table KvTableTransactional<'guard, 'tx, D> {
+    type ReadLock = RefWriteGuard<'table, 'guard, Self::Storage>;
+    type Storage = Storage<D::Storage>;
 
     fn read_lock(self) -> Self::ReadLock {
         RefWriteGuard(&self.txn.guard)
     }
 }
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx: 'table,
-    'table,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: TableDesc<Storage = TableStorage> + 'store,
-> OpsMut<'store, TableStorage> for &'table mut KvTableTransactional<'guard, 'tx, TableStorage, D>
+impl<'guard, 'tx, 'table, D: TableDesc> OpsMut
+    for &'table mut KvTableTransactional<'guard, 'tx, D>
 {
-    type WriteLock = RefWriteGuardMut<'table, 'guard, Storage<TableStorage>>;
+    type WriteLock = RefWriteGuardMut<'table, 'guard, Self::StorageMut>;
+    type StorageMut = Storage<D::Storage>;
 
     fn write_lock(self) -> Self::WriteLock {
         RefWriteGuardMut(&mut self.txn.guard)
     }
 }
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: TableDesc<Storage = TableStorage> + 'store,
-> TabularOps<'store, TableStorage, D> for &KvTableTransactional<'guard, 'tx, TableStorage, D>
-{
+impl<'guard, D: TableDesc> TabularOps for &KvTableTransactional<'guard, '_, D> {
+    type Desc = D;
 }
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: TableDesc<Storage = TableStorage> + 'store,
-> TabularOpsMut<'store, TableStorage, D>
-    for &mut KvTableTransactional<'guard, 'tx, TableStorage, D>
-{
+impl<'guard, D: TableDesc> TabularOpsMut for &mut KvTableTransactional<'guard, '_, D> {
+    type DescMut = D;
 }
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: TableDesc<Storage = TableStorage> + 'store,
-> KvTableTransactional<'guard, 'tx, TableStorage, D>
-{
+impl<'guard, D: TableDesc> KvTableTransactional<'guard, '_, D> {
     /// Initialize a table by setting its owner.
     ///
     /// Calling this function is optional, a table can be used without initialization in which case,
@@ -299,22 +247,22 @@ impl<
     /// Returns an error (containing the current owner of the table) if the table has already been
     /// initialized. In this case, the table will be in a consistent state and can be used as normal.
     pub fn init(&mut self) -> Result<()> {
-        <&mut Self as TabularOpsMut<'_, TableStorage, D>>::init(self, self.txn.owner)
+        <&mut Self as TabularOpsMut>::init(self, self.txn.owner)
     }
 
     /// The number of key/value pairs in the table.
     pub fn len(&self) -> usize {
-        <&Self as TabularOps<'_, TableStorage, D>>::len(self)
+        <&Self as TabularOps>::len(self)
     }
 
     /// True if the table is empty.
     pub fn is_empty(&self) -> bool {
-        <&Self as TabularOps<'_, TableStorage, D>>::is_empty(self)
+        <&Self as TabularOps>::is_empty(self)
     }
 
     /// Clear a table by removing all its KVs, but preserving ownership.
     pub fn clear(&mut self) {
-        <&mut Self as TabularOpsMut<'_, TableStorage, D>>::clear(self, self.txn.owner)
+        <&mut Self as TabularOpsMut>::clear(self, self.txn.owner)
     }
 
     /// Get a row of the table from the store by cloning the value.
@@ -326,7 +274,7 @@ impl<
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
     {
-        <&Self as TabularOps<'_, TableStorage, D>>::get::<Q>(self, key, self.txn.owner)
+        <&Self as TabularOps>::get::<Q>(self, key, self.txn.owner)
     }
 
     /// Get immutable access to a row of the table in the store by reference.
@@ -337,7 +285,7 @@ impl<
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
     {
-        <&Self as TabularOps<'_, TableStorage, D>>::with::<Q, T>(self, key, f, self.txn.owner)
+        <&Self as TabularOps>::with::<Q, T>(self, key, f, self.txn.owner)
     }
 
     /// Insert a value into the table.
@@ -347,7 +295,7 @@ impl<
     where
         D::Key: Clone,
     {
-        <&mut Self as TabularOpsMut<'_, TableStorage, D>>::insert(self, key, value, self.txn.owner)
+        <&mut Self as TabularOpsMut>::insert(self, key, value, self.txn.owner)
     }
 
     /// Get mutable access to a row of the table in the store in the store.
@@ -358,7 +306,7 @@ impl<
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
     {
-        <&mut Self as TabularOpsMut<'_, TableStorage, D>>::with_mut(self, key, f, self.txn.owner)
+        <&mut Self as TabularOpsMut>::with_mut(self, key, f, self.txn.owner)
     }
 
     /// Remove a row from the table.
@@ -369,27 +317,27 @@ impl<
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
     {
-        <&mut Self as TabularOpsMut<'_, TableStorage, D>>::remove(self, key, self.txn.owner)
+        <&mut Self as TabularOpsMut>::remove(self, key, self.txn.owner)
     }
 
     /// Iterate all the key/value pairs in a table.
     pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &D::Value)> {
-        <&Self as TabularOps<'_, TableStorage, D>>::iter(self, self.txn.owner)
+        <&Self as TabularOps>::iter(self, self.txn.owner)
     }
 
     /// Iterate all the keys in a table.
     pub fn keys(&self) -> impl Iterator<Item = &D::Key> {
-        <&Self as TabularOps<'_, TableStorage, D>>::keys(self, self.txn.owner)
+        <&Self as TabularOps>::keys(self, self.txn.owner)
     }
 
     /// Iterate all the values in a table.
     pub fn values(&self) -> impl Iterator<Item = &D::Value> {
-        <&Self as TabularOps<'_, TableStorage, D>>::values(self, self.txn.owner)
+        <&Self as TabularOps>::values(self, self.txn.owner)
     }
 
     /// Iterate all the key/value pairs in a table. Values are mutable.
     pub fn for_each_mut(&mut self, f: impl FnMut(&D::Key, &mut D::Value)) {
-        <&mut Self as TabularOpsMut<'_, TableStorage, D>>::for_each_mut(self, f, self.txn.owner)
+        <&mut Self as TabularOpsMut>::for_each_mut(self, f, self.txn.owner)
     }
 }
 
@@ -401,55 +349,36 @@ impl<
 /// as possible([`RoTransaction::commit`] can be used for this).
 ///
 /// A transaction must not be kept alive over an `await` point. This can lead to deadlock.
-pub struct RoTransaction<'guard, TableStorage: schema::GeneratedStorage> {
-    pub(crate) guard: RwLockReadGuard<'guard, Storage<TableStorage>>,
+pub struct RoTransaction<'guard, Storage> {
+    pub(crate) guard: RwLockReadGuard<'guard, Storage>,
     pub(crate) owner: Owner,
 }
 
-impl<'store: 'guard, 'guard: 'tx, 'tx, TableStorage: schema::GeneratedStorage + 'store>
-    Ops<'store, TableStorage> for &'tx RoTransaction<'guard, TableStorage>
-{
-    type ReadLock = RefReadGuard<'tx, 'guard, Storage<TableStorage>>;
+impl<'guard, 'tx, Storage: StorageLike> Ops for &'tx RoTransaction<'guard, Storage> {
+    type ReadLock = RefReadGuard<'tx, 'guard, Storage>;
+    type Storage = Storage;
 
     fn read_lock(self) -> Self::ReadLock {
         RefReadGuard(&self.guard)
     }
 }
 
-impl<'store: 'guard, 'guard, TableStorage: schema::GeneratedStorage + 'store>
-    SingletonOps<'store, TableStorage> for &RoTransaction<'guard, TableStorage>
-{
-}
+impl<'guard, Storage: StorageLike> SingletonOps for &RoTransaction<'guard, Storage> {}
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx: 'table,
-    'table,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: TableDesc<Storage = TableStorage>,
-> Ops<'store, TableStorage> for &'table KvTableRoTransactional<'guard, 'tx, TableStorage, D>
-{
-    type ReadLock = RefReadGuard<'table, 'guard, Storage<TableStorage>>;
+impl<'guard, 'tx, 'table, D: TableDesc> Ops for &'table KvTableRoTransactional<'guard, 'tx, D> {
+    type ReadLock = RefReadGuard<'table, 'guard, Self::Storage>;
+    type Storage = Storage<D::Storage>;
 
     fn read_lock(self) -> Self::ReadLock {
         RefReadGuard(&self.txn.guard)
     }
 }
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: TableDesc<Storage = TableStorage>,
-> TabularOps<'store, TableStorage, D> for &KvTableRoTransactional<'guard, 'tx, TableStorage, D>
-{
+impl<'guard, D: TableDesc> TabularOps for &KvTableRoTransactional<'guard, '_, D> {
+    type Desc = D;
 }
 
-impl<'store: 'guard, 'guard, TableStorage: schema::GeneratedStorage + 'store>
-    RoTransaction<'guard, TableStorage>
-{
+impl<'guard, Gen: schema::GeneratedStorage> RoTransaction<'guard, Storage<Gen>> {
     /// Commit this transaction.
     ///
     /// This simply moves and drops the `RoTransaction` object. It is optional to call and currently
@@ -467,13 +396,10 @@ impl<'store: 'guard, 'guard, TableStorage: schema::GeneratedStorage + 'store>
     /// let txn = store.begin_ro_transaction(OWNER);
     /// let value = txn.table::<Foo>().get(key).unwrap();
     /// ```
-    pub fn table<'tx, D: schema::TableDesc<Storage = TableStorage>>(
+    pub fn table<'tx, D: TableDesc<Storage = Gen>>(
         &'tx self,
-    ) -> KvTableRoTransactional<'guard, 'tx, TableStorage, D> {
-        KvTableRoTransactional {
-            txn: self,
-            table: PhantomData,
-        }
+    ) -> KvTableRoTransactional<'guard, 'tx, D> {
+        KvTableRoTransactional { txn: self }
     }
 
     /// Access a table via an index.
@@ -487,14 +413,10 @@ impl<'store: 'guard, 'guard, TableStorage: schema::GeneratedStorage + 'store>
     ///
     /// Here `Foo` describes a tables and `bar` describes an index over `Foo` using the `bar` field
     /// as foreign key.
-    pub fn table_by<'tx, D: schema::IndexDesc<Storage = TableStorage>>(
+    pub fn table_by<'tx, D: schema::IndexDesc<Storage = Gen>>(
         &'tx self,
-    ) -> KvTableRoTransactionalIndex<'guard, 'tx, TableStorage, D, D::BaseTable> {
-        KvTableRoTransactionalIndex {
-            txn: self,
-            index: PhantomData,
-            base: PhantomData,
-        }
+    ) -> KvTableRoTransactionalIndex<'guard, 'tx, D> {
+        KvTableRoTransactionalIndex { txn: self }
     }
 
     /// Get a single value from the store by cloning the value.
@@ -504,51 +426,38 @@ impl<'store: 'guard, 'guard, TableStorage: schema::GeneratedStorage + 'store>
     where
         D::Value: Clone,
     {
-        <&Self as SingletonOps<'_, TableStorage>>::get::<D>(self, self.owner)
+        <&Self as SingletonOps>::get::<D>(self, self.owner)
     }
 
     /// Get a single value from the store by cloning an `Arc`.
     ///
     /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
     pub fn get_arc<D: schema::ArcSingleton>(&self) -> Option<Arc<D::Value>> {
-        <&Self as SingletonOps<'_, TableStorage>>::get_arc::<D>(self, self.owner)
+        <&Self as SingletonOps>::get_arc::<D>(self, self.owner)
     }
 
     /// Get immutable access to a value in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
     pub fn with<D: schema::Singleton, T>(&self, f: impl FnOnce(&D::Value) -> T) -> Option<T> {
-        <&Self as SingletonOps<'_, TableStorage>>::with::<D, T>(self, f, self.owner)
+        <&Self as SingletonOps>::with::<D, T>(self, f, self.owner)
     }
 }
 
 /// Abstracts a table of key/values pairs in the store as part of a read-only transaction.
-pub struct KvTableRoTransactional<
-    'guard: 'tx,
-    'tx,
-    TableStorage: schema::GeneratedStorage,
-    D: schema::TableDesc<Storage = TableStorage>,
-> {
-    txn: &'tx RoTransaction<'guard, TableStorage>,
-    table: PhantomData<D>,
+pub struct KvTableRoTransactional<'guard, 'tx, D: TableDesc> {
+    txn: &'tx RoTransaction<'guard, Storage<D::Storage>>,
 }
 
-impl<
-    'store: 'guard,
-    'guard: 'tx,
-    'tx,
-    TableStorage: schema::GeneratedStorage + 'store,
-    D: schema::TableDesc<Storage = TableStorage>,
-> KvTableRoTransactional<'guard, 'tx, TableStorage, D>
-{
+impl<'guard, D: TableDesc> KvTableRoTransactional<'guard, '_, D> {
     /// The number of key/value pairs in the table.
     pub fn len(&self) -> usize {
-        <&Self as TabularOps<'_, TableStorage, D>>::len(self)
+        <&Self as TabularOps>::len(self)
     }
 
     /// True if the table is empty.
     pub fn is_empty(&self) -> bool {
-        <&Self as TabularOps<'_, TableStorage, D>>::is_empty(self)
+        <&Self as TabularOps>::is_empty(self)
     }
 
     /// Get a row of the table from the store by cloning the value.
@@ -560,7 +469,7 @@ impl<
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
     {
-        <&Self as TabularOps<'_, TableStorage, D>>::get::<Q>(self, key, self.txn.owner)
+        <&Self as TabularOps>::get::<Q>(self, key, self.txn.owner)
     }
 
     /// Get immutable access to a row of the table in the store by reference.
@@ -571,40 +480,31 @@ impl<
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
     {
-        <&Self as TabularOps<'_, TableStorage, D>>::with::<Q, T>(self, key, f, self.txn.owner)
+        <&Self as TabularOps>::with::<Q, T>(self, key, f, self.txn.owner)
     }
 
     /// Iterate all the key/value pairs in a table.
-    ///
-    /// Clones both keys and values and provides them by-value. To iterate without cloning, see
-    /// [`Self::for_each`].
     pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &D::Value)>
     where
-        D: 'store,
+        D: 'guard,
     {
-        <&Self as TabularOps<'_, TableStorage, D>>::iter(self, self.txn.owner)
+        <&Self as TabularOps>::iter(self, self.txn.owner)
     }
 
     /// Iterate all the keys in a table.
-    ///
-    /// Clones the keys and provides them by-value. To iterate without cloning, see
-    /// [`Self::for_each`].
     pub fn keys(&self) -> impl Iterator<Item = &D::Key>
     where
-        D: 'store,
+        D: 'guard,
     {
-        <&Self as TabularOps<'_, TableStorage, D>>::keys(self, self.txn.owner)
+        <&Self as TabularOps>::keys(self, self.txn.owner)
     }
 
     /// Iterate all the values in a table.
-    ///
-    /// Clones values and provides them by-value. To iterate without cloning, see
-    /// [`Self::for_each`].
     pub fn values(&self) -> impl Iterator<Item = &D::Value>
     where
-        D: 'store,
+        D: 'guard,
     {
-        <&Self as TabularOps<'_, TableStorage, D>>::values(self, self.txn.owner)
+        <&Self as TabularOps>::values(self, self.txn.owner)
     }
 }
 

--- a/ts_kv_store/src/transactions.rs
+++ b/ts_kv_store/src/transactions.rs
@@ -1,0 +1,1410 @@
+//! KvStore transactional API.
+
+use std::{
+    borrow::Borrow,
+    hash::Hash,
+    marker::PhantomData,
+    sync::{Arc, RwLockReadGuard, RwLockWriteGuard, TryLockError},
+};
+
+use crate::{
+    KvStore, Owner, RefReadGuard, RefWriteGuard, RefWriteGuardMut, Result,
+    index::{KvTableRoTransactionalIndex, KvTableTransactionalIndex},
+    operations::{Ops, OpsMut, SingletonOps, SingletonOpsMut, TabularOps, TabularOpsMut},
+    schema::{self, TableDesc},
+    storage::Storage,
+};
+
+impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
+    /// Start a transaction.
+    ///
+    /// Blocks until the store's global lock is available for write access.
+    pub fn begin_transaction(&self, owner: Owner) -> Transaction<'_, TableStorage> {
+        Transaction {
+            guard: self.storage.write().unwrap(),
+            owner,
+        }
+    }
+
+    /// Start a transaction.
+    ///
+    /// Returns `None` if the store's global lock is unavailable for write access.
+    pub fn try_begin_transaction(&self, owner: Owner) -> Option<Transaction<'_, TableStorage>> {
+        let guard = match self.storage.try_write() {
+            Ok(g) => g,
+            Err(TryLockError::WouldBlock) => return None,
+            Err(TryLockError::Poisoned(_)) => panic!(),
+        };
+        Some(Transaction { guard, owner })
+    }
+
+    /// Start a read-only transaction (i.e., only supports non-mutating access to the store, but
+    /// all reads are guaranteed to be atomic).
+    ///
+    /// Blocks until the store's global lock is available for read access.
+    pub fn begin_ro_transaction(&self, owner: Owner) -> RoTransaction<'_, TableStorage> {
+        RoTransaction {
+            guard: self.storage.read().unwrap(),
+            owner,
+        }
+    }
+
+    /// Start a read-only transaction (i.e., only supports non-mutating access to the store, but
+    /// all reads are guaranteed to be atomic).
+    ///
+    /// Returns `None` if the store's global lock is unavailable for read access.
+    pub fn try_begin_ro_transaction(
+        &self,
+        owner: Owner,
+    ) -> Option<RoTransaction<'_, TableStorage>> {
+        let guard = match self.storage.try_read() {
+            Ok(g) => g,
+            Err(TryLockError::WouldBlock) => return None,
+            Err(TryLockError::Poisoned(_)) => panic!(),
+        };
+        Some(RoTransaction { guard, owner })
+    }
+
+    // TODO single-table transactions?
+}
+
+/// A read/write transaction over a [`KvStore`].
+///
+/// Create a transaction by calling [`KvStore::begin_transaction`] or [`KvStore::try_begin_transaction`].
+/// A transaction holds a write lock on the whole store while it is active so ensure that code within
+/// a transaction is relatively quick to execute and that you drop transactions as soon as possible
+/// ([`Transaction::commit`] can be used for this).
+///
+/// A transaction must not be kept alive over an `await` point. This can lead to deadlock.
+// TODO do we need to be able to abort a transaction?
+pub struct Transaction<'a, TableStorage: schema::GeneratedStorage> {
+    pub(crate) guard: RwLockWriteGuard<'a, Storage<TableStorage>>,
+    pub(crate) owner: Owner,
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage + 'a> Ops<'a, TableStorage>
+    for &'a Transaction<'a, TableStorage>
+{
+    type ReadLock = RefWriteGuard<'a, 'a, Storage<TableStorage>>;
+
+    fn read_lock(self) -> Self::ReadLock {
+        RefWriteGuard(&self.guard)
+    }
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage + 'a> SingletonOps<'a, TableStorage>
+    for &'a Transaction<'a, TableStorage>
+{
+}
+
+impl<'a, 't, TableStorage: schema::GeneratedStorage + 'a> OpsMut<'a, TableStorage>
+    for &'t mut Transaction<'a, TableStorage>
+{
+    type WriteLock = RefWriteGuardMut<'t, 'a, Storage<TableStorage>>;
+
+    fn write_lock(self) -> Self::WriteLock {
+        RefWriteGuardMut(&mut self.guard)
+    }
+}
+
+impl<'a, 't, TableStorage: schema::GeneratedStorage + 'a> SingletonOpsMut<'a, 't, TableStorage>
+    for &'t mut Transaction<'a, TableStorage>
+{
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage> Transaction<'a, TableStorage> {
+    /// Commit this transaction.
+    ///
+    /// This simply moves and drops the `Transaction` object. It is optional to call and currently
+    /// always succeeds. You can use this method to release the transaction's lock on the store
+    /// without needing an explicit scope.
+    pub fn commit(self) -> Result<()> {
+        // drop `self` to release the lock.
+        Ok(())
+    }
+
+    /// Operate on tables of key/values in the store.
+    ///
+    /// Example:
+    /// ```rust,ignore
+    /// let txn = store.begin_ro_transaction(OWNER);
+    /// let value = txn.table::<Foo>().get(key).unwrap();
+    /// ```
+    pub fn table<'t, D: schema::TableDesc<Storage = TableStorage>>(
+        &'t mut self,
+    ) -> KvTableTransactional<'a, 't, TableStorage, D> {
+        KvTableTransactional {
+            txn: self,
+            table: PhantomData,
+        }
+    }
+
+    /// Access a table via an index.
+    ///
+    /// # Example:
+    ///
+    /// ```rust,ignore
+    /// let txn = store.begin_ro_transaction(OWNER);
+    /// let value = txn.table_by::<index::Foo::bar>(OWNER).get(foreign_key).unwrap();
+    /// ```
+    ///
+    /// Here `Foo` describes a tables and `bar` describes an index over `Foo` using the `bar` field
+    /// as foreign key.
+    pub fn table_by<'t, D: schema::IndexDesc<Storage = TableStorage>>(
+        &'t mut self,
+    ) -> KvTableTransactionalIndex<'a, 't, TableStorage, D, D::BaseTable> {
+        KvTableTransactionalIndex {
+            txn: self,
+            index: PhantomData,
+            base: PhantomData,
+        }
+    }
+
+    /// Get a single value from the store by cloning the value.
+    ///
+    /// Returns `None` if there is no value for the specified key.
+    pub fn get<D: schema::Singleton>(&'a self) -> Option<D::Value>
+    where
+        D::Value: Clone,
+    {
+        <&Self as SingletonOps<'_, TableStorage>>::get::<D>(self, self.owner)
+    }
+
+    /// Get a single value from the store by cloning an `Arc`.
+    ///
+    /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
+    pub fn get_arc<D: schema::ArcSingleton>(&'a self) -> Option<Arc<D::Value>> {
+        <&Self as SingletonOps<'_, TableStorage>>::get_arc::<D>(self, self.owner)
+    }
+
+    /// Get immutable access to a value in the store by reference.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn with<D: schema::Singleton, T>(&'a self, f: impl FnOnce(&D::Value) -> T) -> Option<T> {
+        <&Self as SingletonOps<'_, TableStorage>>::with::<D, T>(self, f, self.owner)
+    }
+
+    /// Insert a single value into the store.
+    ///
+    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
+    // Question: do we need separate insert/update/upsert methods?
+    pub fn insert<D: schema::Singleton>(&mut self, value: D::ArgValue) -> Option<D::ArgValue> {
+        <&mut Self as SingletonOpsMut<'_, '_, TableStorage>>::insert::<D>(self, value, self.owner)
+    }
+
+    /// Get mutable access to a value in the store.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn mutate<D: schema::MutSingleton, T>(
+        &mut self,
+        f: impl FnOnce(&mut D::Value) -> T,
+    ) -> Option<T> {
+        <&mut Self as SingletonOpsMut<'_, '_, TableStorage>>::mutate::<D, T>(self, f, self.owner)
+    }
+
+    /// Remove a single value from the store.
+    ///
+    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
+    pub fn remove<D: schema::Singleton>(&mut self) -> Option<D::ArgValue> {
+        <&mut Self as SingletonOpsMut<'_, '_, TableStorage>>::remove::<D>(self, self.owner)
+    }
+
+    /// Remove a single value from the store while preserving ownership of the key/value.
+    ///
+    /// Can also be used to initialize a key/value with a key but without a value.
+    ///
+    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
+    pub fn clear<D: schema::Singleton>(&mut self) -> Option<D::ArgValue> {
+        <&mut Self as SingletonOpsMut<'_, '_, TableStorage>>::clear::<D>(self, self.owner)
+    }
+}
+
+/// Abstracts a table of key/values pairs in the store accessed as part of a transaction.
+pub struct KvTableTransactional<
+    'a,
+    't,
+    TableStorage: schema::GeneratedStorage + 'a,
+    D: schema::TableDesc<Storage = TableStorage>,
+> {
+    txn: &'t mut Transaction<'a, TableStorage>,
+    table: PhantomData<D>,
+}
+
+impl<'a, 't, TableStorage: schema::GeneratedStorage + 'a, D: TableDesc<Storage = TableStorage>>
+    Ops<'a, TableStorage> for &'t KvTableTransactional<'a, 't, TableStorage, D>
+{
+    type ReadLock = RefWriteGuard<'t, 'a, Storage<TableStorage>>;
+
+    fn read_lock(self) -> Self::ReadLock {
+        RefWriteGuard(&self.txn.guard)
+    }
+}
+
+impl<'a, 't, 's, TableStorage: schema::GeneratedStorage + 'a, D: TableDesc<Storage = TableStorage>>
+    OpsMut<'a, TableStorage> for &'s mut KvTableTransactional<'a, 't, TableStorage, D>
+{
+    type WriteLock = RefWriteGuardMut<'s, 'a, Storage<TableStorage>>;
+
+    fn write_lock(self) -> Self::WriteLock {
+        RefWriteGuardMut(&mut self.txn.guard)
+    }
+}
+
+impl<'a, 't, TableStorage: schema::GeneratedStorage + 'a, D: TableDesc<Storage = TableStorage> + 'a>
+    TabularOps<'a, TableStorage, D> for &'t KvTableTransactional<'a, 't, TableStorage, D>
+{
+}
+
+impl<'a, 't, TableStorage: schema::GeneratedStorage + 'a, D: TableDesc<Storage = TableStorage>>
+    TabularOpsMut<'a, TableStorage, D> for &mut KvTableTransactional<'a, 't, TableStorage, D>
+{
+}
+
+impl<
+    'a,
+    't,
+    TableStorage: schema::GeneratedStorage,
+    D: schema::TableDesc<Storage = TableStorage> + 'a,
+> KvTableTransactional<'a, 't, TableStorage, D>
+{
+    /// Initialize a table by setting its owner.
+    ///
+    /// Calling this function is optional, a table can be used without initialization in which case,
+    /// its owner is set to the owner specifed in the first write.
+    ///
+    /// Returns an error (containing the current owner of the table) if the table has already been
+    /// initialized. In this case, the table will be in a consistent state and can be used as normal.
+    pub fn init(&mut self) -> Result<()> {
+        <&mut Self as TabularOpsMut<'_, TableStorage, D>>::init(self, self.txn.owner)
+    }
+
+    /// The number of key/value pairs in the table.
+    pub fn len(&'t self) -> usize {
+        <&Self as TabularOps<'_, TableStorage, D>>::len(self)
+    }
+
+    /// True if the table is empty.
+    pub fn is_empty(&'t self) -> bool {
+        <&Self as TabularOps<'_, TableStorage, D>>::is_empty(self)
+    }
+
+    /// Clear a table by removing all its KVs, but preserving ownership.
+    pub fn clear(&mut self) {
+        <&mut Self as TabularOpsMut<'_, TableStorage, D>>::clear(self, self.txn.owner)
+    }
+
+    /// Get a row of the table from the store by cloning the value.
+    ///
+    /// Returns `None` if there is no value for the specified key.
+    pub fn get<Q>(&'t self, key: &Q) -> Option<D::Value>
+    where
+        D::Value: Clone,
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&Self as TabularOps<'_, TableStorage, D>>::get::<Q>(self, key, self.txn.owner)
+    }
+
+    /// Get immutable access to a row of the table in the store by reference.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn with<Q, T>(&'t self, key: &Q, f: impl FnOnce(&D::Value) -> T) -> Option<T>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&Self as TabularOps<'_, TableStorage, D>>::with::<Q, T>(self, key, f, self.txn.owner)
+    }
+
+    /// Insert a value into the table.
+    ///
+    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
+    pub fn insert(&mut self, key: D::Key, value: D::Value) -> Option<D::Value>
+    where
+        D::Key: Clone,
+    {
+        <&mut Self as TabularOpsMut<'_, TableStorage, D>>::insert(self, key, value, self.txn.owner)
+    }
+
+    /// Get mutable access to a row of the table in the store in the store.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn mutate<Q, T>(&mut self, key: &Q, f: impl FnOnce(&mut D::Value) -> T) -> Option<T>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
+    {
+        <&mut Self as TabularOpsMut<'_, TableStorage, D>>::mutate(self, key, f, self.txn.owner)
+    }
+
+    /// Remove a row from the table.
+    ///
+    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<D::Value>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&mut Self as TabularOpsMut<'_, TableStorage, D>>::remove(self, key, self.txn.owner)
+    }
+
+    /// Iterate all the key/value pairs in a table.
+    ///
+    /// Clones both keys and values and provides them by-value. To iterate without cloning, see
+    /// [`Self::for_each`].
+    pub fn iter_cloned(&'t self) -> impl Iterator<Item = (D::Key, D::Value)>
+    where
+        D::Key: Clone,
+        D::Value: Clone,
+    {
+        <&Self as TabularOps<'_, TableStorage, D>>::iter_cloned(self, self.txn.owner)
+    }
+
+    /// Iterate all the keys in a table.
+    ///
+    /// Clones the keys and provides them by-value. To iterate without cloning, see
+    /// [`Self::for_each`].
+    pub fn iter_keys_cloned(&'t self) -> impl Iterator<Item = D::Key>
+    where
+        D::Key: Clone,
+    {
+        <&Self as TabularOps<'_, TableStorage, D>>::iter_keys_cloned(self, self.txn.owner)
+    }
+
+    /// Iterate all the values in a table.
+    ///
+    /// Clones values and provides them by-value. To iterate without cloning, see
+    /// [`Self::for_each`].
+    pub fn iter_values_cloned(&'t self) -> impl Iterator<Item = D::Value>
+    where
+        D::Value: Clone,
+    {
+        <&Self as TabularOps<'_, TableStorage, D>>::iter_values_cloned(self, self.txn.owner)
+    }
+
+    /// Iterate all the key/value pairs in a table.
+    ///
+    /// We're not able to make this an iterator because we have to ensure that the references do
+    /// not outlive our lock on the store. For a (cloning) iterator see [`Self::iter_cloned`].
+    pub fn for_each(&'t self, f: impl FnMut(&D::Key, &D::Value)) {
+        <&Self as TabularOps<'_, TableStorage, D>>::for_each(self, f, self.txn.owner)
+    }
+
+    /// Iterate all the key/value pairs in a table. Values are mutable.
+    pub fn for_each_mut(&mut self, f: impl FnMut(&D::Key, &mut D::Value)) {
+        <&mut Self as TabularOpsMut<'_, TableStorage, D>>::for_each_mut(self, f, self.txn.owner)
+    }
+}
+
+/// A read-only transaction over a [`KvStore`].
+///
+/// Create a read-only transaction by calling [`KvStore::begin_ro_transaction`] or [`KvStore::try_begin_ro_transaction`].
+/// A read-only transaction holds a read lock on the whole store while it is active so ensure that
+/// code within a transaction is relatively quick to execute and that you drop transactions as soon
+/// as possible([`RoTransaction::commit`] can be used for this).
+///
+/// A transaction must not be kept alive over an `await` point. This can lead to deadlock.
+pub struct RoTransaction<'a, TableStorage: schema::GeneratedStorage> {
+    pub(crate) guard: RwLockReadGuard<'a, Storage<TableStorage>>,
+    pub(crate) owner: Owner,
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage + 'a> Ops<'a, TableStorage>
+    for &'a RoTransaction<'a, TableStorage>
+{
+    type ReadLock = RefReadGuard<'a, Storage<TableStorage>>;
+
+    fn read_lock(self) -> Self::ReadLock {
+        RefReadGuard(&self.guard)
+    }
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage + 'a> SingletonOps<'a, TableStorage>
+    for &'a RoTransaction<'a, TableStorage>
+{
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage + 'a, D: TableDesc<Storage = TableStorage>>
+    Ops<'a, TableStorage> for &KvTableRoTransactional<'a, TableStorage, D>
+{
+    type ReadLock = RefReadGuard<'a, Storage<TableStorage>>;
+
+    fn read_lock(self) -> Self::ReadLock {
+        RefReadGuard(&self.txn.guard)
+    }
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage + 'a, D: TableDesc<Storage = TableStorage> + 'a>
+    TabularOps<'a, TableStorage, D> for &KvTableRoTransactional<'a, TableStorage, D>
+{
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage> RoTransaction<'a, TableStorage> {
+    /// Commit this transaction.
+    ///
+    /// This simply moves and drops the `RoTransaction` object. It is optional to call and currently
+    /// always succeeds. You can use this method to release the transaction's lock on the store
+    /// without needing an explicit scope.
+    pub fn commit(self) -> Result<()> {
+        // drop `self` to release the lock.
+        Ok(())
+    }
+
+    /// Operate on tables of key/values in the store.
+    ///
+    /// Example:
+    /// ```rust,ignore
+    /// let txn = store.begin_ro_transaction(OWNER);
+    /// let value = txn.table::<Foo>().get(key).unwrap();
+    /// ```
+    pub fn table<D: schema::TableDesc<Storage = TableStorage>>(
+        &'a self,
+    ) -> KvTableRoTransactional<'a, TableStorage, D> {
+        KvTableRoTransactional {
+            txn: self,
+            table: PhantomData,
+        }
+    }
+
+    /// Access a table via an index.
+    ///
+    /// # Example:
+    ///
+    /// ```rust,ignore
+    /// let txn = store.begin_ro_transaction(OWNER);
+    /// let value = txn.table_by::<index::Foo::bar>(OWNER).get(foreign_key).unwrap();
+    /// ```
+    ///
+    /// Here `Foo` describes a tables and `bar` describes an index over `Foo` using the `bar` field
+    /// as foreign key.
+    pub fn table_by<D: schema::IndexDesc<Storage = TableStorage>>(
+        &'a self,
+    ) -> KvTableRoTransactionalIndex<'a, TableStorage, D, D::BaseTable> {
+        KvTableRoTransactionalIndex {
+            txn: self,
+            index: PhantomData,
+            base: PhantomData,
+        }
+    }
+
+    /// Get a single value from the store by cloning the value.
+    ///
+    /// Returns `None` if there is no value for the specified key.
+    pub fn get<D: schema::Singleton>(&'a self) -> Option<D::Value>
+    where
+        D::Value: Clone,
+    {
+        <&Self as SingletonOps<'_, TableStorage>>::get::<D>(self, self.owner)
+    }
+
+    /// Get a single value from the store by cloning an `Arc`.
+    ///
+    /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
+    pub fn get_arc<D: schema::ArcSingleton>(&'a self) -> Option<Arc<D::Value>> {
+        <&Self as SingletonOps<'_, TableStorage>>::get_arc::<D>(self, self.owner)
+    }
+
+    /// Get immutable access to a value in the store by reference.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn with<D: schema::Singleton, T>(&'a self, f: impl FnOnce(&D::Value) -> T) -> Option<T> {
+        <&Self as SingletonOps<'_, TableStorage>>::with::<D, T>(self, f, self.owner)
+    }
+}
+
+/// Abstracts a table of key/values pairs in the store as part of a read-only transaction.
+pub struct KvTableRoTransactional<
+    'a,
+    TableStorage: schema::GeneratedStorage,
+    D: schema::TableDesc<Storage = TableStorage> + 'a,
+> {
+    txn: &'a RoTransaction<'a, TableStorage>,
+    table: PhantomData<D>,
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage, D: schema::TableDesc<Storage = TableStorage> + 'a>
+    KvTableRoTransactional<'a, TableStorage, D>
+{
+    /// The number of key/value pairs in the table.
+    pub fn len(&'a self) -> usize {
+        <&Self as TabularOps<'_, TableStorage, D>>::len(self)
+    }
+
+    /// True if the table is empty.
+    pub fn is_empty(&'a self) -> bool {
+        <&Self as TabularOps<'_, TableStorage, D>>::is_empty(self)
+    }
+
+    /// Get a row of the table from the store by cloning the value.
+    ///
+    /// Returns `None` if there is no value for the specified key.
+    pub fn get<Q>(&'a self, key: &Q) -> Option<D::Value>
+    where
+        D::Value: Clone,
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&Self as TabularOps<'_, TableStorage, D>>::get::<Q>(self, key, self.txn.owner)
+    }
+
+    /// Get immutable access to a row of the table in the store by reference.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn with<Q, T>(&'a self, key: &Q, f: impl FnOnce(&D::Value) -> T) -> Option<T>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        <&Self as TabularOps<'_, TableStorage, D>>::with::<Q, T>(self, key, f, self.txn.owner)
+    }
+
+    /// Iterate all the key/value pairs in a table.
+    ///
+    /// Clones both keys and values and provides them by-value. To iterate without cloning, see
+    /// [`Self::for_each`].
+    pub fn iter_cloned(&'a self) -> impl Iterator<Item = (D::Key, D::Value)>
+    where
+        D::Key: Clone,
+        D::Value: Clone,
+    {
+        <&Self as TabularOps<'_, TableStorage, D>>::iter_cloned(self, self.txn.owner)
+    }
+
+    /// Iterate all the keys in a table.
+    ///
+    /// Clones the keys and provides them by-value. To iterate without cloning, see
+    /// [`Self::for_each`].
+    pub fn iter_keys_cloned(&'a self) -> impl Iterator<Item = D::Key>
+    where
+        D::Key: Clone,
+    {
+        <&Self as TabularOps<'_, TableStorage, D>>::iter_keys_cloned(self, self.txn.owner)
+    }
+
+    /// Iterate all the values in a table.
+    ///
+    /// Clones values and provides them by-value. To iterate without cloning, see
+    /// [`Self::for_each`].
+    pub fn iter_values_cloned(&'a self) -> impl Iterator<Item = D::Value>
+    where
+        D::Value: Clone,
+    {
+        <&Self as TabularOps<'_, TableStorage, D>>::iter_values_cloned(self, self.txn.owner)
+    }
+
+    /// Iterate all the key/value pairs in a table.
+    ///
+    /// We're not able to make this an iterator because we have to ensure that the references do
+    /// not outlive our lock on the store. For a (cloning) iterator see [`Self::iter_cloned`].
+    pub fn for_each(&self, f: impl FnMut(&D::Key, &D::Value)) {
+        <&Self as TabularOps<'_, TableStorage, D>>::for_each(self, f, self.txn.owner)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{any::Any, sync::Arc};
+
+    use crate::{Error, singleton, tables};
+
+    singleton!(Count(u64));
+    singleton!(Shared(String as Arc));
+
+    tables!(Items(&'static str => String), Counters(u32 => u64));
+
+    const OWNER: &str = "owner";
+    #[cfg(debug_assertions)]
+    const OTHER: &str = "other";
+
+    #[test]
+    fn begin_transaction_works() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.insert::<Count>(42);
+        assert_eq!(txn.get::<Count>(), Some(42));
+    }
+
+    #[test]
+    fn try_begin_transaction_returns_some_when_unlocked() {
+        let store = KvStore::new();
+        assert!(store.try_begin_transaction(OWNER).is_some());
+    }
+
+    #[test]
+    fn begin_ro_transaction_works() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 7);
+        let txn = store.begin_ro_transaction(OWNER);
+        assert_eq!(txn.get::<Count>(), Some(7));
+    }
+
+    #[test]
+    fn try_begin_ro_transaction_returns_some_when_unlocked() {
+        let store = KvStore::new();
+        assert!(store.try_begin_ro_transaction(OWNER).is_some());
+    }
+
+    #[test]
+    fn txn_get_returns_none_when_absent() {
+        let store = KvStore::new();
+        let txn = store.begin_transaction(OWNER);
+        assert!(txn.get::<Count>().is_none());
+    }
+
+    #[test]
+    fn txn_get_returns_value_inserted_in_same_txn() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.insert::<Count>(42);
+        assert_eq!(txn.get::<Count>(), Some(42));
+    }
+
+    #[test]
+    fn txn_get_returns_value_inserted_before_txn() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 5);
+        let txn = store.begin_transaction(OWNER);
+        assert_eq!(txn.get::<Count>(), Some(5));
+    }
+
+    #[test]
+    fn txn_get_returns_none_after_clear_in_same_txn() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.insert::<Count>(1);
+        txn.clear::<Count>();
+        assert!(txn.get::<Count>().is_none());
+    }
+
+    #[test]
+    fn txn_get_arc_returns_none_when_absent() {
+        let store = KvStore::new();
+        let txn = store.begin_transaction(OWNER);
+        assert!(txn.get_arc::<Shared>().is_none());
+    }
+
+    #[test]
+    fn txn_get_arc_returns_arc_after_insert() {
+        let store = KvStore::new();
+        store.insert::<Shared>(OWNER, Arc::new("hello".to_owned()));
+        let txn = store.begin_transaction(OWNER);
+        let arc = txn.get_arc::<Shared>().unwrap();
+        assert_eq!(*arc, "hello");
+    }
+
+    #[test]
+    fn txn_get_arc_shares_allocation() {
+        let store = KvStore::new();
+        store.insert::<Shared>(OWNER, Arc::new("hello".to_owned()));
+        let txn = store.begin_transaction(OWNER);
+        let arc1 = txn.get_arc::<Shared>().unwrap();
+        let arc2 = txn.get_arc::<Shared>().unwrap();
+        assert!(Arc::ptr_eq(&arc1, &arc2));
+    }
+
+    #[test]
+    fn txn_with_returns_none_and_does_not_call_f_when_absent() {
+        let store = KvStore::new();
+        let txn = store.begin_transaction(OWNER);
+        let mut called = false;
+        let result = txn.with::<Count, ()>(|_| {
+            called = true;
+        });
+        assert!(result.is_none());
+        assert!(!called);
+    }
+
+    #[test]
+    fn txn_with_returns_result_of_f() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.insert::<Count>(5);
+        assert_eq!(txn.with::<Count, _>(|v| v * 2), Some(10));
+    }
+
+    #[test]
+    fn txn_insert_returns_none_on_first() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        assert!(txn.insert::<Count>(1).is_none());
+    }
+
+    #[test]
+    fn txn_insert_returns_previous_value() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.insert::<Count>(1);
+        assert_eq!(txn.insert::<Count>(2), Some(1));
+    }
+
+    #[test]
+    fn txn_insert_over_tombstone_returns_none() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.insert::<Count>(1);
+        txn.clear::<Count>();
+        assert!(txn.insert::<Count>(2).is_none());
+    }
+
+    #[test]
+    fn txn_mutate_returns_none_and_does_not_call_f_when_absent() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut called = false;
+        let result = txn.mutate::<Count, ()>(|_| {
+            called = true;
+        });
+        assert!(result.is_none());
+        assert!(!called);
+    }
+
+    #[test]
+    fn txn_mutate_modifies_value_in_place() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.insert::<Count>(10);
+        assert_eq!(
+            txn.mutate::<Count, _>(|v| {
+                *v += 5;
+                *v
+            }),
+            Some(15)
+        );
+        assert_eq!(txn.get::<Count>(), Some(15));
+    }
+
+    #[test]
+    fn txn_remove_returns_none_when_absent() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        assert!(txn.remove::<Count>().is_none());
+    }
+
+    #[test]
+    fn txn_remove_returns_previous_value() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.insert::<Count>(7);
+        assert_eq!(txn.remove::<Count>(), Some(7));
+    }
+
+    #[test]
+    fn txn_remove_makes_get_return_none() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.insert::<Count>(1);
+        txn.remove::<Count>();
+        assert!(txn.get::<Count>().is_none());
+    }
+
+    #[test]
+    fn txn_clear_returns_none_when_absent() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        assert!(txn.clear::<Count>().is_none());
+    }
+
+    #[test]
+    fn txn_clear_returns_previous_value() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.insert::<Count>(3);
+        assert_eq!(txn.clear::<Count>(), Some(3));
+    }
+
+    #[test]
+    fn txn_clear_makes_get_return_none() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.insert::<Count>(1);
+        txn.clear::<Count>();
+        assert!(txn.get::<Count>().is_none());
+    }
+
+    #[test]
+    fn txn_double_clear_returns_none() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.insert::<Count>(1);
+        txn.clear::<Count>();
+        assert!(txn.clear::<Count>().is_none());
+    }
+
+    #[test]
+    fn txn_writes_visible_after_drop() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.insert::<Count>(42);
+        txn.commit().unwrap();
+
+        assert_eq!(store.get::<Count>(OWNER), Some(42));
+    }
+
+    #[test]
+    fn txn_table_writes_visible_after_drop() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Items>().insert("k", "v".to_owned());
+        txn.commit().unwrap();
+
+        assert_eq!(store.table::<Items>(OWNER).get("k"), Some("v".to_owned()));
+    }
+
+    #[test]
+    fn txn_mutate_visible_after_drop() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        let mut txn = store.begin_transaction(OWNER);
+        txn.mutate::<Count, ()>(|v| *v = 100);
+        txn.commit().unwrap();
+
+        assert_eq!(store.get::<Count>(OWNER), Some(100));
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn txn_insert_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        let mut txn = store.begin_transaction(OTHER);
+        txn.insert::<Count>(5);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn txn_mutate_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        let mut txn = store.begin_transaction(OTHER);
+        txn.mutate::<Count, ()>(|_| {});
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn txn_remove_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        let mut txn = store.begin_transaction(OTHER);
+        txn.remove::<Count>();
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn txn_clear_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        let mut txn = store.begin_transaction(OTHER);
+        txn.clear::<Count>();
+    }
+
+    #[test]
+    fn txn_table_init_succeeds() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        assert!(table.init().is_ok());
+    }
+
+    #[test]
+    fn txn_table_init_second_call_err() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.init().unwrap();
+        let err = table.init().unwrap_err();
+        assert!(matches!(err, Error::AlreadyInit(o) if o == OWNER));
+    }
+
+    #[test]
+    fn txn_table_get_returns_none_when_absent() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let table = txn.table::<Items>();
+        assert!(table.get("missing").is_none());
+    }
+
+    #[test]
+    fn txn_table_insert_returns_none_on_first() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        assert!(table.insert("k", "v".to_owned()).is_none());
+    }
+
+    #[test]
+    fn txn_table_insert_returns_previous() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.insert("k", "v1".to_owned());
+        assert_eq!(table.insert("k", "v2".to_owned()), Some("v1".to_owned()));
+    }
+
+    #[test]
+    fn txn_table_get_returns_value_after_insert() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.insert("k", "val".to_owned());
+        assert_eq!(table.get("k"), Some("val".to_owned()));
+    }
+
+    #[test]
+    fn txn_table_with_returns_none_and_does_not_call_f_when_absent() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let table = txn.table::<Items>();
+        let mut called = false;
+        let result = table.with("missing", |_| {
+            called = true;
+        });
+        assert!(result.is_none());
+        assert!(!called);
+    }
+
+    #[test]
+    fn txn_table_with_returns_some_after_insert() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.insert("k", "val".to_owned());
+        assert_eq!(table.with("k", |s| s.len()), Some(3));
+    }
+
+    #[test]
+    fn txn_table_mutate_returns_none_when_absent() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.init().unwrap();
+        assert!(table.mutate(&"missing", |v| v.len()).is_none());
+    }
+
+    #[test]
+    fn txn_table_mutate_modifies_value() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.insert("k", "hello".to_owned());
+        table.mutate(&"k", |v| v.push('!'));
+        assert_eq!(table.get("k"), Some("hello!".to_owned()));
+    }
+
+    #[test]
+    fn txn_table_remove_returns_none_when_absent() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        assert!(table.remove("missing").is_none());
+    }
+
+    #[test]
+    fn txn_table_remove_returns_previous_value() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.insert("k", "v".to_owned());
+        assert_eq!(table.remove("k"), Some("v".to_owned()));
+    }
+
+    #[test]
+    fn txn_table_remove_makes_get_return_none() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.insert("k", "v".to_owned());
+        table.remove("k");
+        assert!(table.get("k").is_none());
+    }
+
+    #[test]
+    fn txn_table_clear_removes_all_rows() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.insert("a", "alpha".to_owned());
+        table.insert("b", "beta".to_owned());
+        table.insert("c", "gamma".to_owned());
+        table.clear();
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn txn_table_is_empty_on_fresh_store() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let table = txn.table::<Items>();
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn txn_table_len_reflects_inserts() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.insert("a", "alpha".to_owned());
+        table.insert("b", "beta".to_owned());
+        assert_eq!(table.len(), 2);
+    }
+
+    #[test]
+    fn txn_table_iter_empty() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let table = txn.table::<Items>();
+        assert_eq!(table.iter_cloned().count(), 0);
+    }
+
+    #[test]
+    fn txn_table_iter_yields_inserted_rows() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.insert("a", "alpha".to_owned());
+        table.insert("b", "beta".to_owned());
+        let mut items: Vec<_> = table.iter_cloned().collect();
+        items.sort();
+        assert_eq!(
+            items,
+            vec![("a", "alpha".to_owned()), ("b", "beta".to_owned())]
+        );
+    }
+
+    #[test]
+    fn txn_table_for_each_empty_calls_closure_zero_times() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let table = txn.table::<Items>();
+        let mut count = 0;
+        table.for_each(|_, _| count += 1);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn txn_table_for_each_yields_all_rows() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.insert("a", "alpha".to_owned());
+        table.insert("b", "beta".to_owned());
+        let mut items: Vec<_> = Vec::new();
+        table.for_each(|k, v| items.push((*k, v.clone())));
+        items.sort();
+        assert_eq!(
+            items,
+            vec![("a", "alpha".to_owned()), ("b", "beta".to_owned())]
+        );
+    }
+
+    #[test]
+    fn txn_table_for_each_mut_empty_calls_closure_zero_times() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        let mut count = 0;
+        table.for_each_mut(|_, _| count += 1);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn txn_table_for_each_mut_modifies_values() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.insert("k", "hello".to_owned());
+        table.for_each_mut(|_, v| v.push('!'));
+        assert_eq!(table.get("k"), Some("hello!".to_owned()));
+    }
+
+    #[test]
+    fn txn_table_iter_keys_cloned_empty() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let table = txn.table::<Items>();
+        let keys: Vec<_> = table.iter_keys_cloned().collect();
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn txn_table_iter_keys_cloned_yields_all_keys() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.insert("a", "alpha".to_owned());
+        table.insert("b", "beta".to_owned());
+        let mut keys: Vec<_> = table.iter_keys_cloned().collect();
+        keys.sort();
+        assert_eq!(keys, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn txn_table_iter_values_cloned_empty() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let table = txn.table::<Items>();
+        let values: Vec<_> = table.iter_values_cloned().collect();
+        assert!(values.is_empty());
+    }
+
+    #[test]
+    fn txn_table_iter_values_cloned_yields_all_values() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.insert("a", "alpha".to_owned());
+        table.insert("b", "beta".to_owned());
+        let mut values: Vec<_> = table.iter_values_cloned().collect();
+        values.sort();
+        assert_eq!(values, vec!["alpha".to_owned(), "beta".to_owned()]);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn txn_table_insert_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).init().unwrap();
+        let mut txn = store.begin_transaction(OTHER);
+        txn.table::<Items>().insert("k", "v".to_owned());
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn txn_table_mutate_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).init().unwrap();
+        let mut txn = store.begin_transaction(OTHER);
+        txn.table::<Items>().mutate(&"k", |v: &mut String| v.len());
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn txn_table_remove_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).init().unwrap();
+        let mut txn = store.begin_transaction(OTHER);
+        txn.table::<Items>().remove("k");
+    }
+
+    #[test]
+    fn ro_txn_get_returns_none_when_absent() {
+        let store = KvStore::new();
+        let txn = store.begin_ro_transaction(OWNER);
+        assert!(txn.get::<Count>().is_none());
+    }
+
+    #[test]
+    fn ro_txn_get_returns_value_inserted_before_txn() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 42);
+        let txn = store.begin_ro_transaction(OWNER);
+        assert_eq!(txn.get::<Count>(), Some(42));
+    }
+
+    #[test]
+    fn ro_txn_get_arc_returns_none_when_absent() {
+        let store = KvStore::new();
+        let txn = store.begin_ro_transaction(OWNER);
+        assert!(txn.get_arc::<Shared>().is_none());
+    }
+
+    #[test]
+    fn ro_txn_get_arc_returns_arc() {
+        let store = KvStore::new();
+        store.insert::<Shared>(OWNER, Arc::new("hello".to_owned()));
+        let txn = store.begin_ro_transaction(OWNER);
+        let arc = txn.get_arc::<Shared>().unwrap();
+        assert_eq!(*arc, "hello");
+    }
+
+    #[test]
+    fn ro_txn_with_returns_none_and_does_not_call_f_when_absent() {
+        let store = KvStore::new();
+        let txn = store.begin_ro_transaction(OWNER);
+        let mut called = false;
+        let result = txn.with::<Count, ()>(|_| {
+            called = true;
+        });
+        assert!(result.is_none());
+        assert!(!called);
+    }
+
+    #[test]
+    fn ro_txn_with_returns_some_after_insert() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 4);
+        let txn = store.begin_ro_transaction(OWNER);
+        assert_eq!(txn.with::<Count, _>(|v| v * 2), Some(8));
+    }
+
+    #[test]
+    fn ro_txn_table_get_returns_none_when_absent() {
+        let store = KvStore::new();
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        assert!(table.get("missing").is_none());
+    }
+
+    #[test]
+    fn ro_txn_table_get_returns_value_inserted_before_txn() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "val".to_owned());
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        assert_eq!(table.get("k"), Some("val".to_owned()));
+    }
+
+    #[test]
+    fn ro_txn_table_with_returns_none_and_does_not_call_f_when_absent() {
+        let store = KvStore::new();
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        let mut called = false;
+        let result = table.with("missing", |_| {
+            called = true;
+        });
+        assert!(result.is_none());
+        assert!(!called);
+    }
+
+    #[test]
+    fn ro_txn_table_with_returns_some() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "val".to_owned());
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        assert_eq!(table.with("k", |s| s.len()), Some(3));
+    }
+
+    #[test]
+    fn ro_txn_table_len_zero_when_empty() {
+        let store = KvStore::new();
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        assert_eq!(table.len(), 0);
+    }
+
+    #[test]
+    fn ro_txn_table_len_reflects_pre_txn_inserts() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("a", "alpha".to_owned());
+        store.table::<Items>(OWNER).insert("b", "beta".to_owned());
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        assert_eq!(table.len(), 2);
+    }
+
+    #[test]
+    fn ro_txn_table_is_empty_true_when_no_rows() {
+        let store = KvStore::new();
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn ro_txn_table_is_empty_false_after_inserts() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "v".to_owned());
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        assert!(!table.is_empty());
+    }
+
+    #[test]
+    fn ro_txn_table_iter_empty() {
+        let store = KvStore::new();
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        assert_eq!(table.iter_cloned().count(), 0);
+    }
+
+    #[test]
+    fn ro_txn_table_iter_yields_pre_txn_rows() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("a", "alpha".to_owned());
+        store.table::<Items>(OWNER).insert("b", "beta".to_owned());
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        let mut items: Vec<_> = table.iter_cloned().collect();
+        items.sort();
+        assert_eq!(
+            items,
+            vec![("a", "alpha".to_owned()), ("b", "beta".to_owned())]
+        );
+    }
+
+    #[test]
+    fn ro_txn_table_for_each_empty_calls_closure_zero_times() {
+        let store = KvStore::new();
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        let mut count = 0;
+        table.for_each(|_, _| count += 1);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn ro_txn_table_for_each_yields_pre_txn_rows() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("a", "alpha".to_owned());
+        store.table::<Items>(OWNER).insert("b", "beta".to_owned());
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        let mut items: Vec<_> = Vec::new();
+        table.for_each(|k, v| items.push((*k, v.clone())));
+        items.sort();
+        assert_eq!(
+            items,
+            vec![("a", "alpha".to_owned()), ("b", "beta".to_owned())]
+        );
+    }
+
+    #[test]
+    fn ro_txn_table_iter_keys_cloned_empty() {
+        let store = KvStore::new();
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        let keys: Vec<_> = table.iter_keys_cloned().collect();
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn ro_txn_table_iter_keys_cloned_yields_pre_txn_keys() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("a", "alpha".to_owned());
+        store.table::<Items>(OWNER).insert("b", "beta".to_owned());
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        let mut keys: Vec<_> = table.iter_keys_cloned().collect();
+        keys.sort();
+        assert_eq!(keys, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn ro_txn_table_iter_values_cloned_empty() {
+        let store = KvStore::new();
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        let values: Vec<_> = table.iter_values_cloned().collect();
+        assert!(values.is_empty());
+    }
+
+    #[test]
+    fn ro_txn_table_iter_values_cloned_yields_pre_txn_values() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("a", "alpha".to_owned());
+        store.table::<Items>(OWNER).insert("b", "beta".to_owned());
+        let txn = store.begin_ro_transaction(OWNER);
+        let table = txn.table::<Items>();
+        let mut values: Vec<_> = table.iter_values_cloned().collect();
+        values.sort();
+        assert_eq!(values, vec!["alpha".to_owned(), "beta".to_owned()]);
+    }
+}

--- a/ts_kv_store/src/transactions.rs
+++ b/ts_kv_store/src/transactions.rs
@@ -77,42 +77,42 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
 ///
 /// A transaction must not be kept alive over an `await` point. This can lead to deadlock.
 // TODO do we need to be able to abort a transaction?
-pub struct Transaction<'a, TableStorage: schema::GeneratedStorage> {
-    pub(crate) guard: RwLockWriteGuard<'a, Storage<TableStorage>>,
+pub struct Transaction<'guard, TableStorage: schema::GeneratedStorage> {
+    pub(crate) guard: RwLockWriteGuard<'guard, Storage<TableStorage>>,
     pub(crate) owner: Owner,
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage + 'a> Ops<'a, TableStorage>
-    for &'a Transaction<'a, TableStorage>
+impl<'store: 'guard, 'guard: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
+    Ops<'r, TableStorage> for &'r Transaction<'guard, TableStorage>
 {
-    type ReadLock = RefWriteGuard<'a, 'a, Storage<TableStorage>>;
+    type ReadLock = RefWriteGuard<'r, 'guard, Storage<TableStorage>>;
 
     fn read_lock(self) -> Self::ReadLock {
         RefWriteGuard(&self.guard)
     }
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage + 'a> SingletonOps<'a, TableStorage>
-    for &'a Transaction<'a, TableStorage>
+impl<'store: 'guard, 'guard: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
+    SingletonOps<'r, TableStorage> for &'r Transaction<'guard, TableStorage>
 {
 }
 
-impl<'a, 't, TableStorage: schema::GeneratedStorage + 'a> OpsMut<'a, TableStorage>
-    for &'t mut Transaction<'a, TableStorage>
+impl<'store: 'guard, 'guard: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
+    OpsMut<'r, TableStorage> for &'r mut Transaction<'guard, TableStorage>
 {
-    type WriteLock = RefWriteGuardMut<'t, 'a, Storage<TableStorage>>;
+    type WriteLock = RefWriteGuardMut<'r, 'guard, Storage<TableStorage>>;
 
     fn write_lock(self) -> Self::WriteLock {
         RefWriteGuardMut(&mut self.guard)
     }
 }
 
-impl<'a, 't, TableStorage: schema::GeneratedStorage + 'a> SingletonOpsMut<'a, 't, TableStorage>
-    for &'t mut Transaction<'a, TableStorage>
+impl<'store: 'guard, 'guard: 'r, 'r, TableStorage: schema::GeneratedStorage + 'store>
+    SingletonOpsMut<'r, TableStorage> for &'r mut Transaction<'guard, TableStorage>
 {
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage> Transaction<'a, TableStorage> {
+impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableStorage> {
     /// Commit this transaction.
     ///
     /// This simply moves and drops the `Transaction` object. It is optional to call and currently
@@ -130,9 +130,9 @@ impl<'a, TableStorage: schema::GeneratedStorage> Transaction<'a, TableStorage> {
     /// let txn = store.begin_ro_transaction(OWNER);
     /// let value = txn.table::<Foo>().get(key).unwrap();
     /// ```
-    pub fn table<'t, D: schema::TableDesc<Storage = TableStorage>>(
-        &'t mut self,
-    ) -> KvTableTransactional<'a, 't, TableStorage, D> {
+    pub fn table<'r, D: schema::TableDesc<Storage = TableStorage>>(
+        &'r mut self,
+    ) -> KvTableTransactional<'guard, 'r, TableStorage, D> {
         KvTableTransactional {
             txn: self,
             table: PhantomData,
@@ -150,9 +150,9 @@ impl<'a, TableStorage: schema::GeneratedStorage> Transaction<'a, TableStorage> {
     ///
     /// Here `Foo` describes a tables and `bar` describes an index over `Foo` using the `bar` field
     /// as foreign key.
-    pub fn table_by<'t, D: schema::IndexDesc<Storage = TableStorage>>(
-        &'t mut self,
-    ) -> KvTableTransactionalIndex<'a, 't, TableStorage, D, D::BaseTable> {
+    pub fn table_by<'r, D: schema::IndexDesc<Storage = TableStorage>>(
+        &'r mut self,
+    ) -> KvTableTransactionalIndex<'guard, 'r, TableStorage, D, D::BaseTable> {
         KvTableTransactionalIndex {
             txn: self,
             index: PhantomData,
@@ -163,7 +163,7 @@ impl<'a, TableStorage: schema::GeneratedStorage> Transaction<'a, TableStorage> {
     /// Get a single value from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<D: schema::Singleton>(&'a self) -> Option<D::Value>
+    pub fn get<D: schema::Singleton>(&self) -> Option<D::Value>
     where
         D::Value: Clone,
     {
@@ -173,14 +173,14 @@ impl<'a, TableStorage: schema::GeneratedStorage> Transaction<'a, TableStorage> {
     /// Get a single value from the store by cloning an `Arc`.
     ///
     /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
-    pub fn get_arc<D: schema::ArcSingleton>(&'a self) -> Option<Arc<D::Value>> {
+    pub fn get_arc<D: schema::ArcSingleton>(&self) -> Option<Arc<D::Value>> {
         <&Self as SingletonOps<'_, TableStorage>>::get_arc::<D>(self, self.owner)
     }
 
     /// Get immutable access to a value in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<D: schema::Singleton, T>(&'a self, f: impl FnOnce(&D::Value) -> T) -> Option<T> {
+    pub fn with<D: schema::Singleton, T>(&self, f: impl FnOnce(&D::Value) -> T) -> Option<T> {
         <&Self as SingletonOps<'_, TableStorage>>::with::<D, T>(self, f, self.owner)
     }
 
@@ -189,7 +189,7 @@ impl<'a, TableStorage: schema::GeneratedStorage> Transaction<'a, TableStorage> {
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     // Question: do we need separate insert/update/upsert methods?
     pub fn insert<D: schema::Singleton>(&mut self, value: D::ArgValue) -> Option<D::ArgValue> {
-        <&mut Self as SingletonOpsMut<'_, '_, TableStorage>>::insert::<D>(self, value, self.owner)
+        <&mut Self as SingletonOpsMut<'_, TableStorage>>::insert::<D>(self, value, self.owner)
     }
 
     /// Get mutable access to a value in the store.
@@ -199,14 +199,14 @@ impl<'a, TableStorage: schema::GeneratedStorage> Transaction<'a, TableStorage> {
         &mut self,
         f: impl FnOnce(&mut D::Value) -> T,
     ) -> Option<T> {
-        <&mut Self as SingletonOpsMut<'_, '_, TableStorage>>::with_mut::<D, T>(self, f, self.owner)
+        <&mut Self as SingletonOpsMut<'_, TableStorage>>::with_mut::<D, T>(self, f, self.owner)
     }
 
     /// Remove a single value from the store.
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn remove<D: schema::Singleton>(&mut self) -> Option<D::ArgValue> {
-        <&mut Self as SingletonOpsMut<'_, '_, TableStorage>>::remove::<D>(self, self.owner)
+        <&mut Self as SingletonOpsMut<'_, TableStorage>>::remove::<D>(self, self.owner)
     }
 
     /// Remove a single value from the store while preserving ownership of the key/value.
@@ -215,57 +215,81 @@ impl<'a, TableStorage: schema::GeneratedStorage> Transaction<'a, TableStorage> {
     ///
     /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn clear<D: schema::Singleton>(&mut self) -> Option<D::ArgValue> {
-        <&mut Self as SingletonOpsMut<'_, '_, TableStorage>>::clear::<D>(self, self.owner)
+        <&mut Self as SingletonOpsMut<'_, TableStorage>>::clear::<D>(self, self.owner)
     }
 }
 
 /// Abstracts a table of key/values pairs in the store accessed as part of a transaction.
 pub struct KvTableTransactional<
-    'a,
-    't,
-    TableStorage: schema::GeneratedStorage + 'a,
+    'guard: 'tx,
+    'tx,
+    TableStorage: schema::GeneratedStorage,
     D: schema::TableDesc<Storage = TableStorage>,
 > {
-    txn: &'t mut Transaction<'a, TableStorage>,
+    txn: &'tx mut Transaction<'guard, TableStorage>,
     table: PhantomData<D>,
 }
 
-impl<'a, 't, TableStorage: schema::GeneratedStorage + 'a, D: TableDesc<Storage = TableStorage>>
-    Ops<'a, TableStorage> for &'t KvTableTransactional<'a, 't, TableStorage, D>
+impl<
+    'store: 'guard,
+    'guard: 'tx,
+    'tx: 'table,
+    'table,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: TableDesc<Storage = TableStorage> + 'store,
+> Ops<'store, TableStorage> for &'table KvTableTransactional<'guard, 'tx, TableStorage, D>
 {
-    type ReadLock = RefWriteGuard<'t, 'a, Storage<TableStorage>>;
+    type ReadLock = RefWriteGuard<'table, 'guard, Storage<TableStorage>>;
 
     fn read_lock(self) -> Self::ReadLock {
         RefWriteGuard(&self.txn.guard)
     }
 }
 
-impl<'a, 't, 's, TableStorage: schema::GeneratedStorage + 'a, D: TableDesc<Storage = TableStorage>>
-    OpsMut<'a, TableStorage> for &'s mut KvTableTransactional<'a, 't, TableStorage, D>
+impl<
+    'store: 'guard,
+    'guard: 'tx,
+    'tx: 'table,
+    'table,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: TableDesc<Storage = TableStorage> + 'store,
+> OpsMut<'store, TableStorage> for &'table mut KvTableTransactional<'guard, 'tx, TableStorage, D>
 {
-    type WriteLock = RefWriteGuardMut<'s, 'a, Storage<TableStorage>>;
+    type WriteLock = RefWriteGuardMut<'table, 'guard, Storage<TableStorage>>;
 
     fn write_lock(self) -> Self::WriteLock {
         RefWriteGuardMut(&mut self.txn.guard)
     }
 }
 
-impl<'a, 't, TableStorage: schema::GeneratedStorage + 'a, D: TableDesc<Storage = TableStorage> + 'a>
-    TabularOps<'a, TableStorage, D> for &'t KvTableTransactional<'a, 't, TableStorage, D>
-{
-}
-
-impl<'a, 't, TableStorage: schema::GeneratedStorage + 'a, D: TableDesc<Storage = TableStorage>>
-    TabularOpsMut<'a, TableStorage, D> for &mut KvTableTransactional<'a, 't, TableStorage, D>
+impl<
+    'store: 'guard,
+    'guard: 'tx,
+    'tx,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: TableDesc<Storage = TableStorage> + 'store,
+> TabularOps<'store, TableStorage, D> for &KvTableTransactional<'guard, 'tx, TableStorage, D>
 {
 }
 
 impl<
-    'a,
-    't,
-    TableStorage: schema::GeneratedStorage,
-    D: schema::TableDesc<Storage = TableStorage> + 'a,
-> KvTableTransactional<'a, 't, TableStorage, D>
+    'store: 'guard,
+    'guard: 'tx,
+    'tx,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: TableDesc<Storage = TableStorage> + 'store,
+> TabularOpsMut<'store, TableStorage, D>
+    for &mut KvTableTransactional<'guard, 'tx, TableStorage, D>
+{
+}
+
+impl<
+    'store: 'guard,
+    'guard: 'tx,
+    'tx,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: TableDesc<Storage = TableStorage> + 'store,
+> KvTableTransactional<'guard, 'tx, TableStorage, D>
 {
     /// Initialize a table by setting its owner.
     ///
@@ -279,12 +303,12 @@ impl<
     }
 
     /// The number of key/value pairs in the table.
-    pub fn len(&'t self) -> usize {
+    pub fn len(&self) -> usize {
         <&Self as TabularOps<'_, TableStorage, D>>::len(self)
     }
 
     /// True if the table is empty.
-    pub fn is_empty(&'t self) -> bool {
+    pub fn is_empty(&self) -> bool {
         <&Self as TabularOps<'_, TableStorage, D>>::is_empty(self)
     }
 
@@ -296,7 +320,7 @@ impl<
     /// Get a row of the table from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<Q>(&'t self, key: &Q) -> Option<D::Value>
+    pub fn get<Q>(&self, key: &Q) -> Option<D::Value>
     where
         D::Value: Clone,
         D::Key: Borrow<Q>,
@@ -308,7 +332,7 @@ impl<
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&'t self, key: &Q, f: impl FnOnce(&D::Value) -> T) -> Option<T>
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&D::Value) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -349,45 +373,18 @@ impl<
     }
 
     /// Iterate all the key/value pairs in a table.
-    ///
-    /// Clones both keys and values and provides them by-value. To iterate without cloning, see
-    /// [`Self::for_each`].
-    pub fn iter_cloned(&'t self) -> impl Iterator<Item = (D::Key, D::Value)>
-    where
-        D::Key: Clone,
-        D::Value: Clone,
-    {
-        <&Self as TabularOps<'_, TableStorage, D>>::iter_cloned(self, self.txn.owner)
+    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &D::Value)> {
+        <&Self as TabularOps<'_, TableStorage, D>>::iter(self, self.txn.owner)
     }
 
     /// Iterate all the keys in a table.
-    ///
-    /// Clones the keys and provides them by-value. To iterate without cloning, see
-    /// [`Self::for_each`].
-    pub fn iter_keys_cloned(&'t self) -> impl Iterator<Item = D::Key>
-    where
-        D::Key: Clone,
-    {
-        <&Self as TabularOps<'_, TableStorage, D>>::iter_keys_cloned(self, self.txn.owner)
+    pub fn keys(&self) -> impl Iterator<Item = &D::Key> {
+        <&Self as TabularOps<'_, TableStorage, D>>::keys(self, self.txn.owner)
     }
 
     /// Iterate all the values in a table.
-    ///
-    /// Clones values and provides them by-value. To iterate without cloning, see
-    /// [`Self::for_each`].
-    pub fn iter_values_cloned(&'t self) -> impl Iterator<Item = D::Value>
-    where
-        D::Value: Clone,
-    {
-        <&Self as TabularOps<'_, TableStorage, D>>::iter_values_cloned(self, self.txn.owner)
-    }
-
-    /// Iterate all the key/value pairs in a table.
-    ///
-    /// We're not able to make this an iterator because we have to ensure that the references do
-    /// not outlive our lock on the store. For a (cloning) iterator see [`Self::iter_cloned`].
-    pub fn for_each(&'t self, f: impl FnMut(&D::Key, &D::Value)) {
-        <&Self as TabularOps<'_, TableStorage, D>>::for_each(self, f, self.txn.owner)
+    pub fn values(&self) -> impl Iterator<Item = &D::Value> {
+        <&Self as TabularOps<'_, TableStorage, D>>::values(self, self.txn.owner)
     }
 
     /// Iterate all the key/value pairs in a table. Values are mutable.
@@ -404,42 +401,55 @@ impl<
 /// as possible([`RoTransaction::commit`] can be used for this).
 ///
 /// A transaction must not be kept alive over an `await` point. This can lead to deadlock.
-pub struct RoTransaction<'a, TableStorage: schema::GeneratedStorage> {
-    pub(crate) guard: RwLockReadGuard<'a, Storage<TableStorage>>,
+pub struct RoTransaction<'guard, TableStorage: schema::GeneratedStorage> {
+    pub(crate) guard: RwLockReadGuard<'guard, Storage<TableStorage>>,
     pub(crate) owner: Owner,
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage + 'a> Ops<'a, TableStorage>
-    for &'a RoTransaction<'a, TableStorage>
+impl<'store: 'guard, 'guard: 'tx, 'tx, TableStorage: schema::GeneratedStorage + 'store>
+    Ops<'store, TableStorage> for &'tx RoTransaction<'guard, TableStorage>
 {
-    type ReadLock = RefReadGuard<'a, Storage<TableStorage>>;
+    type ReadLock = RefReadGuard<'tx, 'guard, Storage<TableStorage>>;
 
     fn read_lock(self) -> Self::ReadLock {
         RefReadGuard(&self.guard)
     }
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage + 'a> SingletonOps<'a, TableStorage>
-    for &'a RoTransaction<'a, TableStorage>
+impl<'store: 'guard, 'guard, TableStorage: schema::GeneratedStorage + 'store>
+    SingletonOps<'store, TableStorage> for &RoTransaction<'guard, TableStorage>
 {
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage + 'a, D: TableDesc<Storage = TableStorage>>
-    Ops<'a, TableStorage> for &KvTableRoTransactional<'a, TableStorage, D>
+impl<
+    'store: 'guard,
+    'guard: 'tx,
+    'tx: 'table,
+    'table,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: TableDesc<Storage = TableStorage>,
+> Ops<'store, TableStorage> for &'table KvTableRoTransactional<'guard, 'tx, TableStorage, D>
 {
-    type ReadLock = RefReadGuard<'a, Storage<TableStorage>>;
+    type ReadLock = RefReadGuard<'table, 'guard, Storage<TableStorage>>;
 
     fn read_lock(self) -> Self::ReadLock {
         RefReadGuard(&self.txn.guard)
     }
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage + 'a, D: TableDesc<Storage = TableStorage> + 'a>
-    TabularOps<'a, TableStorage, D> for &KvTableRoTransactional<'a, TableStorage, D>
+impl<
+    'store: 'guard,
+    'guard: 'tx,
+    'tx,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: TableDesc<Storage = TableStorage>,
+> TabularOps<'store, TableStorage, D> for &KvTableRoTransactional<'guard, 'tx, TableStorage, D>
 {
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage> RoTransaction<'a, TableStorage> {
+impl<'store: 'guard, 'guard, TableStorage: schema::GeneratedStorage + 'store>
+    RoTransaction<'guard, TableStorage>
+{
     /// Commit this transaction.
     ///
     /// This simply moves and drops the `RoTransaction` object. It is optional to call and currently
@@ -457,9 +467,9 @@ impl<'a, TableStorage: schema::GeneratedStorage> RoTransaction<'a, TableStorage>
     /// let txn = store.begin_ro_transaction(OWNER);
     /// let value = txn.table::<Foo>().get(key).unwrap();
     /// ```
-    pub fn table<D: schema::TableDesc<Storage = TableStorage>>(
-        &'a self,
-    ) -> KvTableRoTransactional<'a, TableStorage, D> {
+    pub fn table<'tx, D: schema::TableDesc<Storage = TableStorage>>(
+        &'tx self,
+    ) -> KvTableRoTransactional<'guard, 'tx, TableStorage, D> {
         KvTableRoTransactional {
             txn: self,
             table: PhantomData,
@@ -477,9 +487,9 @@ impl<'a, TableStorage: schema::GeneratedStorage> RoTransaction<'a, TableStorage>
     ///
     /// Here `Foo` describes a tables and `bar` describes an index over `Foo` using the `bar` field
     /// as foreign key.
-    pub fn table_by<D: schema::IndexDesc<Storage = TableStorage>>(
-        &'a self,
-    ) -> KvTableRoTransactionalIndex<'a, TableStorage, D, D::BaseTable> {
+    pub fn table_by<'tx, D: schema::IndexDesc<Storage = TableStorage>>(
+        &'tx self,
+    ) -> KvTableRoTransactionalIndex<'guard, 'tx, TableStorage, D, D::BaseTable> {
         KvTableRoTransactionalIndex {
             txn: self,
             index: PhantomData,
@@ -490,7 +500,7 @@ impl<'a, TableStorage: schema::GeneratedStorage> RoTransaction<'a, TableStorage>
     /// Get a single value from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<D: schema::Singleton>(&'a self) -> Option<D::Value>
+    pub fn get<D: schema::Singleton>(&self) -> Option<D::Value>
     where
         D::Value: Clone,
     {
@@ -500,45 +510,51 @@ impl<'a, TableStorage: schema::GeneratedStorage> RoTransaction<'a, TableStorage>
     /// Get a single value from the store by cloning an `Arc`.
     ///
     /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
-    pub fn get_arc<D: schema::ArcSingleton>(&'a self) -> Option<Arc<D::Value>> {
+    pub fn get_arc<D: schema::ArcSingleton>(&self) -> Option<Arc<D::Value>> {
         <&Self as SingletonOps<'_, TableStorage>>::get_arc::<D>(self, self.owner)
     }
 
     /// Get immutable access to a value in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<D: schema::Singleton, T>(&'a self, f: impl FnOnce(&D::Value) -> T) -> Option<T> {
+    pub fn with<D: schema::Singleton, T>(&self, f: impl FnOnce(&D::Value) -> T) -> Option<T> {
         <&Self as SingletonOps<'_, TableStorage>>::with::<D, T>(self, f, self.owner)
     }
 }
 
 /// Abstracts a table of key/values pairs in the store as part of a read-only transaction.
 pub struct KvTableRoTransactional<
-    'a,
+    'guard: 'tx,
+    'tx,
     TableStorage: schema::GeneratedStorage,
-    D: schema::TableDesc<Storage = TableStorage> + 'a,
+    D: schema::TableDesc<Storage = TableStorage>,
 > {
-    txn: &'a RoTransaction<'a, TableStorage>,
+    txn: &'tx RoTransaction<'guard, TableStorage>,
     table: PhantomData<D>,
 }
 
-impl<'a, TableStorage: schema::GeneratedStorage, D: schema::TableDesc<Storage = TableStorage> + 'a>
-    KvTableRoTransactional<'a, TableStorage, D>
+impl<
+    'store: 'guard,
+    'guard: 'tx,
+    'tx,
+    TableStorage: schema::GeneratedStorage + 'store,
+    D: schema::TableDesc<Storage = TableStorage>,
+> KvTableRoTransactional<'guard, 'tx, TableStorage, D>
 {
     /// The number of key/value pairs in the table.
-    pub fn len(&'a self) -> usize {
+    pub fn len(&self) -> usize {
         <&Self as TabularOps<'_, TableStorage, D>>::len(self)
     }
 
     /// True if the table is empty.
-    pub fn is_empty(&'a self) -> bool {
+    pub fn is_empty(&self) -> bool {
         <&Self as TabularOps<'_, TableStorage, D>>::is_empty(self)
     }
 
     /// Get a row of the table from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<Q>(&'a self, key: &Q) -> Option<D::Value>
+    pub fn get<Q>(&self, key: &Q) -> Option<D::Value>
     where
         D::Value: Clone,
         D::Key: Borrow<Q>,
@@ -550,7 +566,7 @@ impl<'a, TableStorage: schema::GeneratedStorage, D: schema::TableDesc<Storage = 
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&'a self, key: &Q, f: impl FnOnce(&D::Value) -> T) -> Option<T>
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&D::Value) -> T) -> Option<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -562,42 +578,33 @@ impl<'a, TableStorage: schema::GeneratedStorage, D: schema::TableDesc<Storage = 
     ///
     /// Clones both keys and values and provides them by-value. To iterate without cloning, see
     /// [`Self::for_each`].
-    pub fn iter_cloned(&'a self) -> impl Iterator<Item = (D::Key, D::Value)>
+    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &D::Value)>
     where
-        D::Key: Clone,
-        D::Value: Clone,
+        D: 'store,
     {
-        <&Self as TabularOps<'_, TableStorage, D>>::iter_cloned(self, self.txn.owner)
+        <&Self as TabularOps<'_, TableStorage, D>>::iter(self, self.txn.owner)
     }
 
     /// Iterate all the keys in a table.
     ///
     /// Clones the keys and provides them by-value. To iterate without cloning, see
     /// [`Self::for_each`].
-    pub fn iter_keys_cloned(&'a self) -> impl Iterator<Item = D::Key>
+    pub fn keys(&self) -> impl Iterator<Item = &D::Key>
     where
-        D::Key: Clone,
+        D: 'store,
     {
-        <&Self as TabularOps<'_, TableStorage, D>>::iter_keys_cloned(self, self.txn.owner)
+        <&Self as TabularOps<'_, TableStorage, D>>::keys(self, self.txn.owner)
     }
 
     /// Iterate all the values in a table.
     ///
     /// Clones values and provides them by-value. To iterate without cloning, see
     /// [`Self::for_each`].
-    pub fn iter_values_cloned(&'a self) -> impl Iterator<Item = D::Value>
+    pub fn values(&self) -> impl Iterator<Item = &D::Value>
     where
-        D::Value: Clone,
+        D: 'store,
     {
-        <&Self as TabularOps<'_, TableStorage, D>>::iter_values_cloned(self, self.txn.owner)
-    }
-
-    /// Iterate all the key/value pairs in a table.
-    ///
-    /// We're not able to make this an iterator because we have to ensure that the references do
-    /// not outlive our lock on the store. For a (cloning) iterator see [`Self::iter_cloned`].
-    pub fn for_each(&self, f: impl FnMut(&D::Key, &D::Value)) {
-        <&Self as TabularOps<'_, TableStorage, D>>::for_each(self, f, self.txn.owner)
+        <&Self as TabularOps<'_, TableStorage, D>>::values(self, self.txn.owner)
     }
 }
 
@@ -1056,7 +1063,7 @@ mod test {
         let store = KvStore::new();
         let mut txn = store.begin_transaction(OWNER);
         let table = txn.table::<Items>();
-        assert_eq!(table.iter_cloned().count(), 0);
+        assert_eq!(table.iter().count(), 0);
     }
 
     #[test]
@@ -1066,11 +1073,11 @@ mod test {
         let mut table = txn.table::<Items>();
         table.insert("a", "alpha".to_owned());
         table.insert("b", "beta".to_owned());
-        let mut items: Vec<_> = table.iter_cloned().collect();
+        let mut items: Vec<_> = table.iter().collect();
         items.sort();
         assert_eq!(
             items,
-            vec![("a", "alpha".to_owned()), ("b", "beta".to_owned())]
+            vec![(&"a", &"alpha".to_owned()), (&"b", &"beta".to_owned())]
         );
     }
 
@@ -1080,7 +1087,7 @@ mod test {
         let mut txn = store.begin_transaction(OWNER);
         let table = txn.table::<Items>();
         let mut count = 0;
-        table.for_each(|_, _| count += 1);
+        table.iter().for_each(|_| count += 1);
         assert_eq!(count, 0);
     }
 
@@ -1092,7 +1099,7 @@ mod test {
         table.insert("a", "alpha".to_owned());
         table.insert("b", "beta".to_owned());
         let mut items: Vec<_> = Vec::new();
-        table.for_each(|k, v| items.push((*k, v.clone())));
+        table.iter().for_each(|(k, v)| items.push((*k, v.clone())));
         items.sort();
         assert_eq!(
             items,
@@ -1125,7 +1132,7 @@ mod test {
         let store = KvStore::new();
         let mut txn = store.begin_transaction(OWNER);
         let table = txn.table::<Items>();
-        let keys: Vec<_> = table.iter_keys_cloned().collect();
+        let keys: Vec<_> = table.keys().collect();
         assert!(keys.is_empty());
     }
 
@@ -1136,7 +1143,7 @@ mod test {
         let mut table = txn.table::<Items>();
         table.insert("a", "alpha".to_owned());
         table.insert("b", "beta".to_owned());
-        let mut keys: Vec<_> = table.iter_keys_cloned().collect();
+        let mut keys: Vec<_> = table.keys().copied().collect();
         keys.sort();
         assert_eq!(keys, vec!["a", "b"]);
     }
@@ -1146,7 +1153,7 @@ mod test {
         let store = KvStore::new();
         let mut txn = store.begin_transaction(OWNER);
         let table = txn.table::<Items>();
-        let values: Vec<_> = table.iter_values_cloned().collect();
+        let values: Vec<_> = table.values().collect();
         assert!(values.is_empty());
     }
 
@@ -1157,9 +1164,9 @@ mod test {
         let mut table = txn.table::<Items>();
         table.insert("a", "alpha".to_owned());
         table.insert("b", "beta".to_owned());
-        let mut values: Vec<_> = table.iter_values_cloned().collect();
+        let mut values: Vec<_> = table.values().collect();
         values.sort();
-        assert_eq!(values, vec!["alpha".to_owned(), "beta".to_owned()]);
+        assert_eq!(values, vec!["alpha", "beta"]);
     }
 
     #[test]
@@ -1323,7 +1330,7 @@ mod test {
         let store = KvStore::new();
         let txn = store.begin_ro_transaction(OWNER);
         let table = txn.table::<Items>();
-        assert_eq!(table.iter_cloned().count(), 0);
+        assert_eq!(table.iter().count(), 0);
     }
 
     #[test]
@@ -1333,11 +1340,11 @@ mod test {
         store.table::<Items>(OWNER).insert("b", "beta".to_owned());
         let txn = store.begin_ro_transaction(OWNER);
         let table = txn.table::<Items>();
-        let mut items: Vec<_> = table.iter_cloned().collect();
+        let mut items: Vec<_> = table.iter().collect();
         items.sort();
         assert_eq!(
             items,
-            vec![("a", "alpha".to_owned()), ("b", "beta".to_owned())]
+            vec![(&"a", &"alpha".to_owned()), (&"b", &"beta".to_owned())]
         );
     }
 
@@ -1347,7 +1354,7 @@ mod test {
         let txn = store.begin_ro_transaction(OWNER);
         let table = txn.table::<Items>();
         let mut count = 0;
-        table.for_each(|_, _| count += 1);
+        table.iter().for_each(|_| count += 1);
         assert_eq!(count, 0);
     }
 
@@ -1359,7 +1366,7 @@ mod test {
         let txn = store.begin_ro_transaction(OWNER);
         let table = txn.table::<Items>();
         let mut items: Vec<_> = Vec::new();
-        table.for_each(|k, v| items.push((*k, v.clone())));
+        table.iter().for_each(|(k, v)| items.push((*k, v.clone())));
         items.sort();
         assert_eq!(
             items,
@@ -1372,7 +1379,7 @@ mod test {
         let store = KvStore::new();
         let txn = store.begin_ro_transaction(OWNER);
         let table = txn.table::<Items>();
-        let keys: Vec<_> = table.iter_keys_cloned().collect();
+        let keys: Vec<_> = table.keys().collect();
         assert!(keys.is_empty());
     }
 
@@ -1383,7 +1390,7 @@ mod test {
         store.table::<Items>(OWNER).insert("b", "beta".to_owned());
         let txn = store.begin_ro_transaction(OWNER);
         let table = txn.table::<Items>();
-        let mut keys: Vec<_> = table.iter_keys_cloned().collect();
+        let mut keys: Vec<_> = table.keys().copied().collect();
         keys.sort();
         assert_eq!(keys, vec!["a", "b"]);
     }
@@ -1393,7 +1400,7 @@ mod test {
         let store = KvStore::new();
         let txn = store.begin_ro_transaction(OWNER);
         let table = txn.table::<Items>();
-        let values: Vec<_> = table.iter_values_cloned().collect();
+        let values: Vec<_> = table.values().collect();
         assert!(values.is_empty());
     }
 
@@ -1404,8 +1411,8 @@ mod test {
         store.table::<Items>(OWNER).insert("b", "beta".to_owned());
         let txn = store.begin_ro_transaction(OWNER);
         let table = txn.table::<Items>();
-        let mut values: Vec<_> = table.iter_values_cloned().collect();
+        let mut values: Vec<_> = table.values().collect();
         values.sort();
-        assert_eq!(values, vec!["alpha".to_owned(), "beta".to_owned()]);
+        assert_eq!(values, vec!["alpha", "beta"]);
     }
 }


### PR DESCRIPTION
Stacked on #208

Nerd-sniped me on the iterator requiring `Clone` (first commit), but in the course of that, I thought that the API (mostly in `operations`) could be simpler if the traits used associated types more rather than type params (second commit).

The first commit does the `Clone` bound on the iterator by doing much more exhaustive lifetime accounting &mdash; it separately tracks the `'store`, `'guard`, `'tx`, and `'r` (ref-to-txn-or-guard) lifetimes and imposes a strict containment in that order everywhere. This is overkill &mdash; the second commit rolls it back because the API changes obviate the need &mdash; but that lets the inner iterator be held for a much more specific lifetime and avoids the need to `Clone`.

The second commit is an observation mainly that you can get the `Storage` (and index base table) from the `{Table,Index}Desc` rather than passing it through everywhere in parallel by adjusting how the associated types work a bit and writing a trait to wrap `Storage`. There's a bit of a sacrifice in verbosity in getting some ATs back out (a lot of `<Desc as TableDesc>::Key`), but this removes the need for the `'a` lifetime nearly everywhere and makes `schema::GeneratedStorage` mostly implicit. Most of this is just tracking that through and being more surgical with the lifetimes