### PR TITLE
ts_python: add typing/type stubs

### DIFF
--- a/ts_python/Cargo.toml
+++ b/ts_python/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 tailscale.workspace = true
 
 hex.workspace = true
-pyo3 = { version = "0.29", features = ["bytes", "abi3-py312"] }
+pyo3 = { version = "0.29", features = ["bytes", "abi3-py312", "experimental-inspect"] }
 pyo3-async-runtimes = { version = "0.29", features = ["tokio-runtime", "attributes"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/ts_python/README.md
+++ b/ts_python/README.md
@@ -47,20 +47,62 @@ The easiest way to get the library is through PyPI:
 $ pip install tailscale-py
 ```
 
-### In development
+## Developing
 
-If you want to use the module from within this repo, you'll need to build it. The best way to do
-that is with [`maturin`](https://www.maturin.rs/):
+This package uses [`uv`](). All other tooling (`maturin`, `ruff`, etc.) is managed by `uv`.
+
+### Setup
+
+1. Install an appropriate Rust toolchain for your platform. [See here](../README.md#msrv-and-edition)
+   for supported toolchain versions.
+2. [Install `uv`](https://docs.astral.sh/uv/getting-started/installation/).
+3. Clone the `tailscale-rs` repository.
+4. Create, activate, and populate a virtual environment for `ts_python` development:
 
 ```sh
-# In the project where you want to use the tailscale bindings:
-$ python -m virtualenv .venv
-$ . .venv/bin/activate
-$ pip install maturin
+# At the root of your tailscale-rs checkout:
+~/tailscale-rs $ cd ts_python
 
-# Then in tailscale-rs:
-$ cd ~/tailscale-rs/ts_python # use your path to a local clone of tailscale-rs
-$ maturin develop             # build and install python bindings into your virtualenv
+# Create a virtual environment for ts_python development.
+~/tailscale-rs/ts_python $ uv venv
+...
+Activate with: source .venv/bin/activate
 
-$ python -c 'import tailscale' && echo "ready!" # bindings are available!
+# Activate the new virtual environment.
+~/tailscale-rs/ts_python $ source .venv/bin/activate
+
+# Install dependencies, including optional dev dependencies such as maturin.
+(ts_python) ~/tailscale-rs/ts_python $ uv sync --extra dev
+...
 ```
+
+### Formatting
+
+We use `ruff` (via `uv`) to format the Python in our codebase:
+
+```sh
+~/tailscale-rs/ts_python $ uv format --preview-features format
+...
+4 files reformatted
+```
+
+### Generating Type Stubs
+
+The type stubs in `ts_python/python/tailscale/_internal.pyi` need to be generated any time the Rust
+source code (in `ts_python/src/`) changes. To re-generate the stubs:
+
+```sh
+# Make sure ts_python is built/up-to-date and maturin is installed.
+~/tailscale-rs/ts_python $ uv sync --extra dev
+...
+~/tailscale-rs/ts_python $ maturin generate-stubs --out python/tailscale
+🍹 Building a mixed python/rust project
+...
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.09s
+
+# The stubs are typically not properly formatted, so format them.
+~/tailscale-rs/ts_python $ uv format --preview-features format
+```
+
+Currently, you need to **manually check the generated type stubs** and add any missing imports by
+hand.

--- a/ts_python/README.md
+++ b/ts_python/README.md
@@ -49,7 +49,8 @@ $ pip install tailscale-py
 
 ## Developing
 
-This package uses [`uv`](). All other tooling (`maturin`, `ruff`, etc.) is managed by `uv`.
+This package uses [`uv`](https://docs.astral.sh/uv/). All other tooling (`maturin`, `ruff`, etc.)
+is managed by `uv`.
 
 ### Setup
 

--- a/ts_python/README.md
+++ b/ts_python/README.md
@@ -71,8 +71,8 @@ Activate with: source .venv/bin/activate
 # Activate the new virtual environment.
 ~/tailscale-rs/ts_python $ source .venv/bin/activate
 
-# Install dependencies, including optional dev dependencies such as maturin.
-(ts_python) ~/tailscale-rs/ts_python $ uv sync --extra dev
+# Install runtime and dev dependencies (for generating type stubs, testing, etc.).
+(ts_python) ~/tailscale-rs/ts_python $ uv sync --dev
 ...
 ```
 
@@ -93,7 +93,7 @@ source code (in `ts_python/src/`) changes. To re-generate the stubs:
 
 ```sh
 # Make sure ts_python is built/up-to-date and maturin is installed.
-~/tailscale-rs/ts_python $ uv sync --extra dev
+~/tailscale-rs/ts_python $ uv sync --dev
 ...
 ~/tailscale-rs/ts_python $ maturin generate-stubs --out python/tailscale
 🍹 Building a mixed python/rust project

--- a/ts_python/README.md
+++ b/ts_python/README.md
@@ -78,10 +78,10 @@ Activate with: source .venv/bin/activate
 
 ### Formatting
 
-We use `ruff` (via `uv`) to format the Python in our codebase:
+We use `ruff` (via `uv`'s preview feature) to format Python code:
 
 ```sh
-~/tailscale-rs/ts_python $ uv format --preview-features format
+~/tailscale-rs/ts_python $ uv format
 ...
 4 files reformatted
 ```
@@ -100,8 +100,8 @@ source code (in `ts_python/src/`) changes. To re-generate the stubs:
 ...
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.09s
 
-# The stubs are typically not properly formatted, so format them.
-~/tailscale-rs/ts_python $ uv format --preview-features format
+# The stubs are not properly formatted.
+~/tailscale-rs/ts_python $ uv format
 ```
 
 Currently, you need to **manually check the generated type stubs** and add any missing imports by

--- a/ts_python/examples/udp/recv.py
+++ b/ts_python/examples/udp/recv.py
@@ -2,18 +2,22 @@
 """
 A UDP receiver built with `tailscale-py`. Receives datagrams from peers and prints their contents.
 """
+
 import argparse
 import asyncio
 import tailscale
 
+
 async def main(auth_key: str, bind_port: int) -> None:
     # Connect to the tailnet:
-    dev = await tailscale.connect('tsrs_keys_recv.json', auth_key)
+    dev = await tailscale.connect("tsrs_keys_recv.json", auth_key)
 
     # Bind a UDP socket on this device's IPv4 address:
     tailnet_ipv4 = await dev.ipv4_addr()
     udp_sock = await dev.udp_bind((tailnet_ipv4, bind_port))
-    print(f"[{tailnet_ipv4}:{bind_port}] udp bound, local endpoint: {udp_sock.local_addr()}")
+    print(
+        f"[{tailnet_ipv4}:{bind_port}] udp bound, local endpoint: {udp_sock.local_addr()}"
+    )
 
     # Wait for a message and print it, then repeat.
     count = 0
@@ -21,12 +25,15 @@ async def main(auth_key: str, bind_port: int) -> None:
         (msg, remote) = await udp_sock.recvfrom()
         count += 1
         (peer_ip, peer_port) = (f"{remote[0]}", remote[1])
-        print(f"[{tailnet_ipv4}:{bind_port}<-{peer_ip}:{peer_port}|{count:04}] received message: {msg}")
+        print(
+            f"[{tailnet_ipv4}:{bind_port}<-{peer_ip}:{peer_port}|{count:04}] received message: {msg}"
+        )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="UDP receiver built with `tailscale-py`",
-        usage="TS_RS_EXPERIMENT=this_is_unstable_software %(prog)s [options]"
+        usage="TS_RS_EXPERIMENT=this_is_unstable_software %(prog)s [options]",
     )
     parser.add_argument("auth_key", help="auth key to register with tailnet")
     parser.add_argument("bind_port", help="local UDP port to bind", type=int)

--- a/ts_python/examples/udp/send.py
+++ b/ts_python/examples/udp/send.py
@@ -2,35 +2,41 @@
 """
 A UDP sender built with `tailscale-py`. Sends a datagram to the given peer every second.
 """
+
 import argparse
 import asyncio
 import tailscale
 
 BIND_PORT = 1234
-MESSAGE = b'HELLO'
+MESSAGE = b"HELLO"
+
 
 async def main(auth_key: str, peer_ip: str, peer_port: int) -> None:
     # Connect to the tailnet:
-    dev = await tailscale.connect('tsrs_keys_send.json', auth_key)
+    dev = await tailscale.connect("tsrs_keys_send.json", auth_key)
 
     # Bind a UDP socket on this device's IPv4 address:
     tailnet_ipv4 = await dev.ipv4_addr()
     udp_sock = await dev.udp_bind((tailnet_ipv4, BIND_PORT))
-    print(f"[{tailnet_ipv4}:{BIND_PORT}] udp bound, local endpoint: {udp_sock.local_addr()}")
+    print(
+        f"[{tailnet_ipv4}:{BIND_PORT}] udp bound, local endpoint: {udp_sock.local_addr()}"
+    )
 
     # Send a message to the peer every second.
     count = 0
     while True:
         await udp_sock.sendto((peer_ip, peer_port), msg=MESSAGE)
         count += 1
-        print(f"[{tailnet_ipv4}:{BIND_PORT}->{peer_ip}:{peer_port}|{count:04}] sent message: {MESSAGE}")
+        print(
+            f"[{tailnet_ipv4}:{BIND_PORT}->{peer_ip}:{peer_port}|{count:04}] sent message: {MESSAGE}"
+        )
         await asyncio.sleep(1)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="UDP sender built with `tailscale-py`",
-        usage="TS_RS_EXPERIMENT=this_is_unstable_software %(prog)s [options]"
+        usage="TS_RS_EXPERIMENT=this_is_unstable_software %(prog)s [options]",
     )
     parser.add_argument("auth_key", help="auth key to register with tailnet")
     parser.add_argument("peer_ip", help="peer's tailnet IP address")

