### PR TITLE
netmon: init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6183,6 +6183,7 @@ dependencies = [
  "ts_derp",
  "ts_keys",
  "ts_netcheck",
+ "ts_netmon",
  "ts_netstack_smoltcp",
  "ts_overlay_router",
  "ts_packet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,14 +2956,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-packet-route"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "netlink-sys"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
 dependencies = [
  "bytes",
+ "futures-util",
  "libc",
  "log",
+ "tokio",
 ]
 
 [[package]]
@@ -4158,6 +4186,24 @@ dependencies = [
  "sha2 0.11.0",
  "signature",
  "zeroize",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc19f84f710fa2f337617f9bc0400260a94224bde7bae28fd8879f3771ca5784"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route 0.30.0",
+ "netlink-proto",
+ "netlink-sys",
+ "nix 0.30.1",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -5950,6 +5996,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ts_netmon"
+version = "0.3.3"
+dependencies = [
+ "cfg-if",
+ "flume",
+ "futures-util",
+ "ipnet",
+ "nix 0.31.3",
+ "pin-project-lite",
+ "rtnetlink",
+ "smallvec",
+ "socket2",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "ts_cli_util",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "ts_netstack_smoltcp"
 version = "0.3.3"
 dependencies = [
@@ -6107,6 +6173,7 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tracing",
  "ts_bart",
  "ts_bart_packetfilter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "ts_keys",
     "ts_kv_store",
     "ts_netcheck",
+    "ts_netmon",
     "ts_netstack_smoltcp",
     "ts_netstack_smoltcp_core",
     "ts_netstack_smoltcp_socket",
@@ -124,6 +125,7 @@ ts_dynbitset = { path = "ts_dynbitset", version = "0.3.3" }
 ts_hexdump = { path = "ts_hexdump", version = "0.3.3" }
 ts_keys = { path = "ts_keys", version = "0.3.3" }
 ts_netcheck = { path = "ts_netcheck", version = "0.3.3" }
+ts_netmon = { path = "ts_netmon", version = "0.3.3" }
 ts_netstack_smoltcp = { path = "ts_netstack_smoltcp", version = "0.3.3" }
 ts_netstack_smoltcp_core = { path = "ts_netstack_smoltcp_core", version = "0.3.3" }
 ts_netstack_smoltcp_socket = { path = "ts_netstack_smoltcp_socket", version = "0.3.3" }

--- a/ts_netmon/Cargo.toml
+++ b/ts_netmon/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "ts_netmon"
+version.workspace = true
+description = "tailscale network interface monitor"
+categories = ["network-programming"]
+keywords = ["tailscale", "network", "monitor", "netmon"]
+
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+cfg-if.workspace = true
+flume.workspace = true
+futures-util.workspace = true
+ipnet.workspace = true
+pin-project-lite = "0.2"
+smallvec.workspace = true
+tokio.workspace = true
+tokio-stream = "0.1"
+tracing.workspace = true
+
+[dev-dependencies]
+ts_cli_util.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.62", features = [
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_NetworkManagement_Ndis",
+    "Win32_Networking_WinSock",
+] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+rtnetlink = "0.21"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+nix = "0.31"
+socket2 = "0.6"
+tokio = { workspace = true, features = ["net"] }
+
+[lints]
+workspace = true

--- a/ts_netmon/README.md
+++ b/ts_netmon/README.md
@@ -1,0 +1,4 @@
+# ts_netmon
+
+Platform-specific monitor implementations for network configuration events, such as the creation,
+modification, or removal of links, routes, and addresses.

--- a/ts_netmon/examples/monitor.rs
+++ b/ts_netmon/examples/monitor.rs
@@ -1,0 +1,24 @@
+//! Log all changes captured by netmon.
+
+use std::io;
+
+use tokio_stream::StreamExt;
+use ts_netmon::Netmon;
+
+#[tokio::main]
+async fn main() -> io::Result<()> {
+    ts_cli_util::init_tracing();
+
+    let mon = ts_netmon::platform_mon().ok_or(io::ErrorKind::Unsupported)?;
+    let stream = (&mon as &dyn Netmon).with_default_route_events()?;
+
+    let mut stream = core::pin::pin![stream];
+
+    while let Some(evt) = stream.next().await {
+        tracing::info!(evt = ?evt?);
+    }
+
+    tracing::warn!("stream ended");
+
+    Ok(())
+}

--- a/ts_netmon/examples/netlink_monitor.rs
+++ b/ts_netmon/examples/netlink_monitor.rs
@@ -1,0 +1,60 @@
+//! Monitor rtnetlink for debugging.
+
+#[cfg(target_os = "linux")]
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use std::net::IpAddr;
+
+    use futures_util::StreamExt;
+    use rtnetlink::{RouteMessageBuilder, packet_core::NetlinkPayload};
+
+    let (runner, handle, mut rx) =
+        rtnetlink::new_multicast_connection(ts_netmon::linux::NETLINK_GROUPS)?;
+
+    tokio::spawn(runner);
+
+    let mut link_stream = handle.link().get().execute();
+    while let Some(link) = link_stream.next().await {
+        eprintln!("{:#?}", link?);
+    }
+
+    let mut route_stream = handle
+        .route()
+        .get(RouteMessageBuilder::<IpAddr>::new().build())
+        .execute();
+
+    while let Some(route) = route_stream.next().await {
+        eprintln!("{:#?}", route?);
+    }
+
+    let mut ip_stream = handle.address().get().execute();
+    while let Some(address) = ip_stream.next().await {
+        eprintln!("{:#?}", address?);
+    }
+
+    eprintln!("\n\nstreaming:");
+
+    while let Some((msg, _)) = rx.next().await {
+        let msg = match msg.payload {
+            NetlinkPayload::InnerMessage(msg) => msg,
+            NetlinkPayload::Error(e) => return Err(e.to_io().into()),
+            NetlinkPayload::Done(done) => {
+                eprintln!("netlink stream done: {done:?}");
+                return Ok(());
+            }
+            unknown => {
+                eprintln!("unknown netlink payload: {unknown:?}");
+                continue;
+            }
+        };
+
+        eprintln!("{msg:#?}");
+    }
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("this example is a no-op on non-linux targets")
+}

--- a/ts_netmon/examples/win32_print_routes.rs
+++ b/ts_netmon/examples/win32_print_routes.rs
@@ -1,0 +1,41 @@
+//! Print routes gathered using iphlpapi.
+
+#[cfg(windows)]
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use std::time::Instant;
+
+    use ts_netmon::{FamilyOrBoth, Route, windows::RouteTable};
+
+    ts_cli_util::init_tracing();
+
+    let start = Instant::now();
+    let mut rt = RouteTable::get(FamilyOrBoth::Both)?;
+
+    const MEASURE_TIMING: bool = false;
+
+    for row in rt.iter_mut() {
+        ts_netmon::windows::populate_route(row)?;
+
+        let route = Route::from(&*row);
+
+        if MEASURE_TIMING {
+            core::hint::black_box(route);
+        } else {
+            tracing::info!(?route);
+        }
+    }
+    let elapsed = start.elapsed();
+
+    // On my machine each route costs about 70µs to load in release mode. The most expensive part of
+    // that (~45μs) is loading the route itself, getting the interface metric costs about 10μs, so
+    // I don't think it's worth caching.
+    tracing::info!(?elapsed, per_route = ?(elapsed / rt.len() as u32), "dumped routes");
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn main() {
+    eprintln!("this example is a no-op on non-windows targets")
+}

--- a/ts_netmon/examples/win32_raw_monitor.rs
+++ b/ts_netmon/examples/win32_raw_monitor.rs
@@ -1,0 +1,170 @@
+//! Print routes gathered using iphlpapi.
+//!
+//! Notable observations:
+//!
+//! - The Win32 layer (or the kernel) spins up worker threads to run the notification
+//!   callbacks; they do not execute on a user-controlled thread (like a Unix signal
+//!   handler would).
+//! - There appear not to be ordering guarantees between the notification streams.
+//!   I have seen a route deletion come after a link deletion.
+
+#[cfg(windows)]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use core::{ffi, ptr::null};
+
+    use ts_netmon::{
+        FamilyOrBoth, Route,
+        windows::{InterfaceReport, unicast_row_to_ipnet},
+    };
+    use windows::Win32::{
+        Foundation::HANDLE,
+        NetworkManagement::{IpHelper, Ndis},
+        Networking::WinSock,
+    };
+
+    fn thread_id() -> std::thread::ThreadId {
+        std::thread::current().id()
+    }
+
+    ts_cli_util::init_tracing();
+
+    fn tyname(ty: IpHelper::MIB_NOTIFICATION_TYPE) -> String {
+        match ty {
+            IpHelper::MibAddInstance => "ADD".to_owned(),
+            IpHelper::MibDeleteInstance => "DEL".to_owned(),
+            IpHelper::MibParameterNotification => "UPD".to_owned(),
+            ty => ty.0.to_string(),
+        }
+    }
+
+    unsafe extern "system" fn route_cb(
+        _ctx: *const ffi::c_void,
+        row: *const IpHelper::MIB_IPFORWARD_ROW2,
+        ty: IpHelper::MIB_NOTIFICATION_TYPE,
+    ) {
+        let mut row = unsafe { *row };
+
+        if ty != IpHelper::MibDeleteInstance {
+            ts_netmon::windows::populate_route(&mut row).unwrap();
+        }
+
+        let route = Route::from(row);
+        let gw = match route.gateway.as_slice() {
+            &[] => "ON-LINK".to_string(),
+            &[gw] => {
+                format!("VIA {gw}")
+            }
+            gws => {
+                format!("VIA {gws:?}")
+            }
+        };
+
+        eprintln!(
+            "[{:2?}] {} ROUT {} {:32} {gw}",
+            thread_id(),
+            row.InterfaceIndex,
+            tyname(ty),
+            format!("{}", route.dst)
+        );
+    }
+
+    let mut route_notif: HANDLE = HANDLE::default();
+    unsafe {
+        IpHelper::NotifyRouteChange2(
+            WinSock::AF_UNSPEC,
+            Some(route_cb),
+            null(),
+            false,
+            &mut route_notif,
+        )
+        .ok()?
+    };
+
+    unsafe extern "system" fn addr_cb(
+        _ctx: *const ffi::c_void,
+        row: *const IpHelper::MIB_UNICASTIPADDRESS_ROW,
+        ty: IpHelper::MIB_NOTIFICATION_TYPE,
+    ) {
+        let mut row = unsafe { *row };
+
+        if ty != IpHelper::MibDeleteInstance {
+            let _ = unsafe { IpHelper::GetUnicastIpAddressEntry(&mut row) };
+        }
+
+        eprintln!(
+            "[{:2?}] {} ADDR {} {}",
+            thread_id(),
+            row.InterfaceIndex,
+            tyname(ty),
+            unicast_row_to_ipnet(&row)
+        );
+    }
+
+    let mut addr_notif: HANDLE = HANDLE::default();
+    unsafe {
+        IpHelper::NotifyUnicastIpAddressChange(
+            WinSock::AF_UNSPEC,
+            Some(addr_cb),
+            None,
+            false,
+            &mut addr_notif,
+        )
+        .ok()?
+    };
+
+    fn fmt_oper_status(status: Ndis::IF_OPER_STATUS) -> &'static str {
+        match status {
+            Ndis::IfOperStatusUp => " UP ",
+            Ndis::IfOperStatusDown => "DOWN",
+            Ndis::IfOperStatusLowerLayerDown => "LLDN",
+            Ndis::IfOperStatusDormant => "DORM",
+            _ => "UNKN",
+        }
+    }
+
+    unsafe extern "system" fn interface_cb(
+        _ctx: *const ffi::c_void,
+        row: *const IpHelper::MIB_IPINTERFACE_ROW,
+        ty: IpHelper::MIB_NOTIFICATION_TYPE,
+    ) {
+        let row = unsafe { row.as_ref() }.unwrap();
+
+        let rpt = InterfaceReport::get(row.Family.try_into().unwrap()).unwrap();
+        let interface = rpt
+            .iter()
+            .find(|x| unsafe { x.Luid.Value == row.InterfaceLuid.Value })
+            .unwrap();
+
+        eprintln!(
+            "[{:2?}] {} LINK {} {} ({:?})",
+            thread_id(),
+            row.InterfaceIndex,
+            tyname(ty),
+            fmt_oper_status(interface.OperStatus),
+            FamilyOrBoth::try_from(row.Family).unwrap()
+        );
+    }
+
+    let mut interface_notif: HANDLE = HANDLE::default();
+    unsafe {
+        IpHelper::NotifyIpInterfaceChange(
+            WinSock::AF_UNSPEC,
+            Some(interface_cb),
+            None,
+            false,
+            &mut interface_notif,
+        )
+        .ok()?
+    };
+
+    tracing::info!(thread_id = ?thread_id(), "notifications registered");
+
+    loop {
+        std::thread::park();
+    }
+}
+
+#[cfg(not(windows))]
+fn main() {
+    eprintln!("this example is a no-op on non-windows targets")
+}

