### PR TITLE
dataplane: split out derp and stun traffic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "896dc69748b78a3bc4b815084e15cb51efdedc22a6d0ef5a443f6bd5e92af89a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "bitrs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad65ba2eda683a8486f72c13f0e1f5afbaa99ccd08029e6a72b1cf46ef0f0309"
+dependencies = [
+ "bitrs-macro",
+ "zerocopy",
+]
+
+[[package]]
+name = "bitrs-macro"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "896dc69748b78a3bc4b815084e15cb51efdedc22a6d0ef5a443f6bd5e92af89a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5914,10 +5935,13 @@ dependencies = [
 name = "ts_dataplane"
 version = "0.4.0"
 dependencies = [
+ "bitrs",
+ "bytes",
  "etherparse",
  "tokio",
  "tracing",
  "ts_bart",
+ "ts_disco_protocol",
  "ts_overlay_router",
  "ts_packet",
  "ts_packetfilter",

--- a/ts_dataplane/Cargo.toml
+++ b/ts_dataplane/Cargo.toml
@@ -24,10 +24,13 @@ ts_transport.workspace = true
 ts_underlay_router.workspace = true
 ts_tunnel.workspace = true
 ts_bart.workspace = true
+ts_disco_protocol.workspace = true
 
 # Unconditionally required dependencies.
+bytes.workspace = true
 etherparse = "0.19"
 tracing.workspace = true
+bitrs = "0.11"
 
 # Required dependencies for the async_tokio feature.
 tokio = { workspace = true, optional = true, features = ["time", "sync"] }

--- a/ts_dataplane/src/async_tokio.rs
+++ b/ts_dataplane/src/async_tokio.rs
@@ -28,6 +28,11 @@ pub type ToUnderlay = (PeerId, Vec<PacketMut>);
 /// Packet batches received from an underlay.
 pub type FromUnderlay = Vec<PacketMut>;
 
+/// A batch of disco packets received from an underlay transport.
+pub type DiscoBatch = Vec<PacketMut>;
+/// A batch of stun packets received from an underlay transport.
+pub type StunBatch = Vec<PacketMut>;
+
 /// Shorthand for a sender channel.
 pub type Tx<T> = mpsc::UnboundedSender<T>;
 
@@ -58,6 +63,11 @@ struct CoreState {
     overlay_transports: HashMap<OverlayTransportId, Tx<ToOverlay>>,
     /// Queues to write packets to underlay transports.
     underlay_transports: HashMap<UnderlayTransportId, Tx<ToUnderlay>>,
+
+    /// Send handle for disco packets received from underlays.
+    disco_out: Tx<DiscoBatch>,
+    /// Send handle for stun packets received from underlays.
+    stun_out: Tx<StunBatch>,
 }
 
 /// State that must be held during async polling.
@@ -73,13 +83,19 @@ impl DataPlane {
     ///
     /// The caller must configure overlay/underlay output queues for the data plane to be useful,
     /// otherwise all it can do is drop packets.
-    pub fn new(my_key: NodeKeyPair) -> Self {
+    ///
+    /// The second and third elements of the return tuple are output queues for disco and
+    /// STUN messages, respectively.
+    pub fn new(my_key: NodeKeyPair) -> (Self, Rx<DiscoBatch>, Rx<StunBatch>) {
         let (overlay_up, overlay_down) = mpsc::unbounded_channel();
         let (underlay_down, underlay_up) = mpsc::unbounded_channel();
 
+        let (disco_tx, disco_rx) = mpsc::unbounded_channel();
+        let (stun_tx, stun_rx) = mpsc::unbounded_channel();
+
         let sync = crate::DataPlane::new(my_key);
 
-        Self {
+        let dp = Self {
             underlay_down,
             overlay_up,
 
@@ -90,6 +106,8 @@ impl DataPlane {
 
             core_state: Mutex::new(CoreState {
                 sync,
+                stun_out: stun_tx,
+                disco_out: disco_tx,
                 overlay_transports: Default::default(),
                 underlay_transports: Default::default(),
             }),
@@ -98,7 +116,9 @@ impl DataPlane {
                 from_overlay: overlay_down,
                 from_underlay: underlay_up,
             }),
-        }
+        };
+
+        (dp, disco_rx, stun_rx)
     }
 
     /// Allocate a new underlay transport.
@@ -230,7 +250,20 @@ impl DataPlane {
                 (Some(to_peers), Some(loopback))
             }
             SelectResult::UnderlayUp(underlay_up) => {
-                let InboundResult { to_local, to_peers } = core.sync.process_inbound(underlay_up);
+                let InboundResult {
+                    to_local,
+                    to_peers,
+                    disco,
+                    stun,
+                } = core.sync.process_inbound(underlay_up);
+
+                if !disco.is_empty() && core.disco_out.send(disco).is_err() {
+                    tracing::warn!("disco packets dropped: no receiver");
+                }
+
+                if !stun.is_empty() && core.stun_out.send(stun).is_err() {
+                    tracing::warn!("stun packets dropped: no receiver");
+                }
 
                 (Some(to_peers), Some(to_local))
             }

--- a/ts_dataplane/src/async_tokio.rs
+++ b/ts_dataplane/src/async_tokio.rs
@@ -9,19 +9,30 @@ use ts_tunnel::NodeKeyPair;
 
 use crate::{EventResult, InboundResult, OutboundResult};
 
-/// Queue for packets leaving the data plane "up" into an overlay transport.
-pub type DataplaneToOverlay = mpsc::UnboundedSender<Vec<PacketMut>>;
+// NOTE(npry): this used to have unique types for each queue, but the names got confusing due to
+// having to think about the cartesian product of PacketType x QueueDirection x Network
+// (this is a "sender handle for receive packets on the overlay", vs. "receive handle for sender
+// packets on the overlay", etc.). It wasn't always clear to distinguish what referred to the
+// channel direction (sender/receiver) and what referred to the actual traffic kind (packets
+// received _from_ the underlay are different from packets sent _to_ the underlay). So now we name
+// the packet type here (to/from overlay/underlay) and use separate helper types to make the channel
+// directions easier to name.
 
-/// Queue for packets entering the data plane "down" from an overlay transport.
-pub type DataplaneFromOverlay = mpsc::UnboundedReceiver<Vec<PacketMut>>;
+/// Packet batches sent to an overlay.
+pub type ToOverlay = Vec<PacketMut>;
+/// Packet batches received from an overlay.
+pub type FromOverlay = Vec<PacketMut>;
 
-/// Queue for packets leaving the data plane "down" into an underlay transport.
-pub type DataplaneToUnderlay = mpsc::UnboundedSender<(PeerId, Vec<PacketMut>)>;
+/// Packet batches sent to an underlay.
+pub type ToUnderlay = (PeerId, Vec<PacketMut>);
+/// Packet batches received from an underlay.
+pub type FromUnderlay = Vec<PacketMut>;
 
-/// Queue for packets entering the data plane "up" from an underlay transport.
-pub type DataplaneFromUnderlay = mpsc::UnboundedReceiver<(PeerId, Vec<PacketMut>)>;
+/// Shorthand for a sender channel.
+pub type Tx<T> = mpsc::UnboundedSender<T>;
 
-// TODO: wire in overlay/underlay transport traits
+/// Shorthand for a receiver channel.
+pub type Rx<T> = mpsc::UnboundedReceiver<T>;
 
 /// Transforms packets to make tailscale happen.
 pub struct DataPlane {
@@ -30,8 +41,10 @@ pub struct DataPlane {
 
     transports_changed: tokio::sync::Notify,
 
-    underlay_down: DataplaneToUnderlay,
-    overlay_up: DataplaneToOverlay,
+    // These are the senders handed out in new_*_transport, just held here so we can clone them, we
+    // never send to them.
+    underlay_down: Tx<FromUnderlay>,
+    overlay_up: Tx<FromOverlay>,
 
     next_underlay_transport: AtomicU32,
     next_overlay_transport: AtomicU32,
@@ -42,17 +55,17 @@ struct CoreState {
     sync: crate::DataPlane,
 
     /// Queues to write packets to overlay transports.
-    overlay_transports: HashMap<OverlayTransportId, DataplaneToOverlay>,
+    overlay_transports: HashMap<OverlayTransportId, Tx<ToOverlay>>,
     /// Queues to write packets to underlay transports.
-    underlay_transports: HashMap<UnderlayTransportId, DataplaneToUnderlay>,
+    underlay_transports: HashMap<UnderlayTransportId, Tx<ToUnderlay>>,
 }
 
 /// State that must be held during async polling.
 struct PollState {
     /// Queue for packets entering the data plane ("coming down") from overlay transports.
-    from_overlay: DataplaneFromOverlay,
+    from_overlay: Rx<FromOverlay>,
     /// Queue for packets entering the data plane ("coming up") from underlay transports.
-    from_underlay: DataplaneFromUnderlay,
+    from_underlay: Rx<FromUnderlay>,
 }
 
 impl DataPlane {
@@ -89,13 +102,12 @@ impl DataPlane {
     }
 
     /// Allocate a new underlay transport.
+    ///
+    /// The channels handed back are for an underlay to receive messages from the dataplane
+    /// (`ToUnderlay`) and send messages to the dataplane (`FromUnderlay`).
     pub async fn new_underlay_transport(
         &self,
-    ) -> (
-        UnderlayTransportId,
-        DataplaneFromUnderlay,
-        DataplaneToUnderlay,
-    ) {
+    ) -> (UnderlayTransportId, Rx<ToUnderlay>, Tx<FromUnderlay>) {
         let id = self
             .next_underlay_transport
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
@@ -114,9 +126,12 @@ impl DataPlane {
     }
 
     /// Allocate a new overlay transport.
+    ///
+    /// The channels handed back are for an overlay to send messages to the dataplane
+    /// (`FromOverlay`) and receive messages from the dataplane (`ToOverlay`).
     pub async fn new_overlay_transport(
         &self,
-    ) -> (OverlayTransportId, DataplaneToOverlay, DataplaneFromOverlay) {
+    ) -> (OverlayTransportId, Tx<FromOverlay>, Rx<ToOverlay>) {
         let id = self
             .next_overlay_transport
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
@@ -146,7 +161,7 @@ impl DataPlane {
     pub async fn step(&self) {
         enum SelectResult {
             OverlayDown(Vec<PacketMut>),
-            UnderlayUp(PeerId, Vec<PacketMut>),
+            UnderlayUp(Vec<PacketMut>),
             TransportsChanged,
             Event,
         }
@@ -185,10 +200,10 @@ impl DataPlane {
                 }
 
                 underlay_pkts = underlay_up.recv() => {
-                    let (peer_id, underlay_pkts) = underlay_pkts.unwrap();
-                    tracing::trace!(%peer_id, n_underlay_pkts = underlay_pkts.len());
+                    let underlay_pkts = underlay_pkts.unwrap();
+                    tracing::trace!(n_underlay_pkts = underlay_pkts.len());
 
-                    SelectResult::UnderlayUp(peer_id, underlay_pkts)
+                    SelectResult::UnderlayUp(underlay_pkts)
                 }
 
                 _ = self.transports_changed.notified() => {
@@ -214,7 +229,7 @@ impl DataPlane {
 
                 (Some(to_peers), Some(loopback))
             }
-            SelectResult::UnderlayUp(_peer_id, underlay_up) => {
+            SelectResult::UnderlayUp(underlay_up) => {
                 let InboundResult { to_local, to_peers } = core.sync.process_inbound(underlay_up);
 
                 (Some(to_peers), Some(to_local))

--- a/ts_dataplane/src/lib.rs
+++ b/ts_dataplane/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!("../README.md")]
 
+extern crate ts_disco_protocol as disco;
+
 use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use ts_bart::RoutingTable;
@@ -12,6 +14,9 @@ use ts_tunnel::{Endpoint, NodeKeyPair};
 use ts_underlay_router as ur;
 
 pub mod async_tokio;
+mod packet_ident;
+
+pub use packet_ident::{PacketIdent, PacketType};
 
 /// A data plane subsystem that can be the subject of timer events.
 pub enum Subsystem {

--- a/ts_dataplane/src/lib.rs
+++ b/ts_dataplane/src/lib.rs
@@ -101,8 +101,27 @@ impl DataPlane {
         &mut self,
         packets: impl IntoIterator<Item = PacketMut>,
     ) -> InboundResult {
+        let (wireguard, disco, stun) = packets.into_iter().fold(
+            (vec![], vec![], vec![]),
+            |(mut wg, mut disco, mut stun), pkt| {
+                let ident = PacketIdent::identify(pkt.as_ref());
+
+                match ident.ty {
+                    PacketType::Disco => {
+                        disco.push(pkt);
+                    }
+                    PacketType::StunBinding => {
+                        stun.push(pkt);
+                    }
+                    PacketType::Wireguard | PacketType::Unknown => wg.push(pkt),
+                }
+
+                (wg, disco, stun)
+            },
+        );
+
         let ts_tunnel::RecvResult { to_local, to_peers } =
-            self.wireguard.recv(Instant::now(), packets);
+            self.wireguard.recv(Instant::now(), wireguard);
 
         let to_local = to_local
             .into_iter()
@@ -201,7 +220,12 @@ impl DataPlane {
             prev.cancel();
         }
 
-        InboundResult { to_local, to_peers }
+        InboundResult {
+            to_local,
+            to_peers,
+            disco,
+            stun,
+        }
     }
 
     /// Return the next time at which [`DataPlane::process_events`] must be called.
@@ -261,6 +285,12 @@ pub struct InboundResult {
     pub to_local: HashMap<OverlayTransportId, Vec<PacketMut>>,
     /// Encrypted packets to be sent to wireguard peers by the underlay.
     pub to_peers: HashMap<(UnderlayTransportId, PeerId), Vec<PacketMut>>,
+
+    /// Encrypted disco packets to be handled externally.
+    pub disco: Vec<PacketMut>,
+
+    /// STUN packets to be handled externally.
+    pub stun: Vec<PacketMut>,
 }
 
 /// The result of processing an event.

--- a/ts_dataplane/src/packet_ident.rs
+++ b/ts_dataplane/src/packet_ident.rs
@@ -1,0 +1,192 @@
+use bytes::Buf;
+
+/// Heuristic identification of a packet.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct PacketIdent {
+    /// The type of the packet.
+    pub ty: PacketType,
+    /// Whether the packet is encapsulated.
+    pub encapsulation: Encapsulation,
+}
+
+/// Heuristically-determined packet type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub enum PacketType {
+    /// This is a Tailscale disco packet.
+    Disco,
+    /// This is a WireGuard packet.
+    Wireguard,
+    /// This is a STUN binding packet.
+    StunBinding,
+    /// The type of this packet is unknown.
+    ///
+    /// It should be dropped.
+    #[default]
+    Unknown,
+}
+
+/// The encapsulation format of a packet.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub enum Encapsulation {
+    /// Packet is not encapsulated.
+    #[default]
+    None,
+    /// Packet is encapsulated in a valid Geneve header.
+    Geneve(GeneveHeader),
+}
+
+impl Encapsulation {
+    /// Return the offset to the payload data contents.
+    ///
+    /// This skips any encapsulating header (currently Geneve) if present.
+    pub const fn payload_offset(&self) -> usize {
+        match self {
+            Encapsulation::None => 0,
+            Encapsulation::Geneve(geneve) => {
+                size_of::<GeneveHeader>() + (geneve.opt_len() * 4) as usize
+            }
+        }
+    }
+}
+
+impl PacketIdent {
+    /// Determine the type and encapsulation of `pkt`.
+    ///
+    /// This differs from the Go (`magicsock.go:packetLooksLike`) in that
+    /// `PacketType::Unknown` is separated from WireGuard traffic and means that the packet
+    /// is positively not interpretable as a known packet type. WireGuard is still the catchall, we
+    /// just verify the first few bytes of the message here using
+    /// [`PacketIdent::could_be_wireguard`].
+    pub fn identify(pkt: &[u8]) -> PacketIdent {
+        let geneve = Self::parse_geneve(pkt);
+        let geneve_ty = geneve.map(|x| x.packet_ty()).unwrap_or_default();
+
+        let encapsulation = geneve.map(Encapsulation::Geneve).unwrap_or_default();
+        let payload = &pkt[encapsulation.payload_offset()..];
+
+        let ty = if disco::is_disco_message(payload) {
+            PacketType::Disco
+        } else if Self::could_be_wireguard(payload) {
+            // Assume that all remaining traffic that could be a Wireguard packet is one.
+            PacketType::Wireguard
+        } else {
+            PacketType::Unknown
+        };
+
+        let ty = match (ty, geneve_ty) {
+            (x, y) if x == y => x,
+
+            // A single Unknown verdict resolves to the known packet type.
+            (PacketType::Unknown, x) | (x, PacketType::Unknown) => x,
+
+            // Packet inspection and Geneve disagreed.
+            _ => PacketType::Unknown,
+        };
+
+        Self { encapsulation, ty }
+    }
+
+    /// Attempt to parse `pkt` as a Geneve-encapsulated packet.
+    pub fn parse_geneve(mut pkt: &[u8]) -> Option<GeneveHeader> {
+        let b = pkt.try_get_u64().ok()?;
+
+        let header = GeneveHeader(b);
+        if !header.is_acceptable_data_packet() {
+            return None;
+        }
+
+        Some(header)
+    }
+
+    /// Report whether the packet could be a Wireguard packet.
+    ///
+    /// Checks certain invariants that must be true if this is Wireguard; does not establish
+    /// conclusive proof.
+    pub fn could_be_wireguard(pkt: &[u8]) -> bool {
+        if pkt.len() < 5 {
+            return false;
+        }
+
+        let msgty = pkt[0];
+        if !(1u8..=4).contains(&msgty) {
+            return false;
+        }
+
+        [0u8; 4] == pkt[1..=4]
+    }
+}
+
+bitrs::layout!({
+    /// Geneve encapsulation protocol header as described in [RFC8926].
+    ///
+    /// [RFC8926]: https://www.rfc-editor.org/info/rfc8926/#name-tunnel-header-fields.
+    pub struct GeneveHeader(pub u64);
+    {
+        /// The version of the Geneve packet.
+        ///
+        /// See [`GeneveHeader::VERSION`] for the current version.
+        let version @ 63..62;
+        /// The length of the variable-length options in multiples of 4 bytes. Excludes the length
+        /// of the header.
+        let opt_len @ 61..56;
+        /// This is a control packet.
+        let control @ 55;
+        /// This packet carries critical option fields that must be interpreted or else the packet
+        /// dropped.
+        let critical @ 54;
+        let __ @ 53..48 = 0;
+        /// The type of data encapsulated by the header.
+        let ethertype @ 47..32;
+        /// The virtual network identifier.
+        let vni @ 31..8;
+        /// Reserved field specified by the RFC to be zero on transmit, ignore on receive.
+        ///
+        /// Tailscale checks whether it is zeroed because we always zero it.
+        let trailer @ 7..0 = 0;
+    }
+});
+
+impl GeneveHeader {
+    /// Current version of the Geneve header.
+    pub const VERSION: u8 = 0;
+
+    /// Ethertype indicating this is a Tailscale disco message.
+    pub const PROTO_DISCO: u16 = 0x7a11;
+    /// Ethertype field indicating this is a WireGuard message.
+    pub const PROTO_WIREGUARD: u16 = 0x7a12;
+
+    /// Report whether this is a valid Geneve header.
+    ///
+    /// This checks both the version (against [`GeneveHeader::VERSION`]) and that the final reserved
+    /// field is zero. The RFC specifies that this field should be ignored on receipt, but we always
+    /// zero it, so sanity-check that it came from Tailscale.
+    pub const fn is_valid(&self) -> bool {
+        self.version() == Self::VERSION && self.trailer() == 0
+    }
+
+    /// Report whether this is an acceptable Tailscale data packet.
+    ///
+    /// Ensures that the packet [`is_valid`][GeneveHeader::is_valid], there are no options, this
+    /// isn't a control packet, and it doesn't have the critical options bit set.
+    pub const fn is_acceptable_data_packet(&self) -> bool {
+        // NOTE(npry): the Go doesn't filter on the control bit, but according to the RFC,
+        // "Control messages are sent between tunnel endpoints. Tunnel endpoints MUST NOT forward
+        // the payload." I take this to mean that control messages are treated as their own logical
+        // stream for configuring the tunnel itself, and I don't believe we use them. If this
+        // interpretation turns out to be incorrect, we'll just need to remove the control bit check
+        // in the future.
+
+        self.is_valid() && !self.control() && !self.critical() && self.opt_len() == 0
+    }
+
+    /// Report the [`PacketType`] encapsulated by this header.
+    ///
+    /// If the [`GeneveHeader::ethertype`] isn't recognized, [`PacketType::Unknown`] is returned.
+    pub const fn packet_ty(&self) -> PacketType {
+        match self.ethertype() {
+            Self::PROTO_DISCO => PacketType::Disco,
+            Self::PROTO_WIREGUARD => PacketType::Wireguard,
+            _ => PacketType::Unknown,
+        }
+    }
+}

--- a/ts_runtime/src/dataplane.rs
+++ b/ts_runtime/src/dataplane.rs
@@ -4,9 +4,8 @@ use kameo::{
     actor::{ActorRef, Spawn},
     message::{Context, Message},
 };
-use tokio::sync::mpsc;
-use ts_packet::PacketMut;
-use ts_transport::{OverlayTransportId, PeerId, UnderlayTransportId};
+use ts_dataplane::async_tokio::{FromOverlay, FromUnderlay, Rx, ToOverlay, ToUnderlay, Tx};
+use ts_transport::{OverlayTransportId, UnderlayTransportId};
 
 use crate::{
     Error, Task,
@@ -17,18 +16,6 @@ use crate::{
     src_filter::SourceFilterState,
 };
 
-/// Queue for packets sent from the overlay to the dataplane.
-pub type OverlayToDataplane = mpsc::UnboundedSender<Vec<PacketMut>>;
-
-/// Queue for packets entering the overlay from the dataplane.
-pub type OverlayFromDataplane = mpsc::UnboundedReceiver<Vec<PacketMut>>;
-
-/// Queue for packets leaving the underlay to the dataplane.
-pub type UnderlayToDataplane = mpsc::UnboundedSender<(PeerId, Vec<PacketMut>)>;
-
-/// Queue for packets entering an underlay from the dataplane.
-pub type UnderlayFromDataplane = mpsc::UnboundedReceiver<(PeerId, Vec<PacketMut>)>;
-
 pub struct DataplaneActor {
     dataplane: Arc<ts_dataplane::async_tokio::DataPlane>,
 }
@@ -38,18 +25,14 @@ impl DataplaneActor {
     #[message]
     pub async fn new_overlay_transport(
         &self,
-    ) -> (OverlayTransportId, OverlayToDataplane, OverlayFromDataplane) {
+    ) -> (OverlayTransportId, Tx<FromOverlay>, Rx<ToOverlay>) {
         self.dataplane.new_overlay_transport().await
     }
 
     #[message]
     pub async fn new_underlay_transport(
         &self,
-    ) -> (
-        UnderlayTransportId,
-        UnderlayFromDataplane,
-        UnderlayToDataplane,
-    ) {
+    ) -> (UnderlayTransportId, Rx<ToUnderlay>, Tx<FromUnderlay>) {
         self.dataplane.new_underlay_transport().await
     }
 }

--- a/ts_runtime/src/dataplane.rs
+++ b/ts_runtime/src/dataplane.rs
@@ -42,9 +42,8 @@ impl kameo::Actor for DataplaneActor {
     type Error = Error;
 
     async fn on_start(env: Self::Args, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
-        let dataplane = Arc::new(ts_dataplane::async_tokio::DataPlane::new(
-            env.keys.node_keys.clone(),
-        ));
+        let (dataplane, ..) = ts_dataplane::async_tokio::DataPlane::new(env.keys.node_keys.clone());
+        let dataplane = Arc::new(dataplane);
 
         env.subscribe::<PeerRouteUpdate>(&slf).await?;
         env.subscribe::<SelfRouteUpdate>(&slf).await?;

--- a/ts_runtime/src/multiderp/uniderp.rs
+++ b/ts_runtime/src/multiderp/uniderp.rs
@@ -12,6 +12,7 @@ use kameo::{
 use smol_str::SmolStr;
 use tokio::sync::{Mutex, watch};
 use ts_control::DerpRegion;
+use ts_dataplane::async_tokio::{FromUnderlay, Rx, ToUnderlay, Tx};
 use ts_derp::RegionId;
 use ts_keys::{NodeKeyPair, NodePublicKey};
 use ts_packet::PacketMut;
@@ -21,7 +22,7 @@ use ts_transport::{
 
 use crate::{
     Task,
-    dataplane::{DataplaneActor, NewUnderlayTransport, UnderlayFromDataplane, UnderlayToDataplane},
+    dataplane::{DataplaneActor, NewUnderlayTransport},
     derp_latency::DerpLatencyMeasurement,
     env::Env,
     multiderp::{Multiderp, SetRegionTransportId},
@@ -221,8 +222,8 @@ struct Runner {
     region_id: RegionId,
     region: DerpRegion,
     home_derp_rx: watch::Receiver<bool>,
-    to_dataplane: UnderlayToDataplane,
-    from_dataplane: Arc<Mutex<UnderlayFromDataplane>>,
+    to_dataplane: Tx<FromUnderlay>,
+    from_dataplane: Arc<Mutex<Rx<ToUnderlay>>>,
     peer_db: Arc<RwLock<Option<Arc<PeerDb>>>>,
     keys: NodeKeyPair,
 }
@@ -306,7 +307,7 @@ impl Runner {
 
                         tracing::trace!(parent: &span, %peer_id, len = pkts.len(), "packet from derp server");
 
-                        let Ok(()) = self.to_dataplane.send((peer_id, pkts)) else {
+                        let Ok(()) = self.to_dataplane.send(pkts) else {
                             tracing::error!(parent: &span, "underlay receive channel closed");
                             break;
                         };

--- a/ts_runtime/src/netstack_actor.rs
+++ b/ts_runtime/src/netstack_actor.rs
@@ -9,14 +9,10 @@ use netstack::{
     netcore::{Channel, NetstackControl},
 };
 use tokio::sync::Mutex;
+use ts_dataplane::async_tokio::{FromOverlay, Rx, ToOverlay, Tx};
 use ts_packet::PacketMut;
 
-use crate::{
-    Error,
-    dataplane::{OverlayFromDataplane, OverlayToDataplane},
-    env::Env,
-    task::Task,
-};
+use crate::{Error, env::Env, task::Task};
 
 pub struct NetstackActor {
     channel: Channel,
@@ -26,8 +22,8 @@ impl kameo::Actor for NetstackActor {
     type Args = (
         Env,
         netstack::netcore::Config,
-        OverlayToDataplane,
-        Arc<Mutex<OverlayFromDataplane>>,
+        Tx<FromOverlay>,
+        Arc<Mutex<Rx<ToOverlay>>>,
     );
     type Error = Error;
 


### PR DESCRIPTION
stacked on #214

Port packet identification logic from Go (wireguard vs disco vs stun), begin partitioning incoming packet stream by type. This isn't used in `runtime` yet &mdash; that integration depends on a bunch of other changes I made here so I'm holding off on PRing that until this round of changes merges.

This also eliminates the requirement for underlay transports to supply a peer id, as this is in general unnecessary since packets _must_ cryptographically authenticate themselves anyway, and it will simplify implementation for the UDP transport. Peer ids are still required to route _to_ a peer.