--- a/ts_python/pyproject.toml
+++ b/ts_python/pyproject.toml
@@ -42,6 +42,8 @@ module-name = "tailscale._internal"
 [tool.uv]
 # Rebuild/reinstall on a "uv sync" if the Rust source changed.
 cache-keys = [{file = "pyproject.toml"}, {file = "Cargo.toml"}, {file = "**/*.rs"}]
+# Don't require '--preview-features format' on 'uv format'.
+preview-features = ["format"]
 
 [[tool.uv.index]]
 name = "pypi"

--- a/ts_python/pyproject.toml
+++ b/ts_python/pyproject.toml
@@ -29,8 +29,9 @@ Repository = "https://github.com/tailscale/tailscale-rs"
 requires = ["maturin>=1.13.1,<2.0"]
 build-backend = "maturin"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
+    # Install maturin as a dev dependency for generating type stubs.
     "maturin>=1.13.1,<2.0"
 ]
 

--- a/ts_python/pyproject.toml
+++ b/ts_python/pyproject.toml
@@ -29,9 +29,18 @@ Repository = "https://github.com/tailscale/tailscale-rs"
 requires = ["maturin>=1.13.1,<2.0"]
 build-backend = "maturin"
 
+[project.optional-dependencies]
+dev = [
+    "maturin>=1.13.1,<2.0"
+]
+
 [tool.maturin]
 python-source = "python"
 module-name = "tailscale._internal"