--- a/ts_netmon/src/darwin/mod.rs
+++ b/ts_netmon/src/darwin/mod.rs
@@ -1,0 +1,25 @@
+//! macOS network monitor implementation.
+
+use nix::libc::AF_ROUTE;
+use socket2::{Domain, Type};
+use tokio::io::unix::AsyncFd;
+
+use crate::{BoxStream, Event, MonType, Netmon};
+
+/// Canonical platform [`Netmon`] for macos based on `AF_ROUTE` sockets.
+pub struct AfRouteMon;
+
+impl Netmon for AfRouteMon {
+    fn ty(&self) -> MonType {
+        MonType::AF_ROUTE
+    }
+
+    fn event_stream(&self) -> std::io::Result<BoxStream<std::io::Result<Event>>> {
+        let sock = socket2::Socket::new(Domain::from(AF_ROUTE), Type::RAW, None)?;
+        sock.set_nonblocking(true)?;
+
+        let _fd = AsyncFd::new(sock)?;
+
+        todo!("macos netmon is currently a placeholder")
+    }
+}

--- a/ts_netmon/src/family.rs
+++ b/ts_netmon/src/family.rs
@@ -1,0 +1,45 @@
+use core::fmt::{Debug, Formatter};
+
+/// Specification of IPv4 or IPv6 or both.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum FamilyOrBoth {
+    /// Both address families; `AF_UNSPEC`.
+    Both,
+    /// A single address family.
+    Single(Family),
+}
+
+impl Debug for FamilyOrBoth {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FamilyOrBoth::Both => write!(f, "Both"),
+            FamilyOrBoth::Single(family) => family.fmt(f),
+        }
+    }
+}
+
+impl From<Family> for FamilyOrBoth {
+    fn from(family: Family) -> Self {
+        FamilyOrBoth::Single(family)
+    }
+}
+
+/// Specification of either IPv4 or IPv6.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Family {
+    /// The IPv4 address family.
+    Ipv4,
+    /// The IPv6 address family.
+    Ipv6,
+}
+
+impl TryFrom<FamilyOrBoth> for Family {
+    type Error = ();
+
+    fn try_from(value: FamilyOrBoth) -> Result<Self, Self::Error> {
+        match value {
+            FamilyOrBoth::Both => Err(()),
+            FamilyOrBoth::Single(family) => Ok(family),
+        }
+    }
+}

--- a/ts_netmon/src/id.rs
+++ b/ts_netmon/src/id.rs
@@ -1,0 +1,133 @@
+use core::{
+    fmt::{Debug, Display, Formatter},
+    hash::Hash,
+    str::FromStr,
+};
+use std::borrow::Cow;
+
+/// The unique id of a [`Netmon`][crate::Netmon].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MonType(Cow<'static, str>);
+
+impl Display for MonType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        Display::fmt(self.0.as_ref(), f)
+    }
+}
+
+impl MonType {
+    /// [`MonType`] for the canonical Windows-platform network monitor, built around
+    /// Win32's
+    /// [`<iphlpapi.h>`](https://learn.microsoft.com/en-us/windows/win32/api/_iphlp/).
+    ///
+    /// [`InterfaceId`]s with this type are NET_LUIDs.
+    pub const WINDOWS_IPHLPAPI: Self = Self::new_static("win32_iphlpapi");
+
+    /// [`MonType`] for the canonical Linux-platform network monitor, built around
+    /// [`rtnetlink`](https://www.man7.org/linux/man-pages/man7/rtnetlink.7.html).
+    ///
+    /// [`InterfaceId`]s with this type are interface indices.
+    pub const RTNETLINK: Self = Self::new_static("rtnetlink");
+
+    /// [`MonType`] for the canonical macOS-platform network monitor, built around messages
+    /// sent through `AF_ROUTE` sockets.
+    ///
+    /// [`InterfaceId`]s with this type are interface indices.
+    pub const AF_ROUTE: Self = Self::new_static("af_route");
+
+    /// Convenience helper to construct a new mon type from a `&'static str`.
+    ///
+    /// # Panics
+    ///
+    /// If `ty` is not ascii or `ty` contains ':'.
+    pub const fn new_static(ty: &'static str) -> Self {
+        Self::new(Cow::Borrowed(ty))
+    }
+
+    /// Construct a new mon type.
+    ///
+    /// # Panics
+    ///
+    /// If `ty` is not ascii or `ty` contains ':'.
+    pub const fn new(ty: Cow<'static, str>) -> Self {
+        let s = match &ty {
+            Cow::Borrowed(s) => *s,
+            Cow::Owned(s) => s.as_str(),
+        };
+
+        if !s.is_ascii() {
+            panic!("id types must be ascii")
+        }
+
+        let t = s.as_bytes();
+
+        let mut i = 0;
+        while i < t.len() {
+            if t[i] == b':' {
+                panic!("id type may not contain ':'");
+            }
+
+            i += 1;
+        }
+
+        Self(ty)
+    }
+}
+
+impl AsRef<str> for MonType {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+/// A network interface id.
+///
+/// The meaning is specific to the particular netmon implementation, which can be
+/// identified from [`InterfaceId::ty`].
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct InterfaceId {
+    ty: MonType,
+    value: u64,
+}
+
+impl InterfaceId {
+    /// Construct a new network interface id.
+    pub const fn new(ty: MonType, value: u64) -> Self {
+        InterfaceId { ty, value }
+    }
+
+    /// Get the [`MonType`] of this id.
+    pub const fn ty(&self) -> &MonType {
+        &self.ty
+    }
+
+    /// Get the value contained in this id (the actual interface id).
+    pub const fn value(&self) -> u64 {
+        self.value
+    }
+}
+
+impl Debug for InterfaceId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "InterfaceId({})", self)
+    }
+}
+
+impl Display for InterfaceId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.ty, self.value)
+    }
+}
+
+impl FromStr for InterfaceId {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (ty, value) = s.split_once(':').ok_or(())?;
+
+        Ok(InterfaceId::new(
+            MonType::new(ty.to_owned().into()),
+            value.parse().map_err(|_| ())?,
+        ))
+    }
+}

--- a/ts_netmon/src/lib.rs
+++ b/ts_netmon/src/lib.rs
@@ -1,0 +1,110 @@
+#![doc = include_str!("../README.md")]
+
+use std::net::IpAddr;
+
+#[cfg(target_os = "macos")]
+pub mod darwin;
+mod family;
+mod id;
+#[cfg(target_os = "linux")]
+pub mod linux;
+mod netmon;
+#[cfg(windows)]
+pub mod windows;
+
+pub use family::{Family, FamilyOrBoth};
+pub use id::{InterfaceId, MonType};
+pub use netmon::{BoxStream, Netmon, PlatformMon, platform_mon};
+
+/// An event produced by the network monitor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Event {
+    /// The given address on the given interface has been added or modified.
+    ///
+    /// Modification is possible when the [`Netmon`] impl has [`Netmon::interface_unique_addrs`].
+    AddrUpsert(InterfaceId, ipnet::IpNet),
+    /// The given address has been removed from the given interface.
+    AddrRemoved(InterfaceId, ipnet::IpNet),
+
+    /// This network interface has been added or modified.
+    InterfaceUpsert(Interface),
+
+    /// The network interface with the given id has been removed.
+    InterfaceRemoved(InterfaceId),
+
+    /// This route has been added to or modified on the given interface.
+    RouteUpsert(InterfaceId, Route),
+
+    /// This route has been removed from the given interface.
+    RouteRemoved(InterfaceId, Route),
+
+    /// A new default route interface has been selected, or there is no default route
+    /// interface anymore.
+    DefaultRouteInterface(Option<InterfaceId>, Family),
+}
+
+/// Details about a network interface.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Interface {
+    /// The id of the interface.
+    pub id: InterfaceId,
+
+    /// Whether the interface is up and accepting traffic.
+    pub up: bool,
+
+    /// The name of the interface.
+    pub name: String,
+
+    /// The MTU of the interface.
+    pub mtu: Option<usize>,
+
+    /// The interface's hardware address (if set).
+    pub hardware_addr: Option<smallvec::SmallVec<[u8; 6]>>,
+}
+
+/// The unique/identifying part of a [`Route`] (excludes the metric field).
+pub type RouteUnique = (ipnet::IpNet, smallvec::SmallVec<[IpAddr; 1]>);
+
+/// A route definition.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Route {
+    /// The destination subnet specified by the route.
+    pub dst: ipnet::IpNet,
+    /// The gateways (next-hops) to use for this route in descending order of preference.
+    ///
+    /// Currently, this field is only ever populated by zero (implying the route is
+    /// on-link) or one addresses, but multipath implies that there could be any number of
+    /// gateways for a given route.
+    pub gateway: smallvec::SmallVec<[IpAddr; 1]>,
+    /// The metric for this route. Lower is higher-preference.
+    pub metric: usize,
+}
+
+impl Route {
+    /// Report whether this is a default route.
+    ///
+    /// Default routes have a zero prefix length on their destination (handle all addresses)
+    /// and must have a gateway (i.e. the destination prefix is not on-link).
+    pub fn is_default_route(&self) -> bool {
+        self.dst.prefix_len() == 0 && !self.gateway.is_empty()
+    }
+
+    /// Report the address family to which this route pertains.
+    pub fn family(&self) -> Family {
+        if self.dst.addr().is_ipv4() {
+            Family::Ipv4
+        } else {
+            Family::Ipv6
+        }
+    }
+
+    /// The unique identifying tuple of this [`Route`].
+    pub fn unique(&self) -> RouteUnique {
+        (self.dst, self.gateway.clone())
+    }
+
+    /// A reference to the fields of the unique identifying tuple of this [`Route`].
+    pub const fn unique_ref(&self) -> (&ipnet::IpNet, &smallvec::SmallVec<[IpAddr; 1]>) {
+        (&self.dst, &self.gateway)
+    }
+}

