### PR TITLE
runtime: run periodic ipv4 stuns for public ip

### DIFF
--- a/ts_runtime/src/control_runner.rs
+++ b/ts_runtime/src/control_runner.rs
@@ -39,7 +39,7 @@ pub struct Params {
 }
 
 #[doc(hidden)]
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum ControlRunnerError {
     #[error(transparent)]
     Control(#[from] ControlError),

--- a/ts_runtime/src/env.rs
+++ b/ts_runtime/src/env.rs
@@ -4,7 +4,10 @@ use kameo::{
     actor::{ActorRef, Spawn},
     message::Message,
 };
-use kameo_actors::message_bus::{MessageBus, Publish, Register};
+use kameo_actors::{
+    message_bus::{MessageBus, Publish, Register},
+    scheduler::Scheduler,
+};
 use tokio::sync::watch;
 
 use crate::{Error, error::ResultExt};
@@ -12,6 +15,8 @@ use crate::{Error, error::ResultExt};
 #[derive(Clone)]
 pub struct Env {
     pub bus: ActorRef<MessageBus>,
+    pub scheduler: ActorRef<Scheduler>,
+
     pub keys: Arc<ts_keys::NodeState>,
 
     /// Whether the runtime is shutdown.
@@ -29,6 +34,7 @@ impl Env {
     pub fn new(keys: ts_keys::NodeState, shutdown: watch::Receiver<bool>) -> Self {
         Self {
             bus: MessageBus::spawn_default(),
+            scheduler: Scheduler::spawn_default(),
             keys: Arc::new(keys),
             shutdown,
         }

--- a/ts_runtime/src/error.rs
+++ b/ts_runtime/src/error.rs
@@ -3,7 +3,7 @@ use core::fmt::{Formatter, Write};
 use kameo::{
     Actor,
     actor::{ActorRef, WeakActorRef},
-    error::SendError,
+    error::{HookError, SendError},
 };
 
 pub(crate) trait ResultExt {
@@ -87,6 +87,26 @@ impl<M, E> From<SendError<M, E>> for Error {
             kind: err.into(),
             message_ty: Some(core::any::type_name::<M>()),
             target_actor: None,
+        }
+    }
+}
+
+impl<E> From<HookError<E>> for Error {
+    fn from(value: HookError<E>) -> Self {
+        // TODO(npry): due to https://github.com/tqwewe/kameo/pull/340, we _must not_ access `e`'s
+        // internals if it's a panic error and this function may be called via with_startup_result
+        // or any of the other `ActorRef::*_with_*` callback functions.
+        match value {
+            HookError::Error(_) => Self {
+                kind: ErrorKind::ReplyErr,
+                target_actor: None,
+                message_ty: Some("ActorStartOrStop"),
+            },
+            HookError::Panicked(_) => Self {
+                kind: ErrorKind::ActorGone,
+                target_actor: None,
+                message_ty: Some("ActorStartOrStop"),
+            },
         }
     }
 }

--- a/ts_runtime/src/lib.rs
+++ b/ts_runtime/src/lib.rs
@@ -37,6 +37,62 @@ pub use error::{Error, ErrorKind};
 
 use crate::peer_tracker::PeerTracker;
 
+/// Wait for all of the listed [`ActorRef`]s to start, ensuring they haven't failed.
+///
+/// TODO(npry): we only do this this way because we don't currently have a supervision tree and any
+/// of these actors failing to start means that the runtime is permanently compromised. In the
+/// future, it should not be a fatal error to start up the runtime if your underlay network is
+/// offline, where it currently is because e.g. control will fail its on_start if it can't connect,
+/// so it will just be dead forever, making your runtime unusable.
+///
+/// So long as we're lacking the supervision functionality, it's better to fail early/fast like this
+/// and have it take down the whole runtime before it starts rather than living with a
+/// silently-degraded one; the actors being dead would only be surfaced later when something tried
+/// to talk to them.
+macro_rules! try_join_startup {
+    ($([$($optaref:ident)*] $(,)?)? $($aref:ident),* $(,)?) => {
+        {
+            tokio::try_join![
+                $(
+                    $(
+                        match $optaref.as_ref() {
+                            Some(aref) => {
+                                Box::pin(map_startup_result(aref)) as core::pin::Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>
+                            },
+                            None => {
+                                Box::pin(core::future::ready(Ok(()))) as core::pin::Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>
+                            }
+                        },
+                    )*
+                )?
+                $(
+                    map_startup_result(&$aref),
+                )*
+            ]
+        }
+    }
+}
+
+async fn map_startup_result<A>(aref: &ActorRef<A>) -> Result<(), Error>
+where
+    A: kameo::Actor,
+    A::Error: core::error::Error,
+{
+    aref.wait_for_startup_with_result(|r| {
+        r.map_err(|e| {
+            // TODO(npry): due to https://github.com/tqwewe/kameo/pull/340, we _must not_ access
+            // `e`'s internals (via Debug, Display, or a field access) in this closure scope if it's
+            // a panic error or it will deadlock this thread. `Error::from` upholds this invariant
+            // (and drops the error, so it won't cause the issue later on), but we don't want to
+            // print it as part of this trace for now.
+            tracing::error!(actor = ?aref, "startup for actor failed");
+
+            Error::from(e).with_actor_info(aref.clone())
+        })
+    })
+    .await
+}
+
 /// The runtime for a tailscale device.
 pub struct Runtime {
     /// Reference to the control actor.
@@ -66,16 +122,16 @@ impl Runtime {
 
         let multiderp = Multiderp::spawn((env.clone(), dataplane.clone()));
 
-        route_updater::RouteUpdater::spawn((multiderp.clone(), env.clone(), netstack_id));
-        packetfilter::PacketfilterUpdater::spawn(env.clone());
-        src_filter::SourceFilterUpdater::spawn(env.clone());
-        stunner::Stunner::spawn(env.clone());
+        let rt_upd =
+            route_updater::RouteUpdater::spawn((multiderp.clone(), env.clone(), netstack_id));
+        let pf_upd = packetfilter::PacketfilterUpdater::spawn(env.clone());
+        let src_upd = src_filter::SourceFilterUpdater::spawn(env.clone());
+        let stunner = stunner::Stunner::spawn(env.clone());
 
-        if let Some(mon) = ts_netmon::platform_mon() {
-            netmon::NetmonActor::spawn((env.clone(), Arc::new(mon)));
-        }
+        let netmon = ts_netmon::platform_mon()
+            .map(|mon| netmon::NetmonActor::spawn((env.clone(), Arc::new(mon))));
 
-        let peer_tracker = PeerTracker::spawn(env.clone()).downgrade();
+        let peer_tracker = PeerTracker::spawn(env.clone());
 
         let netstack =
             NetstackActor::spawn((env.clone(), Default::default(), netstack_up, netstack_down));
@@ -86,14 +142,32 @@ impl Runtime {
             env: env.clone(),
         });
 
-        Ok(Self {
-            control,
-            dataplane,
-            peer_tracker,
+        // Construct the Runtime _before_ awaiting all actor startups so we get the cleanup in its
+        // Drop for free.
+        let rt = Self {
+            control: control.clone(),
+            dataplane: dataplane.clone(),
+            peer_tracker: peer_tracker.downgrade(),
             netstack: netstack.downgrade(),
             env,
             shutdown: shutdown_tx,
-        })
+        };
+
+        tracing::trace!("waiting for actors to finish starting");
+        try_join_startup![
+            [netmon],
+            dataplane,
+            rt_upd,
+            pf_upd,
+            src_upd,
+            stunner,
+            peer_tracker,
+            netstack,
+            control,
+        ]?;
+        tracing::trace!("all root actors started ok");
+
+        Ok(rt)
     }
 
     /// Get a channel to send commands to the netstack.

--- a/ts_runtime/src/lib.rs
+++ b/ts_runtime/src/lib.rs
@@ -30,6 +30,7 @@ mod packetfilter;
 pub mod peer_tracker;
 mod route_updater;
 mod src_filter;
+mod stunner;
 
 pub(crate) use env::Env;
 pub use error::{Error, ErrorKind};
@@ -68,6 +69,7 @@ impl Runtime {
         route_updater::RouteUpdater::spawn((multiderp.clone(), env.clone(), netstack_id));
         packetfilter::PacketfilterUpdater::spawn(env.clone());
         src_filter::SourceFilterUpdater::spawn(env.clone());
+        stunner::Stunner::spawn(env.clone());
 
         if let Some(mon) = ts_netmon::platform_mon() {
             netmon::NetmonActor::spawn((env.clone(), Arc::new(mon)));
@@ -124,11 +126,13 @@ impl Runtime {
             let _ignore = runtime.control.stop_gracefully().await;
             let _ignore = runtime.dataplane.stop_gracefully().await;
             let _ignore = runtime.env.bus.stop_gracefully().await;
+            let _ignore = runtime.env.scheduler.stop_gracefully().await;
 
             tokio::join![
                 runtime.control.wait_for_shutdown(),
                 runtime.dataplane.wait_for_shutdown(),
                 runtime.env.bus.wait_for_shutdown(),
+                runtime.env.scheduler.wait_for_shutdown(),
             ];
         }
 
@@ -153,6 +157,7 @@ impl Drop for Runtime {
             self.control.kill();
             self.dataplane.kill();
             self.env.bus.kill();
+            self.env.scheduler.kill();
             return;
         }
 
@@ -169,6 +174,7 @@ impl Drop for Runtime {
 
         // Then shutdown the message bus, stopping the rest of the actors:
         try_shutdown(&self.env.bus);
+        try_shutdown(&self.env.scheduler);
     }
 }
 

--- a/ts_runtime/src/stunner.rs
+++ b/ts_runtime/src/stunner.rs
@@ -21,6 +21,7 @@ pub struct Stunner {
 }
 
 impl Stunner {
+    #[tracing::instrument(skip_all, fields(n_server = self.servers.len()), level = "trace")]
     async fn try_stun(&self) {
         for &server in &self.servers {
             if let Ok(Ok((_dur, x))) =

--- a/ts_runtime/src/stunner.rs
+++ b/ts_runtime/src/stunner.rs
@@ -1,0 +1,142 @@
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use kameo::{
+    actor::ActorRef,
+    message::{Context, Message},
+};
+use tokio::time::MissedTickBehavior;
+use ts_derp::IpUsage;
+
+use crate::env::Env;
+
+/// Actor that sends STUN requests to DERP servers to get this node's public IPv4.
+pub struct Stunner {
+    env: Env,
+    stun: Arc<ts_netcheck::StunProber>,
+    servers: Vec<SocketAddr>,
+}
+
+impl Stunner {
+    async fn try_stun(&self) {
+        for &server in &self.servers {
+            if let Ok(Ok((_dur, x))) =
+                tokio::time::timeout(Duration::from_secs(3), self.stun.measure(server)).await
+            {
+                tracing::debug!(stun_addr = %x);
+
+                self.env
+                    .publish(StunAddress {
+                        addr: x.ip(),
+                        measured: Instant::now(),
+                    })
+                    .await
+                    .unwrap();
+
+                return;
+            }
+        }
+
+        tracing::warn!("failed to stun");
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct StunAddress {
+    pub addr: IpAddr,
+    pub measured: Instant,
+}
+
+#[derive(Copy, Clone)]
+struct Tick;
+
+impl kameo::Actor for Stunner {
+    type Error = crate::Error;
+    type Args = Env;
+
+    async fn on_start(env: Self::Args, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
+        // panicking in on_start is fine, this is checked as part of Runtime::spawn
+        let stun = ts_netcheck::StunProber::try_new().await.unwrap();
+        env.subscribe::<Arc<ts_control::StateUpdate>>(&slf).await?;
+
+        env.scheduler
+            .tell(
+                kameo_actors::scheduler::SetInterval::new(
+                    slf.downgrade(),
+                    Duration::from_secs(20),
+                    Tick,
+                )
+                .set_missed_tick_behaviour(MissedTickBehavior::Skip),
+            )
+            .await?;
+
+        Ok(Self {
+            env,
+            servers: vec![],
+            stun: Arc::new(stun),
+        })
+    }
+}
+
+impl Message<Tick> for Stunner {
+    type Reply = ();
+
+    async fn handle(&mut self, _: Tick, _ctx: &mut Context<Self, Self::Reply>) {
+        self.try_stun().await;
+    }
+}
+
+impl Message<Arc<ts_control::StateUpdate>> for Stunner {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        state_update: Arc<ts_control::StateUpdate>,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let Some(derp_map) = &state_update.derp else {
+            return;
+        };
+
+        let was_empty = self.servers.is_empty();
+        self.servers.clear();
+
+        for region in derp_map.values() {
+            for server in &region.servers {
+                let Some(stun_port) = server.stun_port else {
+                    continue;
+                };
+
+                let addr = match server.ipv4 {
+                    IpUsage::FixedAddr(a) => (a, stun_port).into(),
+                    IpUsage::UseDns => {
+                        let addr = tokio::net::lookup_host((server.hostname.as_str(), stun_port))
+                            .await
+                            .ok()
+                            .and_then(|mut x| x.next());
+
+                        let Some(addr) = addr else {
+                            continue;
+                        };
+
+                        addr
+                    }
+                    _ => continue,
+                };
+
+                tracing::trace!(%addr, "identified stun server");
+                self.servers.push(addr);
+            }
+        }
+
+        tracing::debug!(n_server = self.servers.len(), "updated stun servers");
+
+        if was_empty && !self.servers.is_empty() {
+            tracing::trace!("stun server set became populated, trying stun now");
+            self.try_stun().await;
+        }
+    }
+}


### PR DESCRIPTION
stacked on #214

Provide an actor that runs periodic stuns to a derp server to get our public ipv4 and publishes the response on the message bus.

Nothing currently consumes the messages, but this is needed for future commits re: direct connections. In the future the internals may change slightly to reuse the single UDP endpoint socket rather than using a dedicated stun socket, but this should be fine for now.