+
+[tool.uv]
+# Rebuild/reinstall on a "uv sync" if the Rust source changed.
+cache-keys = [{file = "pyproject.toml"}, {file = "Cargo.toml"}, {file = "**/*.rs"}]
 
 [[tool.uv.index]]
 name = "pypi"

--- a/ts_python/python/tailscale/__init__.py
+++ b/ts_python/python/tailscale/__init__.py
@@ -1,1 +1,2 @@
+# noinspection PyProtectedMember
 from tailscale._internal import *

--- a/ts_python/python/tailscale/_internal.pyi
+++ b/ts_python/python/tailscale/_internal.pyi
@@ -1,0 +1,221 @@
+"""
+Tailscale API.
+"""
+
+from ipaddress import IPv4Address, IPv6Address
+from typing import Any, Awaitable, final
+
+@final
+class Device:
+    """
+    Tailscale client.
+    """
+    def ipv4_addr(self, /) -> "Awaitable[IPv4Address]":
+        """
+        Get the device's IPv4 tailnet address.
+        """
+    def ipv6_addr(self, /) -> "Awaitable[IPv6Address]":
+        """
+        Get the device's IPv6 tailnet address.
+        """
+    def peer_by_name(self, /, name: "str") -> "Awaitable[dict[str, Any]]":
+        """
+        Look up info about a peer by its name.
+
+        `name` may be an unqualified hostname or a fully-qualified name.
+        """
+    def peer_by_tailnet_ip(
+        self, /, ip: "IPv4Address | IPv6Address | str"
+    ) -> "Awaitable[dict[str, Any]]":
+        """
+        Look up a peer by its tailnet IP address.
+        """
+    def peers_with_route(
+        self, /, ip: "IPv4Address | IPv6Address | str"
+    ) -> "Awaitable[list[dict[str, Any]]]":
+        """
+        Look up peer(s) with the most specific route match for the given address.
+
+        If more than one peer has the same route covering the same address, more than one
+        result may be returned.
+        """
+    def self_node(self, /) -> "Awaitable[dict[str, Any]]":
+        """
+        Get this device's node info.
+        """
+    def tcp_connect(
+        self, /, addr: "tuple[IPv4Address | IPv6Address | str, int]"
+    ) -> "Awaitable[TcpStream]":
+        """
+        Create a new TCP connection to the given `addr`.
+
+        `addr` must be given as (host, port). Presently, `host` must be an IP.
+        """
+    def tcp_listen(
+        self, /, addr: "tuple[IPv4Address | IPv6Address | str, int]"
+    ) -> "Awaitable[TcpListener]":
+        """
+        Bind a new TCP listen socket on the given `addr` and `port`.
+
+        `addr` must be given as (host, port). Presently, `host` must be an IP.
+        """
+    def udp_bind(
+        self, /, addr: "tuple[IPv4Address | IPv6Address | str, int]"
+    ) -> "Awaitable[UdpSocket]":
+        """
+        Bind a new UDP socket on the given `addr`.
+
+        `addr` must be given as (host, port). Presently, `host` must be an IP.
+        """
+
+@final
+class Keystate:
+    """
+    Tailscale keys.
+    """
+    def __new__(
+        cls,
+        /,
+        machine: "bytes | None" = None,
+        node: "bytes | None" = None,
+        network_lock: "bytes | None" = None,
+    ) -> Keystate: ...
+    def __repr__(self, /) -> str: ...
+    @property
+    def machine(self, /) -> bytes:
+        """
+        Machine key.
+        """
+    @property
+    def network_lock(self, /) -> bytes:
+        """
+        Network lock key.
+        """
+    @property
+    def node(self, /) -> bytes:
+        """
+        Node (device) key.
+        """
+
+@final
+class TcpListener:
+    """
+    A TCP listen socket.
+    """
+    def __repr__(self, /) -> str: ...
+    def accept(self, /) -> "Awaitable[TcpStream]":
+        """
+        Accept a new incoming connection.
+
+        Blocks indefinitely until a connection is ready to be accepted.
+        """
+    def local_addr(self, /) -> "tuple[IPv4Address | IPv6Address, int]":
+        """
+        Get the local endpoint this TCP listener is listening on.
+        """
+
+@final
+class TcpStream:
+    """
+    An established TCP stream.
+    """
+    def __repr__(self, /) -> str: ...
+    def fileno(self, /) -> int:
+        """
+        Report the file descriptor number for this TCP stream.
+
+        As this is a tailscale userspace device, there is no file descriptor, so this always
+        raises an `OsError`.
+        """
+    def isatty(self, /) -> bool:
+        """
+        Report whether this is a TTY.
+
+        Always returns `False`.
+        """
+    def local_addr(self, /) -> "tuple[IPv4Address | IPv6Address, int]":
+        """
+        Get the local endpoint this socket is bound to.
+        """
+    def readable(self, /) -> bool:
+        """
+        Report whether the stream is writable.
+
+        Always returns `True`.
+        """
+    def recv(self, /) -> "Awaitable[bytes]":
+        """
+        Receive bytes from the stream.
+
+        Always returns at least one byte if not an error.
+        """
+    def remote_addr(self, /) -> "tuple[IPv4Address | IPv6Address, int]":
+        """
+        Get the remote endpoint this socket is connected to.
+        """
+    def seekable(self, /) -> bool:
+        """
+        Report whether the stream is writable.
+
+        Always returns `False`.
+        """
+    def send(self, /, msg: "bytes") -> "Awaitable[int]":
+        """
+        Send bytes to the stream, returning the number of bytes transmitted.
+
+        Always sends at least one byte if not an error.
+        """
+    def tell(self, /) -> int:
+        """
+        Report the current position.
+
+        TCP streams don't support seeking, so this always returns `0`.
+        """
+    def writable(self, /) -> bool:
+        """
+        Report whether the stream is writable.
+
+        Always returns `True`.
+        """
+
+@final
+class UdpSocket:
+    """
+    A tailscale UDP socket.
+    """
+    def __repr__(self, /) -> str: ...
+    def local_addr(self, /) -> "tuple[IPv4Address | IPv6Address, int]":
+        """
+        Get the local endpoint this socket is bound to.
+        """
+    def recvfrom(
+        self, /
+    ) -> "Awaitable[tuple[bytes, tuple[IPv4Address | IPv6Address | str, int]]]":
+        """
+        Receive a datagram from the socket.
+
+        Returns a tuple `(bytes, address)`, e.g. `(b"hello", ("127.0.0.1", 1234))`.
+        """
+    def sendto(
+        self, /, addr: "tuple[IPv4Address | IPv6Address | str, int]", msg: "bytes"
+    ) -> "Awaitable[None]":
+        """
+        Send a datagram to the given address.
+
+        The address argument is currently expected to adopt the 2-tuple form (host, port),
+        where host is strictly an IP address -- DNS lookup is not yet supported.
+        """
+
+def connect(
+    key_file_path: "str | None" = None,
+    /,
+    auth_key: "str | None" = None,
+    *,
+    control_server_url: "str | None" = None,
+    hostname: "str | None" = None,
+    tags: "list[str] | None" = None,
+    keys: "Keystate | None" = None,
+) -> "Awaitable[Device]":
+    """
+    Connect to tailscale using the specified parameters.
+    """