--- a/ts_netmon/src/linux/mod.rs
+++ b/ts_netmon/src/linux/mod.rs
@@ -1,0 +1,295 @@
+//! Linux network monitor implementation.
+
+use std::{io, net::IpAddr};
+
+use futures_util::{Stream, StreamExt, TryStreamExt};
+use rtnetlink::{
+    Handle, MulticastGroup, RouteMessageBuilder,
+    packet_core::NetlinkPayload,
+    packet_route::{
+        AddressFamily, RouteNetlinkMessage,
+        address::{AddressAttribute, AddressMessage},
+        link::{LinkAttribute, LinkFlags, LinkLayerType, LinkMessage},
+        route::{RouteAddress, RouteAttribute, RouteMessage, RouteType},
+    },
+};
+use tokio::task::JoinSet;
+
+use crate::{BoxStream, Event, Interface, InterfaceId, MonType, Netmon, Route};
+
+/// Linux-platform [`Netmon`] implementation based on rtnetlink.
+pub struct RtNetlinkMon;
+
+impl Netmon for RtNetlinkMon {
+    fn ty(&self) -> MonType {
+        MonType::RTNETLINK
+    }
+
+    fn event_stream(&self) -> io::Result<BoxStream<io::Result<Event>>> {
+        Ok(stream()?.boxed())
+    }
+}
+
+/// Multicast groups subscribed to on rtnetlink.
+///
+/// Reused in some of the examples but not part of the API, so hidden.
+#[doc(hidden)]
+pub const NETLINK_GROUPS: &[MulticastGroup] = &[
+    MulticastGroup::Link,
+    MulticastGroup::Ipv4Route,
+    MulticastGroup::Ipv6Route,
+    MulticastGroup::Ipv4Ifaddr,
+    MulticastGroup::Ipv6Ifaddr,
+];
+
+fn interface_id(idx: u32) -> InterfaceId {
+    InterfaceId::new(MonType::RTNETLINK, idx as _)
+}
+
+fn link_state(handle: Handle) -> impl Stream<Item = Result<Event, rtnetlink::Error>> {
+    handle
+        .link()
+        .get()
+        .execute()
+        .try_filter_map(async |link| Ok(link_event(link)))
+}
+
+fn addr_state(handle: Handle) -> impl Stream<Item = Result<Event, rtnetlink::Error>> {
+    handle
+        .address()
+        .get()
+        .execute()
+        .try_filter_map(async |addr| Ok(addr_added_event(addr)))
+}
+
+fn route_state(handle: Handle) -> impl Stream<Item = Result<Event, rtnetlink::Error>> {
+    handle
+        .route()
+        .get(RouteMessageBuilder::<IpAddr>::new().build())
+        .execute()
+        .try_filter_map(async |route| Ok(route_added_event(route)))
+}
+
+fn init_state(handle: Handle) -> impl Stream<Item = io::Result<Event>> {
+    use tokio_stream::StreamExt;
+
+    link_state(handle.clone())
+        .merge(addr_state(handle.clone()))
+        .merge(route_state(handle))
+        .map_err(io::Error::other)
+}
+
+fn stream() -> io::Result<impl Stream<Item = io::Result<Event>>> {
+    let (conn, handle, msgs) = rtnetlink::new_multicast_connection(NETLINK_GROUPS)?;
+
+    let mut joinset = JoinSet::new();
+    joinset.spawn(conn);
+
+    let update_stream = msgs
+        .filter_map(async |(msg, _sa)| match msg.payload {
+            NetlinkPayload::InnerMessage(msg) => Some(Ok(msg)),
+            NetlinkPayload::Error(msg) => Some(Err(msg.to_io())),
+            _ => None,
+        })
+        .try_filter_map(async |msg| {
+            let ret = match msg {
+                RouteNetlinkMessage::NewRoute(rt) => route_added_event(rt),
+                RouteNetlinkMessage::DelRoute(rt) => route_removed_event(rt),
+                RouteNetlinkMessage::NewAddress(addr) => addr_added_event(addr),
+                RouteNetlinkMessage::DelAddress(addr) => addr_removed_event(addr),
+                RouteNetlinkMessage::NewLink(link) => link_event(link),
+                RouteNetlinkMessage::DelLink(link) => {
+                    Some(Event::InterfaceRemoved(interface_id(link.header.index)))
+                }
+
+                msg => {
+                    tracing::warn!(?msg, "unhandled netlink message");
+                    None
+                }
+            };
+
+            Ok(ret)
+        })
+        // hacky way to move the joinset running the netlink `conn` into the stream so it isn't
+        // dropped until the stream is (which would kill the runner -> stall the stream).
+        .scan(
+            joinset,
+            #[allow(closure_returning_async_block)]
+            |_, x| async move { Some(x) },
+        );
+
+    Ok(init_state(handle).chain(update_stream))
+}
+
+fn link_event(link: LinkMessage) -> Option<Event> {
+    let iface = load_interface(link)?;
+    Some(Event::InterfaceUpsert(iface))
+}
+
+fn addr_added_event(addr: AddressMessage) -> Option<Event> {
+    let ip = addr_msg(&addr)?;
+
+    Some(Event::AddrUpsert(interface_id(addr.header.index), ip))
+}
+
+fn addr_removed_event(addr: AddressMessage) -> Option<Event> {
+    let ip = addr_msg(&addr)?;
+    Some(Event::AddrRemoved(interface_id(addr.header.index), ip))
+}
+
+fn route_added_event(route: RouteMessage) -> Option<Event> {
+    let (interface, route) = route_msg(&route)?;
+    Some(Event::RouteUpsert(interface, route))
+}
+
+fn route_removed_event(route: RouteMessage) -> Option<Event> {
+    let (interface, route) = route_msg(&route)?;
+    Some(Event::RouteRemoved(interface, route))
+}
+
+#[tracing::instrument(skip_all, fields(id = link.header.index))]
+fn load_interface(link: LinkMessage) -> Option<Interface> {
+    let mut name = None;
+    let mut mtu = None;
+    let mut hardware_addr = None;
+
+    for attr in link.attributes {
+        match attr {
+            LinkAttribute::IfName(new_name) => {
+                name = Some(new_name);
+            }
+            LinkAttribute::Address(addr) => {
+                if link.header.link_layer_type != LinkLayerType::Ether {
+                    continue;
+                }
+
+                match addr.len() {
+                    // MAC
+                    6 => {
+                        hardware_addr = Some(smallvec::SmallVec::from(addr));
+                    }
+                    _ => {
+                        tracing::warn!(?addr, link_type = ?link.header.link_layer_type, "unknown link address type");
+                        continue;
+                    }
+                }
+            }
+            LinkAttribute::Mtu(new_mtu) => {
+                mtu = Some(new_mtu as usize);
+            }
+            _ => {}
+        }
+    }
+
+    Some(Interface {
+        up: link.header.flags.contains(LinkFlags::Up),
+        id: interface_id(link.header.index),
+        name: name?,
+        mtu,
+        hardware_addr,
+    })
+}
+
+fn addr_msg(msg: &AddressMessage) -> Option<ipnet::IpNet> {
+    for attr in &msg.attributes {
+        if let AddressAttribute::Address(ip) = attr {
+            return Some(ipnet::IpNet::new(*ip, msg.header.prefix_len).unwrap());
+        }
+    }
+
+    None
+}
+
+fn route_msg(rt: &RouteMessage) -> Option<(InterfaceId, Route)> {
+    let mut gateway = smallvec::smallvec![];
+    // Lack of a destination attr with pfx len 0 means the destination should be treated as
+    // unspecified.
+    let mut dst = match rt.header.address_family {
+        AddressFamily::Inet if rt.header.destination_prefix_length == 0 => {
+            Some(ipnet::Ipv4Net::default().into())
+        }
+        AddressFamily::Inet6 if rt.header.destination_prefix_length == 0 => {
+            Some(ipnet::Ipv6Net::default().into())
+        }
+        _ => None,
+    };
+    let mut metric = 0;
+    let mut interface = None;
+
+    // Only allow unicast routes
+    match rt.header.kind {
+        RouteType::Unicast | RouteType::Local => {}
+
+        // TODO(npry): handling for negative routes? multiple tables?
+        RouteType::Unreachable
+        | RouteType::Prohibit
+        | RouteType::BlackHole
+        | RouteType::Throw
+        | RouteType::Unspec => {
+            return None;
+        }
+
+        _ => {
+            return None;
+        }
+    }
+
+    for attr in &rt.attributes {
+        match attr {
+            RouteAttribute::Destination(addr) => {
+                dst = routeaddr_pfx(addr, rt.header.destination_prefix_length);
+            }
+            RouteAttribute::Gateway(addr) => {
+                if let Some(addr) = routeaddr_ip(addr) {
+                    gateway.push(addr);
+                }
+            }
+            &RouteAttribute::Oif(idx) => {
+                interface = Some(interface_id(idx));
+            }
+            &RouteAttribute::Priority(prio) => {
+                metric = prio as _;
+            }
+
+            // TODO(npry): complicated routing scenarios -- multipath, src interface, off-AF
+            // gateway, etc.
+            RouteAttribute::MultiPath(next_hops) => {
+                tracing::warn!(?next_hops, "route has multiple next-hops");
+            }
+            RouteAttribute::Iif(idx) => {
+                tracing::warn!(input_idx = idx, "route has input interface specified");
+            }
+            RouteAttribute::Via(via) => {
+                tracing::warn!(
+                    ?via,
+                    "route has `via` attribute (gateway in different AF), skipping"
+                );
+                return None;
+            }
+            _ => {}
+        }
+    }
+
+    let route = Route {
+        dst: dst?,
+        metric,
+        gateway,
+    };
+
+    Some((interface?, route))
+}
+
+fn routeaddr_ip(addr: &RouteAddress) -> Option<IpAddr> {
+    let ip = match addr {
+        RouteAddress::Inet(ip) => (*ip).into(),
+        RouteAddress::Inet6(ip) => (*ip).into(),
+        _ => return None,
+    };
+
+    Some(ip)
+}
+
+fn routeaddr_pfx(addr: &RouteAddress, pfx_len: u8) -> Option<ipnet::IpNet> {
+    let ip = routeaddr_ip(addr)?;
+    ipnet::IpNet::new(ip, pfx_len).ok()
+}

