### PR TITLE
README, ts_python/README: update dep version, package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add this dependency line to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tailscale = { version = "0.2" }
+tailscale = { version = "0.3" }
 ```
 
 Examples of using the `tailscale` crate can be found in [`examples/`](examples/README.md).

--- a/ts_python/README.md
+++ b/ts_python/README.md
@@ -8,9 +8,10 @@ have access to the tailnet.
 ## Code Sample
 
 ```python
+#!/usr/bin/env python3
+
 import asyncio
 import tailscale
-
 
 async def main():
     # connect to the tailnet:
@@ -40,10 +41,10 @@ $ TS_RS_EXPERIMENT=this_is_unstable_software python demo.py
 
 ## Building and Usage
 
-The easiest way to get the library is through pypi:
+The easiest way to get the library is through PyPI:
 
 ```shell
-$ pip install tailscale
+$ pip install tailscale-py
 ```
 
 ### In development


### PR DESCRIPTION
Updates the `tailscale` crate's version requirement to `0.3` in the README. Fixes the Python package name to `tailscale-py` in the `ts_python` README. Adds a hashbang to the example Python script for easy copy/paste.

Updates #cleanup.
