### PR TITLE
runtime/peer_tracker: don't panic on invalid patch

### DIFF
--- a/ts_runtime/src/peer_tracker/mod.rs
+++ b/ts_runtime/src/peer_tracker/mod.rs
@@ -238,9 +238,11 @@ impl Message<Arc<ts_control::StateUpdate>> for PeerTracker {
                 }
 
                 for update in patch {
-                    let id = self.peer_db.patch(update);
-
-                    upserts.insert(id);
+                    if let Some(id) = self.peer_db.patch(update) {
+                        upserts.insert(id);
+                    } else {
+                        tracing::warn!(?update, "no peer for update");
+                    }
                 }
             }
         }

--- a/ts_runtime/src/peer_tracker/peer_db.rs
+++ b/ts_runtime/src/peer_tracker/peer_db.rs
@@ -85,16 +85,11 @@ impl PeerDb {
     /// Apply an update to a node in the peer db.
     ///
     /// The [`NodeUpdate::id`] field is used as the primary key to identify the node.
-    ///
-    /// # Panics
-    /// If the peer db does not contain a node where [`Node::id`] == [`NodeUpdate::id`].
-    pub fn patch(&mut self, update: &NodeUpdate) -> PeerId {
-        let id = (update.id)
-            .lookup(self)
-            .expect("no matching peer for update");
+    pub fn patch(&mut self, update: &NodeUpdate) -> Option<PeerId> {
+        let id = update.id.lookup(self)?;
         let mut peer = self.peers.remove(&id).unwrap();
         peer.apply_update(update);
-        self.upsert(&peer)
+        Some(self.upsert(&peer))
     }
 
     /// Upsert a node into the peer db.


### PR DESCRIPTION
Previously, the peer tracker would panic if there was a patch for a peer that isn't in our peer map. I've encountered this repeatedly on headscale; we should be tolerant to this but log a warning.