--- a/ts_netmon/src/netmon.rs
+++ b/ts_netmon/src/netmon.rs
@@ -1,0 +1,366 @@
+use core::{net::IpAddr, pin::Pin};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+use futures_util::{Stream, StreamExt, stream};
+
+#[cfg(target_os = "macos")]
+pub use crate::darwin::AfRouteMon as PlatformMon;
+#[cfg(target_os = "linux")]
+pub use crate::linux::RtNetlinkMon as PlatformMon;
+#[cfg(windows)]
+pub use crate::windows::Winmon as PlatformMon;
+use crate::{Event, Family, InterfaceId, Route, id::MonType};
+
+/// A [`Pin`]-[`Box`]ed [`Send`] [`Stream`] with items of type `T`.
+pub type BoxStream<T> = Pin<Box<dyn Stream<Item = T> + Send + 'static>>;
+
+/// Get the platform [`Netmon`] implementation if there is one.
+pub const fn platform_mon() -> Option<impl Netmon + 'static> {
+    cfg_if::cfg_if! {
+        if #[cfg(any(windows, target_os = "linux"))] {
+            Some(&PlatformMon)
+        } else {
+            struct NoopMon;
+
+            impl Netmon for NoopMon {
+                fn ty(&self) -> MonType {
+                    unimplemented!()
+                }
+
+                fn event_stream(&self) -> std::io::Result<BoxStream<std::io::Result<Event>>> {
+                    unimplemented!()
+                }
+            }
+
+            Option::<NoopMon>::None
+        }
+    }
+}
+
+/// A network monitor that tracks [`Event`]s related to platform
+/// [`Interface`][crate::Interface]s.
+pub trait Netmon: Send + Sync {
+    /// Get the [`MonType`] of this [`Netmon`].
+    ///
+    /// The return value of this function should never change.
+    fn ty(&self) -> MonType;
+
+    /// Start monitoring for network [`Event`]s.
+    ///
+    /// Generally, implementors don't need to generate [`Event::DefaultRouteInterface`],
+    /// since this can be provided by [`dyn Netmon::with_default_route_events`], which
+    /// generic callers should prefer.
+    ///
+    /// [`dyn Netmon::with_default_route_events`]: trait.Netmon.html#method.with_default_route_events
+    fn event_stream(&self) -> std::io::Result<BoxStream<std::io::Result<Event>>>;
+
+    /// Report whether the event stream is strongly consistent with respect to delete
+    /// ordering.
+    ///
+    /// If `true`, callers should interpret an interface deletion event as an immediate
+    /// deletion of all resources related to the interface. Individual deletion events for
+    /// those resources may or may not be issued.
+    ///
+    /// If `false`, callers should assume that individual deletion events will be issued
+    /// for all resources on interface deletion, but they have no ordering guarantees wrt.
+    /// the interface deletion event.
+    ///
+    /// The return value of this function should never change.
+    fn strong_delete_consistency(&self) -> bool {
+        true
+    }
+
+    /// Report whether addresses are unique per interface independent of netmask.
+    ///
+    /// Some netmon implementations (notably Windows) treat the address as unique
+    /// per interface and permit in-place updates of the netmask.
+    ///
+    /// The return value of this function should never change.
+    fn interface_unique_addrs(&self) -> bool {
+        false
+    }
+}
+
+impl<T> Netmon for &T
+where
+    T: Netmon + ?Sized,
+{
+    fn ty(&self) -> MonType {
+        T::ty(self)
+    }
+
+    fn event_stream(&self) -> std::io::Result<BoxStream<std::io::Result<Event>>> {
+        T::event_stream(self)
+    }
+
+    fn strong_delete_consistency(&self) -> bool {
+        T::strong_delete_consistency(self)
+    }
+
+    fn interface_unique_addrs(&self) -> bool {
+        T::interface_unique_addrs(self)
+    }
+}
+
+impl dyn Netmon {
+    /// Wrap [`Netmon::event_stream`] with automatically calculated
+    /// [`Event::DefaultRouteInterface`].
+    ///
+    /// Suppresses any such events from the inner stream.
+    pub fn with_default_route_events(
+        &self,
+    ) -> std::io::Result<impl Stream<Item = std::io::Result<Event>> + Send + use<>> {
+        let strong_delete_consistency = self.strong_delete_consistency();
+
+        let s = self
+            .event_stream()?
+            .filter(|x| {
+                let result = !x
+                    .as_ref()
+                    .is_ok_and(|x| matches!(x, Event::DefaultRouteInterface(..)));
+
+                async move { result }
+            })
+            .scan(
+                (
+                    DefaultRouteState::new(Family::Ipv4),
+                    DefaultRouteState::new(Family::Ipv6),
+                ),
+                move |(state_v4, state_v6), x| {
+                    let [e1, e2] = match &x {
+                        Ok(Event::RouteUpsert(interface, route)) => [
+                            state_v4.add_route(interface, route),
+                            state_v6.add_route(interface, route),
+                        ],
+                        Ok(Event::RouteRemoved(interface, route)) => [
+                            state_v4.remove_route(interface, route),
+                            state_v6.remove_route(interface, route),
+                        ],
+                        Ok(Event::InterfaceUpsert(interface)) => [
+                            state_v4.update_interface_state(&interface.id, interface.up),
+                            state_v6.update_interface_state(&interface.id, interface.up),
+                        ],
+                        Ok(Event::InterfaceRemoved(i)) => {
+                            if strong_delete_consistency {
+                                let e1 = state_v4.remove_interface(i);
+                                let e2 = state_v6.remove_interface(i);
+
+                                [e1, e2]
+                            } else {
+                                // just wait for the route events
+                                [None, None]
+                            }
+                        }
+                        _ => [None, None],
+                    };
+
+                    async move {
+                        Some(
+                            stream::once(async move { x })
+                                .chain(stream::iter(e1).map(Ok))
+                                .chain(stream::iter(e2).map(Ok)),
+                        )
+                    }
+                },
+            )
+            .flatten();
+
+        Ok(s)
+    }
+}
+
+/// The unique part of a default route: the interface and the set of gateways.
+type DefaultRouteUnique = (InterfaceId, smallvec::SmallVec<[IpAddr; 1]>);
+
+/// Tracker for [`Event::DefaultRouteInterface`].
+///
+/// Ingests route events and interface removals to calculate the default route for a
+/// [`Netmon`], emitting updates as [`Event::DefaultRouteInterface`].
+#[derive(Debug)]
+struct DefaultRouteState {
+    /// Metrics per (interface, gateways) tuple.
+    ///
+    /// Stored in btrees for ordering: we always want the minimum available metric
+    /// (`BTreeMap`), and the inner `BTreeSet` is sorted to provide a stable answer if
+    /// multiple interfaces have a route with the same metric. We have to store the set of
+    /// gateways along with the interface, as technically the same interface could have
+    /// multiple default routes with different sets of gateways (on platforms that permit
+    /// this) and they would be distinguishable.
+    metrics: BTreeMap<usize, BTreeSet<DefaultRouteUnique>>,
+
+    /// Set of interfaces that are in the up state.
+    ///
+    /// Only these interfaces can be considered for being the default route interface.
+    interfaces_up: HashSet<InterfaceId>,
+
+    /// The last [`InterfaceId`] we reported in an event. If routes change but this
+    /// doesn't, we don't need to report a new event.
+    last_id: Option<InterfaceId>,
+
+    /// The IP family this covers.
+    family: Family,
+}
+
+impl DefaultRouteState {
+    fn new(family: Family) -> Self {
+        Self {
+            metrics: Default::default(),
+            last_id: None,
+            interfaces_up: Default::default(),
+            family,
+        }
+    }
+
+    /// Add the specified route for the given interface.
+    fn add_route(&mut self, interface_id: &InterfaceId, route: &Route) -> Option<Event> {
+        if route.family() != self.family || !route.is_default_route() {
+            return None;
+        }
+
+        let mut gws = route.gateway.clone();
+        gws.sort();
+
+        let modified = self
+            .metrics
+            .entry(route.metric)
+            .or_default()
+            .insert((interface_id.clone(), gws));
+
+        if !modified {
+            return None;
+        }
+
+        self.update_best()
+    }
+
+    /// Remove the specified route for the given interface.
+    fn remove_route(&mut self, interface_id: &InterfaceId, route: &Route) -> Option<Event> {
+        if route.family() != self.family || !route.is_default_route() {
+            return None;
+        }
+
+        let entry = self.metrics.get_mut(&route.metric)?;
+        let mut gws = route.gateway.clone();
+        gws.sort();
+
+        let modified = entry.remove(&(interface_id.clone(), gws));
+        if !modified {
+            return None;
+        }
+
+        if entry.is_empty() {
+            self.metrics.remove(&route.metric);
+        }
+
+        self.update_best()
+    }
+
+    /// Set the interface to up or down.
+    fn update_interface_state(&mut self, interface_id: &InterfaceId, up: bool) -> Option<Event> {
+        if up {
+            self.interfaces_up.insert(interface_id.clone())
+        } else {
+            self.interfaces_up.remove(interface_id)
+        }
+        .then(|| self.update_best())
+        .flatten()
+    }
+
+    /// Remove all routes for the given interface from the state.
+    ///
+    /// We don't handle any logic re: [`Netmon::strong_delete_consistency`], the caller is
+    /// responsible for deciding whether to call this function.
+    fn remove_interface(&mut self, interface_id: &InterfaceId) -> Option<Event> {
+        let mut metrics_modified = false;
+
+        self.metrics.retain(|_, e| {
+            e.retain(|(id, _)| {
+                let ret = id == interface_id;
+                metrics_modified = metrics_modified || ret;
+
+                ret
+            });
+
+            !e.is_empty()
+        });
+
+        self.interfaces_up.remove(interface_id);
+
+        if !metrics_modified {
+            return None;
+        }
+
+        self.update_best()
+    }
+
+    /// Update the best-route interface id, generating [`Event::DefaultRouteInterface`] if
+    /// it has changed.
+    fn update_best(&mut self) -> Option<Event> {
+        let new_best_id = self
+            .metrics
+            .values()
+            .flatten()
+            .find_map(|(id, _)| self.interfaces_up.contains(id).then(|| id.clone()));
+
+        if new_best_id == self.last_id {
+            return None;
+        }
+
+        self.last_id = new_best_id.clone();
+
+        Some(Event::DefaultRouteInterface(new_best_id, self.family))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const MONTYPE: MonType = MonType::new_static("test");
+
+    #[test]
+    fn different_gateway() -> Result<(), Box<dyn core::error::Error>> {
+        let mut state = DefaultRouteState::new(Family::Ipv4);
+        let interface = InterfaceId::new(MONTYPE, 0);
+
+        let evt1 = state.update_interface_state(&interface, true);
+
+        let route1 = Route {
+            metric: 0,
+            gateway: smallvec::smallvec!["1.2.3.4".parse()?],
+            dst: ipnet::Ipv4Net::default().into(),
+        };
+
+        let route2 = Route {
+            metric: 0,
+            gateway: smallvec::smallvec!["5.6.7.8".parse()?],
+            dst: ipnet::Ipv4Net::default().into(),
+        };
+
+        assert!(route1.is_default_route() && route2.is_default_route());
+
+        let evt2 = state.add_route(&interface, &route1);
+        let evt3 = state.add_route(&interface, &route2);
+
+        assert_eq!(state.last_id, Some(interface.clone()));
+
+        assert_eq!(evt1, None);
+        assert_eq!(
+            evt2,
+            Some(Event::DefaultRouteInterface(
+                Some(interface.clone()),
+                Family::Ipv4
+            ))
+        );
+        assert_eq!(evt3, None);
+
+        let rem1 = state.remove_route(&interface, &route1);
+        let rem2 = state.remove_route(&interface, &route2);
+
+        assert_eq!(state.last_id, None);
+        assert_eq!(rem1, None);
+        assert_eq!(rem2, Some(Event::DefaultRouteInterface(None, Family::Ipv4)));
+
+        Ok(())
+    }
+}

--- a/ts_netmon/src/windows/addr_iter.rs
+++ b/ts_netmon/src/windows/addr_iter.rs
@@ -1,0 +1,152 @@
+//! Iterators over linked lists of addresses as provided by win32.
+
+use core::{
+    iter::FusedIterator,
+    net::{Ipv4Addr, Ipv6Addr},
+};
+
+use windows::Win32::{NetworkManagement::IpHelper, Networking::WinSock};
+
+trait WinAddr {
+    fn sockaddr(&self) -> &WinSock::SOCKADDR;
+    fn next(&self) -> Option<&dyn WinAddr>;
+    fn prefix_len(&self) -> Option<u8>;
+}
+
+macro_rules! impl_winaddr {
+    ($ty:ty) => {
+        impl_winaddr!($ty, |_| None);
+    };
+    ($ty:ty, $pfx:expr) => {
+        impl WinAddr for $ty {
+            fn sockaddr(&self) -> &WinSock::SOCKADDR {
+                // SAFETY: only used for kernel-provided values, ref-convertibility is guaranteed.
+                unsafe { self.Address.lpSockaddr.as_ref() }.unwrap()
+            }
+
+            fn next(&self) -> Option<&dyn WinAddr> {
+                // SAFETY: only used for kernel-provided values, ref-convertibility is guaranteed.
+                // It's a Self, so it impls `dyn WinAddr`.
+                unsafe { (self.Next as *const dyn WinAddr).as_ref() }
+            }
+
+            fn prefix_len(&self) -> Option<u8> {
+                ($pfx)(self)
+            }
+        }
+    };
+}
+
+impl_winaddr!(
+    IpHelper::IP_ADAPTER_UNICAST_ADDRESS_LH,
+    (|slf: &IpHelper::IP_ADAPTER_UNICAST_ADDRESS_LH| Some(slf.OnLinkPrefixLength))
+);
+impl_winaddr!(IpHelper::IP_ADAPTER_UNICAST_ADDRESS_XP);
+impl_winaddr!(
+    IpHelper::IP_ADAPTER_PREFIX_XP,
+    |slf: &IpHelper::IP_ADAPTER_PREFIX_XP| Some(slf.PrefixLength as u8)
+);
+
+/// Iterator over a Windows linked-list-of-addresses type.
+pub struct AddrIter<'a> {
+    item: Option<&'a dyn WinAddr>,
+}
+
+macro_rules! iter_fn {
+    ($name:ident, $field:ident) => {
+        #[doc = concat!("Helper to iterate over the addresses in [`IpHelper::IP_ADAPTER_ADDRESSES_LH::", stringify!($field), "`].")]
+        pub fn $name(addrs: &IpHelper::IP_ADAPTER_ADDRESSES_LH) -> AddrIter<'_> {
+            AddrIter {
+                // SAFETY: the kernel originally provided the value, so it's ref-convertible as its
+                // type (if non-null), and the field type impls `WinAddr`.
+                item: unsafe { (addrs.$field as *const dyn WinAddr).as_ref() },
+            }
+        }
+    };
+}
+
+iter_fn!(iter_unicast, FirstUnicastAddress);
+iter_fn!(iter_prefixes, FirstPrefix);
+
+impl Iterator for AddrIter<'_> {
+    type Item = ipnet::IpNet;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let ret = self.item?;
+
+            let sa = ret.sockaddr();
+            self.item = ret.next();
+
+            match sa.sa_family {
+                WinSock::AF_INET => {
+                    // SAFETY: this is the meaning of `sa_family = AF_INET`
+                    let sa = unsafe {
+                        core::mem::transmute::<&WinSock::SOCKADDR, &WinSock::SOCKADDR_IN>(sa)
+                    };
+                    // SAFETY: all bitpatterns are valid
+                    let bytes = unsafe { sa.sin_addr.S_un.S_un_b };
+                    let ip = Ipv4Addr::new(bytes.s_b1, bytes.s_b2, bytes.s_b3, bytes.s_b4);
+
+                    break Some(
+                        ipnet::IpNet::new(ip.into(), ret.prefix_len().unwrap_or(32)).unwrap(),
+                    );
+                }
+                WinSock::AF_INET6 => {
+                    // SAFETY: this is the meaning of `sa_family = AF_INET6`
+                    let sa = unsafe {
+                        core::mem::transmute::<&WinSock::SOCKADDR, &WinSock::SOCKADDR_IN6>(sa)
+                    };
+                    // SAFETY: all bitpatterns are valid for [u8; 16]
+                    let ip = Ipv6Addr::from_octets(unsafe { sa.sin6_addr.u.Byte });
+
+                    break Some(
+                        ipnet::IpNet::new(ip.into(), ret.prefix_len().unwrap_or(128)).unwrap(),
+                    );
+                }
+                _unknown => {
+                    continue;
+                }
+            }
+        }
+    }
+}
+
+impl FusedIterator for AddrIter<'_> {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{Family, FamilyOrBoth, windows::InterfaceReport};
+
+    #[test]
+    fn iter_report() {
+        for family in [FamilyOrBoth::Both, Family::Ipv4.into(), Family::Ipv6.into()] {
+            let report = InterfaceReport::get(family).unwrap();
+
+            for elem in report.iter() {
+                println!(
+                    "{}/{}:",
+                    unsafe { elem.AdapterName.to_string() }.unwrap(),
+                    unsafe { elem.FriendlyName.to_string() }.unwrap()
+                );
+
+                print!("\tprefixes: ",);
+                for pfx in iter_prefixes(elem) {
+                    print!("{pfx}, ");
+                }
+
+                print!("\n\tunicast: ");
+                for pfx in iter_unicast(elem) {
+                    print!("{pfx}, ");
+                }
+
+                println!();
+                println!();
+            }
+
+            println!();
+            println!();
+        }
+    }
+}

