### PR TITLE
ts_runtime: don't try_stun if servers are empty

### DIFF
--- a/ts_runtime/src/stunner.rs
+++ b/ts_runtime/src/stunner.rs
@@ -23,6 +23,11 @@ pub struct Stunner {
 impl Stunner {
     #[tracing::instrument(skip_all, fields(n_server = self.servers.len()), level = "trace")]
     async fn try_stun(&self) {
+        if self.servers.is_empty() {
+            tracing::debug!("skipping stun, servers not populated yet");
+            return;
+        }
+
         for &server in &self.servers {
             if let Ok(Ok((_dur, x))) =
                 tokio::time::timeout(Duration::from_secs(3), self.stun.measure(server)).await
@@ -55,8 +60,8 @@ pub struct StunAddress {
 struct Tick;
 
 impl kameo::Actor for Stunner {
-    type Error = crate::Error;
     type Args = Env;
+    type Error = crate::Error;
 
     async fn on_start(env: Self::Args, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
         // panicking in on_start is fine, this is checked as part of Runtime::spawn


### PR DESCRIPTION
ts_runtime: don't try_stun if servers are empty

Exits early from `try_stun()` if `self.servers` is empty to avoid WARN logs about STUN failure on startup. On an underlay network with extremely high latency/packet loss, it takes awhile to get the derp map from control, leading to a warn log every 20 seconds as the control conn is established/DERP map received.

Basically a logging fix. Discovered on a plane that took ~80 seconds to establish the netmap stream.

Updates #cleanup.


