### PR TITLE
Make private keys non-copyable, pass keys by reference more

### DIFF
--- a/ts_control/src/control_dialer.rs
+++ b/ts_control/src/control_dialer.rs
@@ -255,15 +255,9 @@ where
         CapabilityVersion::CURRENT,
     );
 
-    // TODO: pass key by ref?
-    let conn = crate::tokio::upgrade_ts2021(
-        url,
-        &init_msg,
-        handshake,
-        machine_keys.private.clone(),
-        h1_client,
-    )
-    .await?;
+    let conn =
+        crate::tokio::upgrade_ts2021(url, &init_msg, handshake, &machine_keys.private, h1_client)
+            .await?;
     let conn = crate::tokio::read_challenge_packet(conn).await?;
 
     let h2_conn = ts_http_util::http2::connect(conn).await?;

--- a/ts_control/src/control_dialer.rs
+++ b/ts_control/src/control_dialer.rs
@@ -255,9 +255,15 @@ where
         CapabilityVersion::CURRENT,
     );
 
-    let conn =
-        crate::tokio::upgrade_ts2021(url, &init_msg, handshake, machine_keys.private, h1_client)
-            .await?;
+    // TODO: pass key by ref?
+    let conn = crate::tokio::upgrade_ts2021(
+        url,
+        &init_msg,
+        handshake,
+        machine_keys.private.clone(),
+        h1_client,
+    )
+    .await?;
     let conn = crate::tokio::read_challenge_packet(conn).await?;
 
     let h2_conn = ts_http_util::http2::connect(conn).await?;

--- a/ts_control/src/tokio/connect.rs
+++ b/ts_control/src/tokio/connect.rs
@@ -166,12 +166,11 @@ pub async fn connect(
         CapabilityVersion::CURRENT,
     );
 
-    // TODO: pass key by ref
     let conn = upgrade_ts2021(
         control_url,
         &init_msg,
         handshake,
-        machine_keys.private.clone(),
+        &machine_keys.private,
         h1_client,
     )
     .await?;
@@ -234,7 +233,7 @@ pub async fn upgrade_ts2021(
     control_url: &Url,
     init_msg: &str,
     handshake: ts_control_noise::Handshake,
-    machine_private_key: MachinePrivateKey,
+    machine_private_key: &MachinePrivateKey,
     h1_client: impl ts_http_util::Client<EmptyBody>,
 ) -> Result<impl AsyncRead + AsyncWrite + Unpin + 'static, ConnectionError> {
     let ts2021_url = control_url.join("/ts2021")?;
@@ -260,7 +259,7 @@ pub async fn upgrade_ts2021(
         ConnectionError::Internal(InternalErrorKind::Http)
     })?;
 
-    let conn = handshake.complete(upgraded, &machine_private_key).await?;
+    let conn = handshake.complete(upgraded, machine_private_key).await?;
 
     tracing::debug!("upgraded control connection from HTTP/1.1 to TS2021");
 

--- a/ts_control/src/tokio/connect.rs
+++ b/ts_control/src/tokio/connect.rs
@@ -166,11 +166,12 @@ pub async fn connect(
         CapabilityVersion::CURRENT,
     );
 
+    // TODO: pass key by ref
     let conn = upgrade_ts2021(
         control_url,
         &init_msg,
         handshake,
-        machine_keys.private,
+        machine_keys.private.clone(),
         h1_client,
     )
     .await?;