--- a/ts_netmon/src/windows/event_stream/mod.rs
+++ b/ts_netmon/src/windows/event_stream/mod.rs
@@ -1,0 +1,208 @@
+use futures_util::{Stream, StreamExt, TryStreamExt};
+use windows::Win32::{Foundation, NetworkManagement::IpHelper};
+
+use crate::{
+    Event, FamilyOrBoth,
+    windows::{InterfaceReport, routes::RouteTable, unicast_row_to_ipnet},
+};
+
+mod notify_stream;
+pub use notify_stream::{
+    LinkChange, LinkStream, RouteChange, RouteStream, UnicastIpChange, UnicastIpStream,
+};
+
+use crate::windows::iter_unicast;
+
+/// Produce a stream of [`Event`]s as reported by the Windows kernel.
+///
+/// At startup, this stream produces a set of events that establish the initial state.
+pub fn stream() -> std::io::Result<impl Stream<Item = std::io::Result<Event>>> {
+    let route_changes = RouteStream::new(FamilyOrBoth::Both)?;
+    let unicast_changes = UnicastIpStream::new(FamilyOrBoth::Both)?;
+    let link_changes = LinkStream::new(FamilyOrBoth::Both)?;
+
+    let route_changes = route_changes
+        .then(async |(ty, change)| {
+            let a = handle_route_change(ty, change);
+            futures_util::stream::iter(a)
+        })
+        .flatten();
+
+    let unicast_changes =
+        unicast_changes.filter_map(async |(ty, change)| handle_unicast_change(ty, change));
+
+    let link_changes = link_changes
+        .filter_map(async |(ty, change)| handle_link_change(ty, change).await.transpose());
+
+    let init = futures_util::stream::once(init_state())
+        .try_filter_map(async |x| Ok(Some(futures_util::stream::iter(x).map(Ok))))
+        .try_flatten();
+
+    let updates = {
+        use tokio_stream::StreamExt;
+        route_changes.merge(unicast_changes).merge(link_changes)
+    };
+
+    Ok(init.chain(updates))
+}
+
+/// Produce initial [`Event`]s representing the system state from an [`InterfaceReport`]
+/// and [`RouteTable`].
+async fn init_state() -> windows::core::Result<impl Iterator<Item = Event>> {
+    let (report, route_table) = report_and_table(FamilyOrBoth::Both).await?;
+
+    let interfaces = report
+        .iter()
+        .map(|adapter| Event::InterfaceUpsert(crate::Interface::from(adapter)))
+        .collect::<Vec<_>>();
+
+    let addrs = report
+        .iter()
+        .flat_map(|adapter| {
+            iter_unicast(adapter).map(|x| Event::AddrUpsert(adapter.Luid.into(), x))
+        })
+        .collect::<Vec<Event>>();
+
+    let init_routes = route_table
+        .iter()
+        .map(|row| Event::RouteUpsert(row.InterfaceLuid.into(), row.into()))
+        .collect::<Vec<_>>();
+
+    Ok(interfaces.into_iter().chain(addrs).chain(init_routes))
+}
+
+/// Handle a [`RouteChange`] event from the underlying notify stream.
+fn handle_route_change(
+    ty: IpHelper::MIB_NOTIFICATION_TYPE,
+    mut change: IpHelper::MIB_IPFORWARD_ROW2,
+) -> Option<std::io::Result<Event>> {
+    let event = match ty {
+        IpHelper::MibAddInstance | IpHelper::MibParameterNotification => {
+            if let Err(e) = populate_route(&mut change) {
+                return Some(Err(e));
+            }
+
+            Event::RouteUpsert(change.InterfaceLuid.into(), change.into())
+        }
+        IpHelper::MibDeleteInstance => {
+            // On a deletion, the route info is gone already, so don't bother trying to load it.
+            Event::RouteRemoved(change.InterfaceLuid.into(), change.into())
+        }
+        _ => return None,
+    };
+
+    Some(Ok(event))
+}
+
+/// Populate the route entry with additional info from the kernel.
+///
+/// This is needed because the changes loaded by the notify APIs do not include some
+/// relevant information such as the `Metric` field. Even that info isn't typically fully
+/// filled out; it usually omits the link metric, which also needs to be loaded and is
+/// added to the route here.
+///
+/// This will only return successfully if the row is still in the route table. A route
+/// produced by [`IpHelper::NotifyRouteChange2`] and accompanied by
+/// [`IpHelper::MibDeleteInstance`] is no longer in the table, so this will return
+/// [`std::io::ErrorKind::NotFound`].
+pub fn populate_route(row: &mut IpHelper::MIB_IPFORWARD_ROW2) -> std::io::Result<()> {
+    let mut if_row = IpHelper::MIB_IPINTERFACE_ROW {
+        InterfaceLuid: row.InterfaceLuid,
+        // SAFETY: all bitpatterns are valid for si_family
+        Family: unsafe { row.DestinationPrefix.Prefix.si_family },
+        ..Default::default()
+    };
+
+    // SAFETY: this API is invoked correctly.
+    tokio::task::block_in_place(|| unsafe {
+        IpHelper::GetIpForwardEntry2(row).ok()?;
+        IpHelper::GetIpInterfaceEntry(&mut if_row as *mut _).ok()?;
+
+        row.Metric += if_row.Metric;
+
+        Ok(())
+    })
+}
+
+/// Handle a [`UnicastIpChange`] event from the underlying notify stream.
+fn handle_unicast_change(
+    ty: IpHelper::MIB_NOTIFICATION_TYPE,
+    mut change: IpHelper::MIB_UNICASTIPADDRESS_ROW,
+) -> Option<std::io::Result<Event>> {
+    let result = unsafe { IpHelper::GetUnicastIpAddressEntry(&mut change as *mut _) };
+    match result {
+        Foundation::NO_ERROR | Foundation::ERROR_NOT_FOUND => {}
+        e => {
+            return Some(Err(e.ok().unwrap_err().into()));
+        }
+    }
+
+    let ipn = || unicast_row_to_ipnet(&change);
+
+    match ty {
+        // On a parameter notification, the prefix is allowed to change on Windows, the address
+        // itself is the unique key.
+        IpHelper::MibAddInstance | IpHelper::MibParameterNotification => {
+            Some(Ok(Event::AddrUpsert(change.InterfaceLuid.into(), ipn())))
+        }
+        IpHelper::MibDeleteInstance => {
+            Some(Ok(Event::AddrRemoved(change.InterfaceLuid.into(), ipn())))
+        }
+        _ => None,
+    }
+}
+
+/// Handle a [`LinkChange`] event from the underlying notify stream.
+async fn handle_link_change(
+    ty: IpHelper::MIB_NOTIFICATION_TYPE,
+    change: IpHelper::MIB_IPINTERFACE_ROW,
+) -> std::io::Result<Option<Event>> {
+    match ty {
+        IpHelper::MibAddInstance | IpHelper::MibParameterNotification => {
+            let Ok(family) = change.Family.try_into() else {
+                tracing::error!(
+                    family = ?change.Family,
+                    "unexpected address family for link change",
+                );
+                return Ok(None);
+            };
+
+            // Seemingly the only way to get a single interface definition in iphlpapi is to request
+            // the complete interface report via GetAdaptersAddresses.
+            let report = tokio::task::spawn_blocking(move || InterfaceReport::get(family))
+                .await
+                .unwrap()?; // intentionally forward internal panics
+
+            if let Some(interface) = report
+                .iter()
+                // SAFETY: all u64 bitpatterns are valid
+                .find(|x| unsafe { x.Luid.Value == change.InterfaceLuid.Value })
+            {
+                Ok(Some(Event::InterfaceUpsert(interface.into())))
+            } else {
+                Ok(None)
+            }
+        }
+        IpHelper::MibDeleteInstance => {
+            Ok(Some(Event::InterfaceRemoved(change.InterfaceLuid.into())))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Convenience helper to grab an [`InterfaceReport`] and [`RouteTable`] for the given
+/// [`FamilyOrBoth`] correctly wrapped with [`tokio::task::spawn_blocking`].
+async fn report_and_table(family: FamilyOrBoth) -> std::io::Result<(InterfaceReport, RouteTable)> {
+    tokio::task::spawn_blocking(move || {
+        let adp = InterfaceReport::get(family)?;
+        let mut route_table = RouteTable::get(family)?;
+
+        for route in route_table.iter_mut() {
+            populate_route(route)?;
+        }
+
+        Ok((adp, route_table)) as std::io::Result<_>
+    })
+    .await
+    .unwrap() // intentionally forward internal panics
+}

--- a/ts_netmon/src/windows/event_stream/notify_stream.rs
+++ b/ts_netmon/src/windows/event_stream/notify_stream.rs
@@ -1,0 +1,124 @@
+//! [`Stream`] impls wrapping win32 [`IpHelper`] notify methods.
+
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures_util::Stream;
+use windows::Win32::{Foundation, NetworkManagement::IpHelper};
+
+use crate::family::FamilyOrBoth;
+
+macro_rules! notify_stream {
+    ($name:ident, $msg:ident, $f:ident, $rowty:ty) => {
+        notify_stream!($name, $msg, $f, $rowty, |x| x);
+    };
+
+    ($name:ident, $msg:ident, $f:ident, $rowty:ty, $helper:expr) => {
+        #[doc = concat!("Type of event produced by [`", stringify!($name), "`].")]
+        pub type $msg = (IpHelper::MIB_NOTIFICATION_TYPE, $rowty);
+
+        pin_project_lite::pin_project! {
+            #[doc = concat!("Implements [`Stream`] for events produced by [`IpHelper::", stringify!($f), "`].")]
+            pub struct $name {
+                #[pin]
+                rx: flume::r#async::RecvStream<'static, $msg>,
+                _tx: Box<flume::Sender<$msg >>,
+                handle: DropHandle,
+            }
+        }
+
+        impl $name {
+            /// Construct a new notify stream gathering events for `family`.
+            pub fn new(family: FamilyOrBoth) -> windows::core::Result<Self> {
+                let mut handle: Foundation::HANDLE = Foundation::HANDLE::default();
+                let (tx, rx) = flume::unbounded();
+                let tx = Box::new(tx);
+
+                extern "system" fn notify(
+                    ctx: *const core::ffi::c_void,
+                    row: *const $rowty,
+                    ty: IpHelper::MIB_NOTIFICATION_TYPE,
+                ) {
+                    let ctx = ctx as *const flume::Sender<$msg>;
+
+                    // SAFETY: kernel hands us this pointer, should be ref-convertible.
+                    let Some(sender) = (unsafe { ctx.as_ref() }) else {
+                        return;
+                    };
+
+                    // SAFETY: kernel hands us this pointer, should be ref-convertible.
+                    let Some(row) = (unsafe { row.as_ref() }) else {
+                        return;
+                    };
+
+                    let _err = sender.send((ty, *row));
+                }
+
+                // SAFETY: correct usage per MS docs.
+                unsafe {
+                    IpHelper::$f(
+                        family.into(),
+                        Some(notify),
+                        ($helper)(tx.as_ref() as *const _ as *const _),
+                        true,
+                        &mut handle as *mut _,
+                    )
+                }
+                .ok()?;
+
+                Ok(Self {
+                    rx: rx.into_stream(),
+                    _tx: tx,
+                    handle: DropHandle { handle },
+                })
+            }
+        }
+
+        impl Stream for $name {
+            type Item = $msg;
+
+            fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+                self.project().rx.poll_next(cx)
+            }
+        }
+    };
+}
+
+notify_stream!(
+    RouteStream,
+    RouteChange,
+    NotifyRouteChange2,
+    IpHelper::MIB_IPFORWARD_ROW2
+);
+
+notify_stream!(
+    UnicastIpStream,
+    UnicastIpChange,
+    NotifyUnicastIpAddressChange,
+    IpHelper::MIB_UNICASTIPADDRESS_ROW,
+    Some
+);
+
+notify_stream!(
+    LinkStream,
+    LinkChange,
+    NotifyIpInterfaceChange,
+    IpHelper::MIB_IPINTERFACE_ROW,
+    Some
+);
+
+struct DropHandle {
+    handle: Foundation::HANDLE,
+}
+
+unsafe impl Send for DropHandle {}
+
+impl Drop for DropHandle {
+    fn drop(&mut self) {
+        // SAFETY: handle is only constructed if the Notify* call succeeded, so it
+        // should be valid.
+        let _err = unsafe { IpHelper::CancelMibChangeNotify2(self.handle) };
+    }
+}

--- a/ts_netmon/src/windows/interface_report.rs
+++ b/ts_netmon/src/windows/interface_report.rs
@@ -1,0 +1,133 @@
+use std::{iter::FusedIterator, mem::MaybeUninit};
+
+use windows::Win32::{Foundation, NetworkManagement::IpHelper};
+
+use crate::FamilyOrBoth;
+
+/// A set of network interfaces at a point in time, reported by Windows.
+pub struct InterfaceReport {
+    /// Backing storage holding the report which was filled by Windows.
+    buf: Vec<MaybeUninit<u8>>,
+
+    /// The address family this report was gathered against.
+    _family: FamilyOrBoth,
+}
+
+impl InterfaceReport {
+    /// Recommended initial size to avoid calling [`IpHelper::GetAdaptersAddresses`]
+    /// multiple times.
+    const INITIAL_SIZE: u32 = 15000;
+
+    /// Get a report of available network interfaces for the given [`FamilyOrBoth`].
+    ///
+    /// The system call in this function is costly and may block the thread for on the
+    /// order of milliseconds.
+    pub fn get(family: FamilyOrBoth) -> windows::core::Result<Self> {
+        let mut size = Self::INITIAL_SIZE;
+        let mut v = vec![];
+
+        let family_u32 = u32::from(family);
+
+        loop {
+            v.resize_with(size as usize, MaybeUninit::uninit);
+
+            // SAFETY: all parameters are ok, see docs:
+            // https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadaptersaddresses
+            let result = unsafe {
+                IpHelper::GetAdaptersAddresses(
+                    family_u32,
+                    IpHelper::GAA_FLAG_INCLUDE_ALL_INTERFACES,
+                    None,
+                    Some(v.as_mut_ptr() as _),
+                    &mut size as *mut _,
+                )
+            };
+            let result = Foundation::WIN32_ERROR(result).ok();
+
+            match result {
+                Ok(()) => {
+                    // Invariants:
+                    // - This type is only constructed if GetAdaptersAddresses succeeded.
+                    // - self.buf's length is the actual size the kernel told us.
+
+                    v.truncate(size as _);
+
+                    break Ok(Self {
+                        buf: v,
+                        _family: family,
+                    });
+                }
+                Err(e) if e.code() == Foundation::ERROR_BUFFER_OVERFLOW.to_hresult() => {
+                    // need more space, and `size` now holds the new required allocation size, try
+                    // again.
+                    continue;
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    /// Return an iterator over the adapters in this report.
+    pub fn iter(&self) -> ReportIter<'_> {
+        let init = if self.buf.is_empty() {
+            None
+        } else {
+            // SAFETY: two concerns:
+            //
+            // - Ref-convertibility of `self.buf` as `*const IP_ADAPTER_ADDRESSES_LH`: this is
+            //   guaranteed by the kernel -- the first item in the allocation is the first entry in
+            //   the linked list. By the length invariant in `get`, the buf-empty check here is
+            //   sufficient to ensure we have at least one valid entry.
+            // - Lifetime of the returned ref: the `IP_ADAPTER_ADDRESSES_LH` structure is a linked
+            //   list with internal pointers that all point into the internal allocation
+            //   (`self.buf`). Hence, it's fine to return a ref with the inferred `'self` lifetime
+            //   here, as the `ReportIter` (and all its references into `self.buf`) must drop before
+            //   we do (and hence `self.buf` does).
+            unsafe { (self.buf.as_ptr() as *const IpHelper::IP_ADAPTER_ADDRESSES_LH).as_ref() }
+        };
+
+        ReportIter { next: init }
+    }
+}
+
+/// Iterator over an [`InterfaceReport`].
+pub struct ReportIter<'a> {
+    next: Option<&'a IpHelper::IP_ADAPTER_ADDRESSES_LH>,
+}
+
+impl<'a> Iterator for ReportIter<'a> {
+    type Item = &'a IpHelper::IP_ADAPTER_ADDRESSES_LH;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let ret = self.next?;
+
+        // SAFETY: the only way we can have a `ReportIter` is if it was produced by
+        // `InterfaceReport::iter`, meaning that the lifetime 'a is the lifetime of the parent `buf`
+        // holding a backing allocation. `ret.Next` points into that allocation, so its lifetime is
+        // also 'a (as created here).
+        //
+        // The ref-convertibility of the pointer is ensured by the kernel if it's non-null.
+        self.next = unsafe { ret.Next.as_ref() };
+
+        Some(ret)
+    }
+}
+
+impl FusedIterator for ReportIter<'_> {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn report_to_interface() {
+        let report = InterfaceReport::get(FamilyOrBoth::Both).unwrap();
+
+        for interface in report.iter() {
+            let interface = crate::Interface::from(interface);
+            println!("{interface:?}");
+        }
+    }
+}

--- a/ts_netmon/src/windows/mod.rs
+++ b/ts_netmon/src/windows/mod.rs
@@ -1,0 +1,49 @@
+//! Windows network monitor implementation.
+
+use core::pin::Pin;
+
+use futures_util::Stream;
+
+use crate::Event;
+
+mod addr_iter;
+mod event_stream;
+mod interface_report;
+mod routes;
+mod util;
+
+pub use addr_iter::{AddrIter, iter_prefixes, iter_unicast};
+pub use event_stream::{
+    LinkChange, LinkStream, RouteChange, RouteStream, UnicastIpChange, UnicastIpStream,
+    populate_route, stream as event_stream,
+};
+pub use interface_report::{InterfaceReport, ReportIter};
+pub use routes::RouteTable;
+pub use util::{sockaddr_inet_to_ipaddr, unicast_row_to_ipnet};
+
+use crate::{id::MonType, netmon::Netmon};
+
+/// Canonical Windows [`Netmon`] built on Win32's
+/// [`<iphlpapi.h>`](https://learn.microsoft.com/en-us/windows/win32/api/_iphlp/).
+#[derive(Debug, Copy, Clone, Default)]
+pub struct Winmon;
+
+impl Netmon for Winmon {
+    fn ty(&self) -> MonType {
+        MonType::WINDOWS_IPHLPAPI
+    }
+
+    fn event_stream(
+        &self,
+    ) -> std::io::Result<Pin<Box<dyn Stream<Item = std::io::Result<Event>> + Send>>> {
+        Ok(Box::pin(event_stream()?))
+    }
+
+    fn strong_delete_consistency(&self) -> bool {
+        false
+    }
+
+    fn interface_unique_addrs(&self) -> bool {
+        true
+    }
+}

--- a/ts_netmon/src/windows/routes.rs
+++ b/ts_netmon/src/windows/routes.rs
@@ -1,0 +1,94 @@
+use core::{
+    ops::{Deref, DerefMut},
+    ptr::{NonNull, null_mut},
+};
+
+use windows::Win32::NetworkManagement::IpHelper;
+
+use crate::{FamilyOrBoth, Route, windows::sockaddr_inet_to_ipaddr};
+
+/// A route table retrieved using [`IpHelper::GetIpForwardTable2`].
+///
+/// Derefs to `&[IpHelper::MIB_IPFORWARD_ROW2]`.
+pub struct RouteTable {
+    tab: NonNull<IpHelper::MIB_IPFORWARD_TABLE2>,
+    _family: FamilyOrBoth,
+}
+
+impl RouteTable {
+    /// Get the route table for the specified [`FamilyOrBoth`] from the kernel.
+    pub fn get(family: FamilyOrBoth) -> windows::core::Result<Self> {
+        let mut tab = null_mut();
+
+        // SAFETY: this is the correct usage of the API per MS docs.
+        unsafe { IpHelper::GetIpForwardTable2(family.into(), &mut tab) }.ok()?;
+
+        // Invariant: RouteTable is only ever successfully constructed if GetIpForwardTable2
+        // returned NO_ERROR, implying `tab` is a valid, nonnull pointer to a route table.
+        Ok(Self {
+            tab: NonNull::new(tab).unwrap(),
+            _family: family,
+        })
+    }
+}
+
+// SAFETY: route table pointer isn't thread-local, it's just a pointer to a chunk of memory.
+// FreeMibTable can be called from any thread.
+unsafe impl Send for RouteTable {}
+
+impl Deref for RouteTable {
+    type Target = [IpHelper::MIB_IPFORWARD_ROW2];
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: by invariant described in RouteTable::get, tab is a valid, non-null pointer.
+        // Kernel guarantees the table is laid out as a C array, which is valid as a slice.
+        unsafe {
+            let tab = self.tab.as_ref();
+            core::slice::from_raw_parts(tab.Table.as_ptr(), tab.NumEntries as _)
+        }
+    }
+}
+
+impl DerefMut for RouteTable {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: by invariant described in RouteTable::get, tab is a valid, non-null pointer.
+        // Kernel guarantees the table is laid out as a C array, which is valid as a slice.
+        unsafe {
+            let tab = self.tab.as_mut();
+            core::slice::from_raw_parts_mut(tab.Table.as_mut_ptr(), tab.NumEntries as _)
+        }
+    }
+}
+
+impl Drop for RouteTable {
+    fn drop(&mut self) {
+        // SAFETY: by invariant described in RouteTabe::get, tab was successfully allocated by the
+        // platform. This is the correct usage of the API per MS docs.
+        unsafe { IpHelper::FreeMibTable(self.tab.as_ptr() as *const _) }
+    }
+}
+
+impl From<&IpHelper::MIB_IPFORWARD_ROW2> for Route {
+    fn from(route: &IpHelper::MIB_IPFORWARD_ROW2) -> Self {
+        let next_hop = sockaddr_inet_to_ipaddr(&route.NextHop);
+        let dest_ip = sockaddr_inet_to_ipaddr(&route.DestinationPrefix.Prefix);
+        let dst = ipnet::IpNet::new(dest_ip, route.DestinationPrefix.PrefixLength).unwrap();
+
+        Self {
+            metric: route.Metric as _,
+            gateway: if next_hop.is_unspecified() {
+                // Windows uses the unspecified address to indicate no gateway
+                smallvec::smallvec![]
+            } else {
+                smallvec::smallvec![next_hop]
+            },
+            dst,
+        }
+    }
+}
+
+impl From<IpHelper::MIB_IPFORWARD_ROW2> for Route {
+    fn from(route: IpHelper::MIB_IPFORWARD_ROW2) -> Self {
+        Self::from(&route)
+    }
+}