--- a/ts_python/src/key_state.rs
+++ b/ts_python/src/key_state.rs
@@ -13,7 +13,7 @@ pub struct Keystate {
 #[pyo3::pymethods]
 impl Keystate {
     #[new]
-    #[pyo3(signature = (machine=None, node=None, network_lock=None))]
+    #[pyo3(signature = (machine: "bytes | None" = None, node: "bytes | None" = None, network_lock: "bytes | None" = None))]
     pub fn new(
         machine: Option<Vec<u8>>,
         node: Option<Vec<u8>>,

--- a/ts_python/src/lib.rs
+++ b/ts_python/src/lib.rs
@@ -37,7 +37,7 @@ pub mod _internal {
 
     /// Connect to tailscale using the specified parameters.
     #[pyfunction]
-    #[pyo3(signature = (key_file_path=None, /, auth_key=None, *, control_server_url=None, hostname=None, tags=None, keys=None))]
+    #[pyo3(signature = (key_file_path: "str | None" = None , /, auth_key: "str | None" = None, *, control_server_url: "str | None" = None, hostname: "str | None" = None, tags: "list[str] | None" = None, keys: "Keystate | None" = None) -> "Awaitable[Device]")]
     pub fn connect(
         py: Python<'_>,
         key_file_path: Option<String>,
@@ -104,6 +104,7 @@ impl Device {
     /// Bind a new UDP socket on the given `addr`.
     ///
     /// `addr` must be given as (host, port). Presently, `host` must be an IP.
+    #[pyo3(signature = (addr: "tuple[IPv4Address | IPv6Address | str, int]") -> "Awaitable[UdpSocket]")]
     pub fn udp_bind<'p>(&self, py: Python<'p>, addr: (IpRepr, u16)) -> PyFut<'p> {
         let dev = self.dev.clone();
         let ip: Result<IpAddr, _> = addr.0.try_into();
@@ -125,6 +126,7 @@ impl Device {
     /// Bind a new TCP listen socket on the given `addr` and `port`.
     ///
     /// `addr` must be given as (host, port). Presently, `host` must be an IP.
+    #[pyo3(signature = (addr: "tuple[IPv4Address | IPv6Address | str, int]") -> "Awaitable[TcpListener]")]
     pub fn tcp_listen<'p>(&self, py: Python<'p>, addr: (IpRepr, u16)) -> PyFut<'p> {
         let dev = self.dev.clone();
         let ip: Result<IpAddr, _> = addr.0.try_into();
@@ -146,6 +148,7 @@ impl Device {
     /// Create a new TCP connection to the given `addr`.
     ///
     /// `addr` must be given as (host, port). Presently, `host` must be an IP.
+    #[pyo3(signature = (addr: "tuple[IPv4Address | IPv6Address | str, int]") -> "Awaitable[TcpStream]")]
     pub fn tcp_connect<'p>(&self, py: Python<'p>, addr: (IpRepr, u16)) -> PyFut<'p> {
         let dev = self.dev.clone();
         let ip: Result<IpAddr, _> = addr.0.try_into();
@@ -165,6 +168,7 @@ impl Device {
     }
 
     /// Get the device's IPv4 tailnet address.
+    #[pyo3(signature = () -> "Awaitable[IPv4Address]")]
     pub fn ipv4_addr<'p>(&self, py: Python<'p>) -> PyFut<'p> {
         let dev = self.dev.clone();
 
@@ -175,6 +179,7 @@ impl Device {
     }
 
     /// Get the device's IPv6 tailnet address.
+    #[pyo3(signature = () -> "Awaitable[IPv6Address]")]
     pub fn ipv6_addr<'p>(&self, py: Python<'p>) -> PyFut<'p> {
         let dev = self.dev.clone();
 
@@ -187,6 +192,7 @@ impl Device {
     /// Look up info about a peer by its name.
     ///
     /// `name` may be an unqualified hostname or a fully-qualified name.
+    #[pyo3(signature = (name: "str") -> "Awaitable[dict[str, Any]]")]
     pub fn peer_by_name<'p>(&self, py: Python<'p>, name: String) -> PyFut<'p> {
         let dev = self.dev.clone();
 
@@ -198,6 +204,7 @@ impl Device {
     }
 
     /// Get this device's node info.
+    #[pyo3(signature = () -> "Awaitable[dict[str, Any]]")]
     pub fn self_node<'p>(&self, py: Python<'p>) -> PyFut<'p> {
         let dev = self.dev.clone();
 
@@ -208,6 +215,7 @@ impl Device {
     }
 
     /// Look up a peer by its tailnet IP address.
+    #[pyo3(signature = (ip: "IPv4Address | IPv6Address | str") -> "Awaitable[dict[str, Any]]")]
     pub fn peer_by_tailnet_ip<'p>(&self, py: Python<'p>, ip: IpRepr) -> PyFut<'p> {
         let dev = self.dev.clone();
 
@@ -223,6 +231,7 @@ impl Device {
     ///
     /// If more than one peer has the same route covering the same address, more than one
     /// result may be returned.
+    #[pyo3(signature = (ip: "IPv4Address | IPv6Address | str") -> "Awaitable[list[dict[str, Any]]]")]
     pub fn peers_with_route<'p>(&self, py: Python<'p>, ip: IpRepr) -> PyFut<'p> {
         let dev = self.dev.clone();
 

--- a/ts_python/src/tcp.rs
+++ b/ts_python/src/tcp.rs
@@ -22,6 +22,8 @@ impl TcpListener {
     /// Accept a new incoming connection.
     ///
     /// Blocks indefinitely until a connection is ready to be accepted.
+    #[pyo3(signature = () -> "Awaitable[TcpStream]")]
+
     pub fn accept<'p>(&self, py: Python<'p>) -> PyFut<'p> {
         let sock = Arc::clone(&self.listener);
 
@@ -35,6 +37,8 @@ impl TcpListener {
     }
 
     /// Get the local endpoint this TCP listener is listening on.
+    #[pyo3(signature = () -> "tuple[IPv4Address | IPv6Address, int]")]
+
     pub fn local_addr(&self) -> (IpAddr, u16) {
         sockaddr_as_tuple(self.listener.local_addr())
     }
@@ -49,6 +53,7 @@ impl TcpStream {
     /// Send bytes to the stream, returning the number of bytes transmitted.
     ///
     /// Always sends at least one byte if not an error.
+    #[pyo3(signature = (msg: "bytes") -> "Awaitable[int]")]
     pub fn send<'p>(&self, py: Python<'p>, msg: &[u8]) -> PyFut<'p> {
         let sock = Arc::clone(&self.sock);
         let msg = msg.to_vec();
@@ -63,6 +68,7 @@ impl TcpStream {
     /// Receive bytes from the stream.
     ///
     /// Always returns at least one byte if not an error.
+    #[pyo3(signature = () -> "Awaitable[bytes]")]
     pub fn recv<'p>(&self, py: Python<'p>) -> PyFut<'p> {
         let sock = Arc::clone(&self.sock);
 
@@ -74,11 +80,13 @@ impl TcpStream {
     }
 
     /// Get the local endpoint this socket is bound to.
+    #[pyo3(signature = () -> "tuple[IPv4Address | IPv6Address, int]")]
     pub fn local_addr(&self) -> (IpAddr, u16) {
         sockaddr_as_tuple(self.sock.local_addr())
     }
 
     /// Get the remote endpoint this socket is connected to.
+    #[pyo3(signature = () -> "tuple[IPv4Address | IPv6Address, int]")]
     pub fn remote_addr(&self) -> (IpAddr, u16) {
         sockaddr_as_tuple(self.sock.remote_addr())
     }

--- a/ts_python/src/udp.rs
+++ b/ts_python/src/udp.rs
@@ -18,6 +18,7 @@ impl UdpSocket {
     ///
     /// The address argument is currently expected to adopt the 2-tuple form (host, port),
     /// where host is strictly an IP address -- DNS lookup is not yet supported.
+    #[pyo3(signature = (addr: "tuple[IPv4Address | IPv6Address | str, int]", msg: "bytes") -> "Awaitable[None]")]
     pub fn sendto<'p>(&self, py: Python<'p>, addr: (IpRepr, u16), msg: &[u8]) -> PyFut<'p> {
         let (ip, port) = addr;
 
@@ -40,6 +41,7 @@ impl UdpSocket {
     /// Receive a datagram from the socket.
     ///
     /// Returns a tuple `(bytes, address)`, e.g. `(b"hello", ("127.0.0.1", 1234))`.
+    #[pyo3(signature = () -> "Awaitable[tuple[bytes, tuple[IPv4Address | IPv6Address | str, int]]]")]
     pub fn recvfrom<'p>(&self, py: Python<'p>) -> PyFut<'p> {
         let sock = self.sock.clone();
 
@@ -51,6 +53,7 @@ impl UdpSocket {
     }
 
     /// Get the local endpoint this socket is bound to.
+    #[pyo3(signature = () -> "tuple[IPv4Address | IPv6Address, int]")]
     pub fn local_addr(&self) -> (IpAddr, u16) {
         sockaddr_as_tuple(self.sock.local_addr())
     }

--- a/ts_python/uv.lock
+++ b/ts_python/uv.lock
@@ -28,11 +28,12 @@ name = "tailscale-py"
 version = "0.3.3"
 source = { editable = "." }
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "maturin" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "maturin", marker = "extra == 'dev'", specifier = ">=1.13.1,<2.0" }]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "maturin", specifier = ">=1.13.1,<2.0" }]