--- a/ts_derp/src/client.rs
+++ b/ts_derp/src/client.rs
@@ -236,8 +236,7 @@ fn make_clientinfo(
     node_keypair: &NodeKeyPair,
     server_key: &ts_keys::DerpServerPublicKey,
 ) -> Result<(ClientInfo, Vec<u8>), Error> {
-    // TODO: nicer way to handle reference gore around keypair?
-    let cbox = crypto_box::SalsaBox::new(&server_key.into(), &(&node_keypair.private).into());
+    let cbox = crypto_box::SalsaBox::new(&server_key.into(), &node_keypair.into());
     let nonce = crypto_box::SalsaBox::generate_nonce(&mut OsRng);
 
     let json = serde_json::to_vec(&frame::ClientInfoPayload {
@@ -267,7 +266,7 @@ fn decrypt_server_info(
 ) -> Result<frame::ServerInfoPayload, Error> {
     let mut payload = PacketMut::from(payload);
 
-    let mut cbox = crypto_box::SalsaBox::new(&sk.key.into(), &(&node_keypair.private).into());
+    let mut cbox = crypto_box::SalsaBox::new(&sk.key.into(), &node_keypair.into());
     cbox.decrypt_in_place(&server_info.nonce.into(), &[], &mut payload)
         .map_err(|e| frame::Error::DecryptionFailed(format!("err: {e}")))?;
 

--- a/ts_derp/src/client.rs
+++ b/ts_derp/src/client.rs
@@ -236,7 +236,8 @@ fn make_clientinfo(
     node_keypair: &NodeKeyPair,
     server_key: &ts_keys::DerpServerPublicKey,
 ) -> Result<(ClientInfo, Vec<u8>), Error> {
-    let cbox = crypto_box::SalsaBox::new(&server_key.into(), &node_keypair.private.into());
+    // TODO: nicer way to handle reference gore around keypair?
+    let cbox = crypto_box::SalsaBox::new(&server_key.into(), &(&node_keypair.private).into());
     let nonce = crypto_box::SalsaBox::generate_nonce(&mut OsRng);
 
     let json = serde_json::to_vec(&frame::ClientInfoPayload {
@@ -266,7 +267,7 @@ fn decrypt_server_info(
 ) -> Result<frame::ServerInfoPayload, Error> {
     let mut payload = PacketMut::from(payload);
 
-    let mut cbox = crypto_box::SalsaBox::new(&sk.key.into(), &node_keypair.private.into());
+    let mut cbox = crypto_box::SalsaBox::new(&sk.key.into(), &(&node_keypair.private).into());
     cbox.decrypt_in_place(&server_info.nonce.into(), &[], &mut payload)
         .map_err(|e| frame::Error::DecryptionFailed(format!("err: {e}")))?;
 

--- a/ts_ffi/src/keys.rs
+++ b/ts_ffi/src/keys.rs
@@ -34,9 +34,10 @@ macro_rules! impl_to_from {
                 key(value.into())
             }
         }
+
         impl From<&$key> for key {
             fn from(value: &$key) -> Self {
-                key((*value).into())
+                key(value.into())
             }
         }
     };

--- a/ts_keys/src/keystate.rs
+++ b/ts_keys/src/keystate.rs
@@ -25,9 +25,9 @@ pub struct PersistState {
 impl From<&NodeState> for PersistState {
     fn from(value: &NodeState) -> Self {
         Self {
-            node_key: value.node_keys.private,
-            machine_key: value.machine_keys.private,
-            network_lock_key: value.network_lock_keys.private,
+            node_key: value.node_keys.private.clone(),
+            machine_key: value.machine_keys.private.clone(),
+            network_lock_key: value.network_lock_keys.private.clone(),
         }
     }
 }
@@ -95,9 +95,9 @@ impl From<&PersistState> for NodeState {
     fn from(value: &PersistState) -> Self {
         Self {
             disco_keys: Default::default(),
-            node_keys: value.node_key.into(),
-            machine_keys: value.machine_key.into(),
-            network_lock_keys: value.network_lock_key.into(),
+            node_keys: value.node_key.clone().into(),
+            machine_keys: value.machine_key.clone().into(),
+            network_lock_keys: value.network_lock_key.clone().into(),
         }
     }
 }

--- a/ts_keys/src/macros.rs
+++ b/ts_keys/src/macros.rs
@@ -4,7 +4,7 @@
 macro_rules! _create_x25519_base_key_type {
     ($(#[$attr:meta])* $key_name:ident, $key_prefix:literal) => {
         $(#[$attr])*
-        #[derive(Clone, Copy, Eq, PartialEq, ::zerocopy::FromBytes, ::zerocopy::Immutable, ::zerocopy::IntoBytes, ::zerocopy::KnownLayout)]
+        #[derive(Clone, Eq, PartialEq, ::zerocopy::FromBytes, ::zerocopy::Immutable, ::zerocopy::IntoBytes, ::zerocopy::KnownLayout)]
         pub struct $key_name(
             [u8; $key_name::KEY_LEN_BYTES]
         );
@@ -97,6 +97,12 @@ macro_rules! _create_x25519_base_key_type {
             }
         }
 
+        impl From<&$key_name> for [u8; $key_name::KEY_LEN_BYTES] {
+            fn from(v: &$key_name) -> [u8; $key_name::KEY_LEN_BYTES] {
+                v.0
+            }
+        }
+
         #[cfg(feature = "serde")]
         impl<'de> ::serde::Deserialize<'de> for $key_name {
             fn deserialize<D>(deserializer: D) -> ::core::result::Result<$key_name, D::Error> where D: ::serde::Deserializer<'de> {
@@ -136,7 +142,7 @@ macro_rules! _create_x25519_base_key_type {
 /// Generates a struct that implements all the fields/methods needed by X25519 public keys.
 macro_rules! create_x25519_public_key_type {
     ($(#[$attr:meta])* $public_name:ident, $key_prefix:literal) => {
-        _create_x25519_base_key_type!($(#[$attr])* #[derive(Default, Hash, PartialOrd, Ord)] $public_name, $key_prefix);
+        _create_x25519_base_key_type!($(#[$attr])* #[derive(Copy, Default, Hash, PartialOrd, Ord)] $public_name, $key_prefix);
 
         impl From<$public_name> for ::x25519_dalek::PublicKey {
             fn from(v: $public_name) -> Self {
@@ -176,7 +182,7 @@ macro_rules! create_x25519_private_key_type {
             }
 
             /// Calculate the corresponding public key for this private key.
-            pub fn public_key(self) -> $public_name {
+            pub fn public_key(&self) -> $public_name {
                 ::crypto_box::SecretKey::from(self).public_key().to_bytes().into()
             }
         }
@@ -224,7 +230,7 @@ macro_rules! create_x25519_keypair_types {
 
         $(#[$pair_attr])*
         #[cfg_attr(feature = "serde", derive(::serde::Deserialize, ::serde::Serialize))]
-        #[derive(Clone, Copy, Debug, Eq, PartialEq, ::zerocopy::FromBytes, ::zerocopy::Immutable, ::zerocopy::IntoBytes, ::zerocopy::KnownLayout)]
+        #[derive(Clone, Debug, Eq, PartialEq, ::zerocopy::FromBytes, ::zerocopy::Immutable, ::zerocopy::IntoBytes, ::zerocopy::KnownLayout)]
         pub struct $keypair_name {
             /// This keypair's public key.
             pub public: $public_name,
@@ -236,9 +242,10 @@ macro_rules! create_x25519_keypair_types {
             /// Generate a new X25519 public/private key pair.
             pub fn new() -> Self {
                 let private = $private_name::random();
+                let public = private.public_key();
                 Self {
                     private,
-                    public: private.into(),
+                    public,
                 }
             }
         }
@@ -251,9 +258,10 @@ macro_rules! create_x25519_keypair_types {
 
         impl From<$private_name> for $keypair_name {
             fn from(private: $private_name) -> Self {
+                let public = private.public_key();
                 Self {
                     private,
-                    public: private.into(),
+                    public,
                 }
             }
         }

--- a/ts_keys/src/macros.rs
+++ b/ts_keys/src/macros.rs
@@ -265,6 +265,54 @@ macro_rules! create_x25519_keypair_types {
                 }
             }
         }
+
+        impl From<$keypair_name> for ::x25519_dalek::PublicKey {
+            fn from(v: $keypair_name) -> Self {
+                v.public.into()
+            }
+        }
+
+        impl From<&$keypair_name> for ::x25519_dalek::PublicKey {
+            fn from(v: &$keypair_name) -> Self {
+                v.public.into()
+            }
+        }
+
+        impl From<$keypair_name> for ::crypto_box::PublicKey {
+            fn from(v: $keypair_name) -> Self {
+                v.public.into()
+            }
+        }
+
+        impl From<&$keypair_name> for ::crypto_box::PublicKey {
+            fn from(v: &$keypair_name) -> Self {
+                v.public.into()
+            }
+        }
+
+        impl From<$keypair_name> for ::x25519_dalek::StaticSecret {
+            fn from(v: $keypair_name) -> Self {
+                v.private.into()
+            }
+        }
+
+        impl From<&$keypair_name> for ::x25519_dalek::StaticSecret {
+            fn from(v: &$keypair_name) -> Self {
+                (&v.private).into()
+            }
+        }
+
+        impl From<$keypair_name> for ::crypto_box::SecretKey {
+            fn from(v: $keypair_name) -> Self {
+                v.private.into()
+            }
+        }
+
+        impl From<&$keypair_name> for ::crypto_box::SecretKey {
+            fn from(v: &$keypair_name) -> Self {
+                (&v.private).into()
+            }
+        }
     }
 }
 

--- a/ts_runtime/src/dataplane.rs
+++ b/ts_runtime/src/dataplane.rs
@@ -67,7 +67,7 @@ impl kameo::Actor for DataplaneActor {
 
     async fn on_start(env: Self::Args, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
         let dataplane = Arc::new(ts_dataplane::async_tokio::DataPlane::new(
-            env.keys.node_keys,
+            env.keys.node_keys.clone(),
         ));
 
         env.subscribe::<PeerRouteUpdate>(&slf).await?;

--- a/ts_runtime/src/multiderp.rs
+++ b/ts_runtime/src/multiderp.rs
@@ -66,7 +66,7 @@ impl Multiderp {
         }
 
         let region = region.clone();
-        let keys = self.env.keys.node_keys;
+        let keys = self.env.keys.node_keys.clone();
 
         let (transport_id, mut up, down) = match self.dataplane.ask(NewUnderlayTransport).await {
             Ok(val) => val,
@@ -92,7 +92,7 @@ impl Multiderp {
                     ret = run_derp_once(
                         id,
                         &region,
-                        keys,
+                        keys.clone(),
                         &down,
                         &mut up,
                         &mut home_derp_rx,

--- a/ts_runtime/src/multiderp.rs
+++ b/ts_runtime/src/multiderp.rs
@@ -92,7 +92,7 @@ impl Multiderp {
                     ret = run_derp_once(
                         id,
                         &region,
-                        keys.clone(),
+                        &keys,
                         &down,
                         &mut up,
                         &mut home_derp_rx,
@@ -160,7 +160,7 @@ impl ts_transport::PeerLookup<NodePublicKey, PeerId> for PeerDbLookup<'_> {
 async fn run_derp_once(
     id: RegionId,
     region: &DerpRegion,
-    keys: NodeKeyPair,
+    keys: &NodeKeyPair,
     to_dataplane: &UnderlayToDataplane,
     from_dataplane: &mut UnderlayFromDataplane,
     home_derp_rx: &mut watch::Receiver<bool>,
@@ -189,7 +189,7 @@ async fn run_derp_once(
 
         tracing::trace!("establishing derp connection");
 
-        let client = ts_derp::DefaultClient::connect(&region.servers, &keys).await?;
+        let client = ts_derp::DefaultClient::connect(&region.servers, keys).await?;
         let transport = client.with_key_lookup(PeerDbLookup(peer_db));
 
         if let Some(pending) = pending {

--- a/ts_tunnel/src/endpoint.rs
+++ b/ts_tunnel/src/endpoint.rs
@@ -515,7 +515,7 @@ impl Peer {
         // TODO most of this logic might be better in the `handshake` module.
         let session_id = endpoint.ids.allocate_session(self.id);
         let (handshake, packet) = initiate_handshake(
-            endpoint.my_key.private,
+            endpoint.my_key.private.clone(), // TODO: pass by ref
             self.config.key,
             session_id,
             endpoint.timestamps.now(),
@@ -555,10 +555,11 @@ struct EndpointState {
 impl Endpoint {
     /// Construct a new endpoint with the given keypair.
     pub fn new(my_key: NodeKeyPair) -> Self {
+        let my_cookie = MACReceiver::new(&my_key.public);
         Self {
             state: EndpointState {
                 my_key,
-                my_cookie: MACReceiver::new(&my_key.public),
+                my_cookie,
                 ids: Default::default(),
                 timestamps: Default::default(),
                 scheduler: Default::default(),
@@ -822,7 +823,10 @@ mod tests {
         let (a_static, b_static) = (NodeKeyPair::new(), NodeKeyPair::new());
         let psk = rand::random();
 
-        let (mut a_ep, mut b_ep) = (Endpoint::new(a_static), Endpoint::new(b_static));
+        let (mut a_ep, mut b_ep) = (
+            Endpoint::new(a_static.clone()),
+            Endpoint::new(b_static.clone()),
+        );
 
         let a_peer = PeerId(1);
         let b_peer = PeerId(1);

--- a/ts_tunnel/src/endpoint.rs
+++ b/ts_tunnel/src/endpoint.rs
@@ -515,8 +515,8 @@ impl Peer {
         // TODO most of this logic might be better in the `handshake` module.
         let session_id = endpoint.ids.allocate_session(self.id);
         let (handshake, packet) = initiate_handshake(
-            endpoint.my_key.private.clone(), // TODO: pass by ref
-            self.config.key,
+            &endpoint.my_key.private,
+            &self.config.key,
             session_id,
             endpoint.timestamps.now(),
         );

--- a/ts_tunnel/src/handshake.rs
+++ b/ts_tunnel/src/handshake.rs
@@ -36,11 +36,8 @@ impl ReceivedHandshake {
             return None;
         };
 
-        let (noise, timestamp) = ikpsk2::ReceivedHandshake::new(
-            &mut pkt.noise,
-            PROLOGUE,
-            my_static.private.clone().into(), // TODO: pass by ref
-        )?;
+        let (noise, timestamp) =
+            ikpsk2::ReceivedHandshake::new(&mut pkt.noise, PROLOGUE, my_static.into())?;
 
         Some(ReceivedHandshake {
             send_id: pkt.sender_id,

--- a/ts_tunnel/src/handshake.rs
+++ b/ts_tunnel/src/handshake.rs
@@ -36,8 +36,11 @@ impl ReceivedHandshake {
             return None;
         };
 
-        let (noise, timestamp) =
-            ikpsk2::ReceivedHandshake::new(&mut pkt.noise, PROLOGUE, my_static.private.into())?;
+        let (noise, timestamp) = ikpsk2::ReceivedHandshake::new(
+            &mut pkt.noise,
+            PROLOGUE,
+            my_static.private.clone().into(), // TODO: pass by ref
+        )?;
 
         Some(ReceivedHandshake {
             send_id: pkt.sender_id,
@@ -274,8 +277,12 @@ mod tests {
         let a_mac_recv = MACReceiver::new(&a_static.public);
         let a_session = SessionId::random(); // A wants to receive at this ID
         let a_init_time = TAI64N::now();
-        let (a_handshake, init_pkt) =
-            initiate_handshake(a_static.private, b_static.public, a_session, a_init_time);
+        let (a_handshake, init_pkt) = initiate_handshake(
+            a_static.private.clone(),
+            b_static.public,
+            a_session,
+            a_init_time,
+        );
 
         let mut init_pkt = PacketMut::from(init_pkt.as_bytes());
         let handshake_mac = a_mac_send.write_macs(init_pkt.as_mut());

--- a/ts_tunnel/src/handshake.rs
+++ b/ts_tunnel/src/handshake.rs
@@ -81,8 +81,8 @@ impl ReceivedHandshake {
 
 /// Generate a handshake initiation message for a peer.
 pub fn initiate_handshake(
-    endpoint_static: NodePrivateKey,
-    peer_static: NodePublicKey,
+    endpoint_static: &NodePrivateKey,
+    peer_static: &NodePublicKey,
     session_id: SessionId,
     timestamp: TAI64N,
 ) -> (SentHandshake, HandshakeInitiation) {
@@ -277,12 +277,8 @@ mod tests {
         let a_mac_recv = MACReceiver::new(&a_static.public);
         let a_session = SessionId::random(); // A wants to receive at this ID
         let a_init_time = TAI64N::now();
-        let (a_handshake, init_pkt) = initiate_handshake(
-            a_static.private.clone(),
-            b_static.public,
-            a_session,
-            a_init_time,
-        );
+        let (a_handshake, init_pkt) =
+            initiate_handshake(&a_static.private, &b_static.public, a_session, a_init_time);
 
         let mut init_pkt = PacketMut::from(init_pkt.as_bytes());
         let handshake_mac = a_mac_send.write_macs(init_pkt.as_mut());


### PR DESCRIPTION
This kind of change bubbles out pretty far and wide, but I kept the PR as individual commits that each do one small thing.

The initial change that makes private keys and keypairs non-Copy just mechanically inserts explicit `clone()`s everywhere needed to make everything compile again.

Then subsequent changes get rid of the cloning by passing keys around by reference as much as possible, which in many cases makes the cloning/copying disappear entirely.

Finally, I implemented some convenience conversions from the keypair types to the 3p library types, so that pairs can convert directly into the 3p public/private types that we need to use for actual crypto. This cleans up a little bit of type gore in places where passing keys by ref required things like `&(&pair.private).into()`, replacing that with `&pair.into()`.

Updates #246 