--- a/ts_netmon/src/windows/util.rs
+++ b/ts_netmon/src/windows/util.rs
@@ -1,0 +1,125 @@
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use windows::Win32::{
+    NetworkManagement::{IpHelper, Ndis},
+    Networking::WinSock,
+};
+
+use crate::{Family, FamilyOrBoth, InterfaceId, MonType};
+
+impl From<Ndis::NET_LUID_LH> for InterfaceId {
+    fn from(luid: Ndis::NET_LUID_LH) -> InterfaceId {
+        // SAFETY: all u64 bitpatterns are valid
+        InterfaceId::new(MonType::WINDOWS_IPHLPAPI, unsafe { luid.Value })
+    }
+}
+
+impl From<&Ndis::NET_LUID_LH> for InterfaceId {
+    fn from(l: &Ndis::NET_LUID_LH) -> InterfaceId {
+        (*l).into()
+    }
+}
+
+/// Convert a [`WinSock::SOCKADDR_INET`] to [`IpAddr`].
+pub fn sockaddr_inet_to_ipaddr(sin: &WinSock::SOCKADDR_INET) -> IpAddr {
+    // SAFETY: all bitpatterns valid for u16
+    match unsafe { sin.si_family } {
+        WinSock::AF_INET => {
+            // SAFETY: this is the meaning of `sa_family = AF_INET`
+            let sa = unsafe { &sin.Ipv4 };
+            // SAFETY: all bitpatterns are valid
+            let bytes = unsafe { sa.sin_addr.S_un.S_un_b };
+            let ip = Ipv4Addr::new(bytes.s_b1, bytes.s_b2, bytes.s_b3, bytes.s_b4);
+
+            ip.into()
+        }
+        WinSock::AF_INET6 => {
+            // SAFETY: this is the meaning of `sa_family = AF_INET6`
+            let sa = unsafe { &sin.Ipv6 };
+            // SAFETY: all bitpatterns are valid for [u8; 16]
+            let ip = Ipv6Addr::from_octets(unsafe { sa.sin6_addr.u.Byte });
+
+            ip.into()
+        }
+        _unknown => {
+            unreachable!()
+        }
+    }
+}
+
+/// Convert [`IpHelper::MIB_UNICASTIPADDRESS_ROW`] to [`ipnet::IpNet`].
+pub fn unicast_row_to_ipnet(row: &IpHelper::MIB_UNICASTIPADDRESS_ROW) -> ipnet::IpNet {
+    let pfx_len = row.OnLinkPrefixLength;
+    let ip = sockaddr_inet_to_ipaddr(&row.Address);
+    ipnet::IpNet::new(ip, pfx_len).unwrap()
+}
+
+impl From<&IpHelper::IP_ADAPTER_ADDRESSES_LH> for crate::Interface {
+    fn from(value: &IpHelper::IP_ADAPTER_ADDRESSES_LH) -> Self {
+        let mac = &value.PhysicalAddress[..value.PhysicalAddressLength as _];
+
+        crate::Interface {
+            id: value.Luid.into(),
+
+            // SAFETY: Windows handed us this value, so we can rely on it being correctly
+            // NUL-terminated.
+            name: String::from_utf16_lossy(unsafe { value.FriendlyName.as_wide() }),
+
+            up: value.OperStatus == Ndis::IfOperStatusUp,
+
+            mtu: if value.Mtu == 0 {
+                None
+            } else {
+                Some(value.Mtu as _)
+            },
+
+            hardware_addr: if !mac.is_empty() {
+                Some(mac.into())
+            } else {
+                None
+            },
+        }
+    }
+}
+
+impl From<Family> for WinSock::ADDRESS_FAMILY {
+    fn from(family: Family) -> Self {
+        match family {
+            Family::Ipv4 => WinSock::AF_INET,
+            Family::Ipv6 => WinSock::AF_INET6,
+        }
+    }
+}
+
+impl From<Family> for u32 {
+    fn from(family: Family) -> Self {
+        WinSock::ADDRESS_FAMILY::from(family).0 as _
+    }
+}
+
+impl From<FamilyOrBoth> for WinSock::ADDRESS_FAMILY {
+    fn from(family: FamilyOrBoth) -> Self {
+        match family {
+            FamilyOrBoth::Both => WinSock::AF_UNSPEC,
+            FamilyOrBoth::Single(family) => family.into(),
+        }
+    }
+}
+
+impl From<FamilyOrBoth> for u32 {
+    fn from(family: FamilyOrBoth) -> Self {
+        WinSock::ADDRESS_FAMILY::from(family).0 as _
+    }
+}
+
+impl TryFrom<WinSock::ADDRESS_FAMILY> for FamilyOrBoth {
+    type Error = ();
+    fn try_from(family: WinSock::ADDRESS_FAMILY) -> Result<Self, Self::Error> {
+        match family {
+            WinSock::AF_UNSPEC => Ok(FamilyOrBoth::Both),
+            WinSock::AF_INET => Ok(Family::Ipv4.into()),
+            WinSock::AF_INET6 => Ok(Family::Ipv6.into()),
+            _ => Err(()),
+        }
+    }
+}