--- a/ts_python/uv.lock
+++ b/ts_python/uv.lock
@@ -3,6 +3,36 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "maturin"
+version = "1.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/b3/addd877f871fb1860d46d3a4f206ecb10b946c85846805e6367631926fd3/maturin-1.14.1.tar.gz", hash = "sha256:9d6577a62cd08e0ceba7a0db06fb098e0c9b1b3429bad747a4f3a18215a1b3df", size = 369637, upload-time = "2026-06-19T05:19:49.774Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/f0/97c5a5bd9c71653a066c0976a484eaaae50b9369557838a4176b7b0bdaa5/maturin-1.14.1-py3-none-linux_armv6l.whl", hash = "sha256:522292398945442cdafa9daeb2271b2340fbde57027b818f923f88eab04174f8", size = 10207496, upload-time = "2026-06-19T05:19:09.321Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/83/294bca639b0e052f1e2f65199b3db258780c7d4e31408b934c9c974a1379/maturin-1.14.1-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:ffe5ad71f21d1e6603c4dd75f7fee34adf5ed5ebcebb692886549888ebb329ed", size = 19680113, upload-time = "2026-06-19T05:19:13.43Z" },
+    { url = "https://files.pythonhosted.org/packages/43/b6/79c881410a3b1c187f7eb3d407aecae646c6a4433d630d72200359015e83/maturin-1.14.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f3306078070c1508fd715b9116070cbcaff5959024272a9f1e6f5cb29768b86c", size = 10169205, upload-time = "2026-06-19T05:19:16.615Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9d/44b6f26dcb7f7a04c5501ac2dbb6ca1490150682baa525ca5860504f9eab/maturin-1.14.1-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:cd457cd88961156e26379e1155bd287cc0ec1c8b2f1582b0660fb31b87c8842d", size = 10188098, upload-time = "2026-06-19T05:19:19.736Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bd/9c0d5d6983905ce2c9edaa073a7e89355a9cf7f396988e05d32f1c37785d/maturin-1.14.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:dfc54ae32e6fcb18302193ab9a30b0b25eefffba994ae13238974805533ef75e", size = 10627576, upload-time = "2026-06-19T05:19:22.713Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/33/b096412bd6a7cb399652b260666f901adf88a687181a6dbd6a3f89f0a94e/maturin-1.14.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:a131d912b5267e640bc96d70f4914e10590aed64082ec9abacba7cea52004224", size = 10085181, upload-time = "2026-06-19T05:19:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/56/8d/08c3bf469c38a23c9e6c877e338193001eb604d010fedc08341974e38528/maturin-1.14.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:be18fc568fb76884c0205456336892a75105ec398e6b667cd777c6268bd06d69", size = 10026363, upload-time = "2026-06-19T05:19:28.904Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a4/c4d1a92839f8745ab4aab988a7db884a79d6d710bd3b286fcf9316dece1a/maturin-1.14.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:994a0c8ba3ad8a92b3a9ee1b02645d200d610216b15cff5102b0fe65e8e08666", size = 13321347, upload-time = "2026-06-19T05:19:32.411Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/fa/170f04624d03fd07d2a8b1b67de83a127af93aef9eaa425839553347297b/maturin-1.14.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:be80866363e605d137991b491a741a84cde9ae350183c4c85f49690ca9aaaa65", size = 10877609, upload-time = "2026-06-19T05:19:35.448Z" },
+    { url = "https://files.pythonhosted.org/packages/61/ad/1ae2e1d0ded282bf2c55ac13f0811d87deb425e200ae64a15785675dede9/maturin-1.14.1-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:5282dffd4b539d2be245f4e5b1a5ab6bc1033b58f4a4872f5833f9d43c954aa4", size = 10417316, upload-time = "2026-06-19T05:19:38.28Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/27/bf677183920718da49cd7982d6a3ffc440aad8919329f571d189f81b7bdf/maturin-1.14.1-py3-none-win32.whl", hash = "sha256:1a04de0a20188f95c721b5702eed18140bdcccb28c386797093eca3f62f4d4e0", size = 8931293, upload-time = "2026-06-19T05:19:41.183Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/585adeb9167b08d3cdff0032a938b0e72655c92003df4f52c3f696a1bcc2/maturin-1.14.1-py3-none-win_amd64.whl", hash = "sha256:3c9f94640ecc4895e94abaf834a0684430032c865b2748a36c12461fd9252fdd", size = 10314067, upload-time = "2026-06-19T05:19:44.389Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d4/dac8c0720ae246be1700afb6fbdbbea20fe35b13f6570b2f70faa005df77/maturin-1.14.1-py3-none-win_arm64.whl", hash = "sha256:15cea8fcb3ba47dd636f50092bb34baea8b04ac777392f23e6bf8a9a61efb894", size = 9718943, upload-time = "2026-06-19T05:19:47.49Z" },
+]
+
+[[package]]
 name = "tailscale-py"
 version = "0.3.3"
 source = { editable = "." }
+
+[package.optional-dependencies]
+dev = [
+    { name = "maturin" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "maturin", marker = "extra == 'dev'", specifier = ">=1.13.1,<2.0" }]
+provides-extras = ["dev"]


### PR DESCRIPTION
Generate type stubs using `#[pyo3(signature = ...)]` annotations and `maturin generate-stubs --out python/tailscale`. Also forces `uv sync` to rebuild `ts_python` if the Rust source has changed, updates the README to use `uv`, and formats the Python codebase with `ruff` (via `uv format`).

Not urgent, but makes things more pleasant in IDEs. Was working on #243 and decided to separate this out for comment.

Updates #cleanup.