--- a/ts_runtime/Cargo.toml
+++ b/ts_runtime/Cargo.toml
@@ -18,6 +18,7 @@ ts_control.workspace = true
 ts_dataplane.workspace = true
 ts_keys.workspace = true
 ts_netcheck.workspace = true
+ts_netmon.workspace = true
 ts_netstack_smoltcp = { workspace = true, features = ["tokio"] }
 ts_overlay_router.workspace = true
 ts_packet.workspace = true
@@ -34,6 +35,7 @@ kameo = "0.19"
 kameo_actors = "0.4"
 thiserror.workspace = true
 tokio.workspace = true
+tokio-stream = { version = "0.1", default-features = false, features = ["time"] }
 tracing.workspace = true
 smallvec.workspace = true
 

--- a/ts_runtime/src/control_runner.rs
+++ b/ts_runtime/src/control_runner.rs
@@ -77,9 +77,9 @@ impl kameo::Actor for ControlRunner {
         )
         .await?;
 
+        params.env.subscribe::<DerpLatencyMeasurement>(&slf).await?;
         DerpLatencyMeasurer::spawn_link(&slf, params.env.clone()).await;
 
-        params.env.subscribe::<DerpLatencyMeasurement>(&slf).await?;
         slf.attach_stream(stream.boxed(), (), ());
 
         Ok(Self {

--- a/ts_runtime/src/lib.rs
+++ b/ts_runtime/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate ts_netstack_smoltcp as netstack;
 
 use core::time::Duration;
+use std::sync::Arc;
 
 use kameo::{
     actor::{ActorRef, Spawn, WeakActorRef},
@@ -23,6 +24,7 @@ mod derp_latency;
 mod env;
 mod error;
 mod multiderp;
+mod netmon;
 mod netstack_actor;
 mod packetfilter;
 pub mod peer_tracker;
@@ -66,6 +68,11 @@ impl Runtime {
         route_updater::RouteUpdater::spawn((multiderp.clone(), env.clone(), netstack_id));
         packetfilter::PacketfilterUpdater::spawn(env.clone());
         src_filter::SourceFilterUpdater::spawn(env.clone());
+
+        if let Some(mon) = ts_netmon::platform_mon() {
+            netmon::NetmonActor::spawn((env.clone(), Arc::new(mon)));
+        }
+
         let peer_tracker = PeerTracker::spawn(env.clone()).downgrade();
 
         let netstack =

--- a/ts_runtime/src/netmon.rs
+++ b/ts_runtime/src/netmon.rs
@@ -1,0 +1,335 @@
+use std::{
+    collections::HashMap,
+    io,
+    sync::{Arc, atomic::AtomicUsize},
+    time::Duration,
+};
+
+use futures::StreamExt;
+use kameo::{
+    Actor,
+    actor::ActorRef,
+    message::{Context, Message, StreamMessage},
+};
+use ts_netmon::{Event, Family, InterfaceId, Netmon};
+
+use crate::env::Env;
+
+pub struct NetmonActor {
+    mon: Arc<dyn Netmon>,
+    state: State,
+    env: Env,
+    _id: Id,
+}
+
+/// Map from the unique part of a route to its metric.
+pub type Routes = HashMap<ts_netmon::RouteUnique, usize>;
+
+/// The unique id of a [`NetmonActor`] instance.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Id {
+    pub ty: ts_netmon::MonType,
+    pub id: usize,
+}
+
+impl Id {
+    fn new(ty: ts_netmon::MonType) -> Self {
+        static ID: AtomicUsize = AtomicUsize::new(0);
+
+        Self {
+            ty,
+            id: ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+        }
+    }
+}
+
+/// Netmon state at a point in time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct State {
+    /// The id of the [`NetmonActor`] that generated this [`State`].
+    pub id: Id,
+
+    /// Interfaces detected on a [`Netmon`].
+    pub interfaces: HashMap<InterfaceId, ts_netmon::Interface>,
+
+    /// Routes per interface.
+    pub routes: HashMap<InterfaceId, Routes>,
+
+    /// Addresses per interface.
+    ///
+    /// To recover the full address with the prefix len, use key's `addr()` as the address
+    /// and the value as the prefix len.
+    ///
+    /// The representation is split this way to support [`Netmon::interface_unique_addrs`].
+    pub addrs: HashMap<InterfaceId, HashMap<ipnet::IpNet, u8>>,
+
+    /// The interface that has the IPv4 default route, if any.
+    pub default_route_interface_v4: Option<InterfaceId>,
+
+    /// The interface that has the IPv6 default route, if any.
+    pub default_route_interface_v6: Option<InterfaceId>,
+}
+
+#[expect(dead_code)]
+impl State {
+    /// Iterate the addresses on all interfaces in the `up` state.
+    pub fn up_addrs(&self) -> impl Iterator<Item = (InterfaceId, ipnet::IpNet)> {
+        self.addrs
+            .iter()
+            .filter_map(|(id, addrs)| {
+                let interface = self.interfaces.get(id)?;
+                if !interface.up {
+                    return None;
+                }
+
+                Some(
+                    addrs
+                        .iter()
+                        .map(|(ipn, &pfx)| (id.clone(), ipnet::IpNet::new_assert(ipn.addr(), pfx))),
+                )
+            })
+            .flatten()
+    }
+
+    /// Iterate the routes on all interfaces in the `up` state.
+    pub fn up_routes(&self) -> impl Iterator<Item = (InterfaceId, ts_netmon::Route)> {
+        self.routes
+            .iter()
+            .filter_map(|(id, routes)| {
+                let interface = self.interfaces.get(id)?;
+                if !interface.up {
+                    return None;
+                }
+
+                Some(routes.iter().map(|((dst, gws), &metric)| {
+                    (
+                        id.clone(),
+                        ts_netmon::Route {
+                            gateway: gws.clone(),
+                            metric,
+                            dst: *dst,
+                        },
+                    )
+                }))
+            })
+            .flatten()
+    }
+}
+
+impl Actor for NetmonActor {
+    type Args = (Env, Arc<dyn Netmon>);
+    type Error = io::Error;
+
+    async fn on_start((env, mon): Self::Args, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
+        let id = Id::new(mon.ty());
+
+        slf.attach_stream(
+            {
+                use tokio_stream::StreamExt;
+
+                mon.with_default_route_events()?
+                    .chunks_timeout(256, Duration::from_millis(100))
+                    .boxed()
+            },
+            (),
+            (),
+        );
+
+        Ok(Self {
+            env,
+            mon,
+            state: State {
+                id: id.clone(),
+                addrs: Default::default(),
+                routes: Default::default(),
+                interfaces: Default::default(),
+                default_route_interface_v4: None,
+                default_route_interface_v6: None,
+            },
+            _id: id,
+        })
+    }
+}
+
+impl Message<StreamMessage<Vec<io::Result<Event>>, (), ()>> for NetmonActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: StreamMessage<Vec<io::Result<Event>>, (), ()>,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) {
+        let events = match msg {
+            StreamMessage::Started(_) | StreamMessage::Finished(_) => {
+                return;
+            }
+            StreamMessage::Next(val) => val,
+        };
+
+        if events.is_empty() {
+            tracing::warn!("empty netmon event");
+            return;
+        }
+
+        let mut modified = false;
+
+        for event in &events {
+            let event_modified = self.handle_event(event);
+            if event_modified {
+                tracing::trace!(mutating_netmon_event = ?event);
+            }
+
+            modified = modified || event_modified;
+        }
+
+        if !modified {
+            return;
+        }
+
+        tracing::debug!(n_coalesced_events = events.len(), "netmon mutation");
+
+        self.env
+            .publish(Arc::new(self.state.clone()))
+            .await
+            .unwrap();
+    }
+}
+
+impl NetmonActor {
+    fn handle_event(&mut self, event: &io::Result<Event>) -> bool {
+        let event = match event {
+            Ok(event) => event,
+            Err(e) => {
+                tracing::error!(error = %e, "netmon error");
+                return false;
+            }
+        };
+
+        let mut modified = false;
+
+        match &event {
+            Event::RouteUpsert(interface, route) => {
+                let old = self
+                    .state
+                    .routes
+                    .entry(interface.clone())
+                    .or_default()
+                    .insert(route.unique(), route.metric);
+
+                modified = old.is_none_or(|old| old != route.metric);
+            }
+            Event::RouteRemoved(interface, route) => {
+                let mut empty = false;
+
+                self.state.routes.entry(interface.clone()).and_modify(|r| {
+                    modified = r.remove(&route.unique()).is_some();
+                    empty = r.is_empty();
+                });
+
+                if empty {
+                    self.state.routes.remove(interface);
+                }
+            }
+            Event::AddrUpsert(interface, addr) => {
+                let (addr, pfx_len) = self.split_interface_addr(addr);
+
+                let old = self
+                    .state
+                    .addrs
+                    .entry(interface.clone())
+                    .or_default()
+                    .insert(addr, pfx_len);
+
+                modified = old.is_none_or(|old| old != pfx_len);
+            }
+            Event::AddrRemoved(interface, addr) => {
+                let mut empty = false;
+                let (addr, _pfx_len) = self.split_interface_addr(addr);
+
+                self.state.addrs.entry(interface.clone()).and_modify(|e| {
+                    modified = e.remove(&addr).is_some();
+                    empty = e.is_empty();
+                });
+
+                if empty {
+                    self.state.addrs.remove(interface);
+                }
+            }
+            Event::InterfaceUpsert(interface) => {
+                let old = self
+                    .state
+                    .interfaces
+                    .insert(interface.id.clone(), interface.clone());
+
+                modified = old.is_none_or(|old| &old != interface);
+            }
+            Event::InterfaceRemoved(interface) => {
+                self.state.interfaces.retain(|x, _| {
+                    let ret = x != interface;
+                    if !ret {
+                        modified = true;
+                    }
+
+                    ret
+                });
+
+                // NOTE(npry): the below modification of routes and addrs on link deletion is due to
+                // divergence in platform behavior:
+                //
+                // - rtnetlink has a strongly-consistent event ordering model (as it's a single
+                //   reliable socket) that orders route and address deletion events before link
+                //   deletions, but it doesn't seem to _guarantee_ individual deletions for all
+                //   routes and addresses related to a link when it's deleted; the link deletion
+                //   itself seems to be intended to clean those up.
+                // - Win32 notify APIs are, on the other hand, free to race between route, address,
+                //   and link modifications, but are ordered within each logical resource stream and
+                //   appear to exhaustively issue deletion events for all routes and addresses _at
+                //   some point_ when a link is deleted. The link deletion event, however, may issue
+                //   in an arbitrary order wrt. the other events. The implication of this is that we
+                //   technically shouldn't proactively delete the other resources when the link is
+                //   removed, since we could be deleting routes and addresses related to a future
+                //   generation of the link in a race condition.
+                //
+                // This logic is meant to rectify that and make our state reflect what the platform
+                // has told us it should be regardless of the underlying consistency model.
+                if self.mon.strong_delete_consistency() {
+                    modified = modified || self.state.routes.remove(interface).is_some();
+                    modified = modified || self.state.addrs.remove(interface).is_some();
+                }
+            }
+            Event::DefaultRouteInterface(iface, family) => {
+                let pre_v4 = self.state.default_route_interface_v4.clone();
+                let pre_v6 = self.state.default_route_interface_v6.clone();
+
+                match family {
+                    Family::Ipv4 => self.state.default_route_interface_v4 = iface.clone(),
+                    Family::Ipv6 => self.state.default_route_interface_v6 = iface.clone(),
+                }
+
+                if pre_v4 != self.state.default_route_interface_v4
+                    || pre_v6 != self.state.default_route_interface_v6
+                {
+                    modified = true;
+                }
+            }
+        }
+
+        if !modified {
+            tracing::trace!(?event, "netmon event with no delta");
+        }
+
+        modified
+    }
+
+    /// Split the interface addr according to [`Netmon::interface_unique_addrs`]:
+    ///
+    /// - If interface addresses are unique, returns (addr/0, prefix_len)
+    /// - If interface addresses are not unique, returns (addr/prefix_len, prefix_len)
+    fn split_interface_addr(&self, addr: &ipnet::IpNet) -> (ipnet::IpNet, u8) {
+        if self.mon.interface_unique_addrs() {
+            (ipnet::IpNet::new_assert(addr.addr(), 0), addr.prefix_len())
+        } else {
+            (*addr, addr.prefix_len())
+        }
+    }
+}


### PR DESCRIPTION
Write crate `ts_netmon`, which is organized around the `Netmon` trait, whose primary job is to return a `Stream<Item = ts_netmon::Event>`. The events are upserts and removals for routes, addresses, and interfaces, as well as the selection of a new "default route interface" (the interface that has the best-metric default route). The default route interface is the one we expect to use with STUN and NAT traversal.

Implementations are provided for Windows and Linux (macOS is stubbed pending me getting shipped a laptop to work on from IT). There is an actor that runs `Netmon` instances configured to run the platform `Netmon` if one exists, and aggregates the incoming `Events` to produce a `State`. Nothing subscribes to this actor right now; the direct UDP actor will do this to interpret what address(es) an unspecified (`0.0.0.0`/`::`) socket bind actually means (and then the port it bound on can be combined to report endpoints to control).

Closes #219

## Windows quirks

### consistency 

The Windows `Netmon` impl aggregates 3 separate streams of events (for routes, addresses, and interfaces respectively) into the one `Event` stream. These are not synchronized with each other by the Win32 platform; they're serviced by callbacks in automatically spawned threads behind the veil of the platform layer. As a result, there are no ordering guarantees (see `ts_netmon/examples/win32_raw_monitor.rs` for an example that proves this), but we do expect to get all events for all resources (by contrast to rtnetlink, which skips deleting some link-associated resources when it deletes the link). 

This behavior is indicated by a method on `Netmon` and resolved by accepting that our view of interface state may be briefly inconsistent (which is true anyway, since AF_NETLINK and AF_ROUTE sockets deliver messages serially, even if they arrive in a batch). This is optimistically mitigated by time-bucketing `Event`s in the actor in increments of 100ms. Empirically, this tends to catch the whole batch of updates from interface creation, deletion, or state change unless you're doing something like joining or leaving the corp tailnet.

### interface address uniqueness

Windows also treats the _address_ as unique on a network interface, e.g. the address bits for `1.2.3.4` can only appear once on a given network interface, even if you wanted to have multiple addresses with different netmasks. Linux permits this, i.e. you can `ip a add 1.2.3.4/24` and then `ip a add 1.2.3.4/20` and both addresses appear distinctly and can be deleted independently. Whereas in Windows, you can mutate the prefix bits _in-place_ because the address bits are the unique identifier. So we need different tracking behavior between the two platforms; this is implemented in the `NetlinkActor` state aggregation logic and indicated by a `Netmon` method.