### PR TITLE
ts_keys: add a wrapper type for an x25519_dalek keypair, and use it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6079,6 +6079,7 @@ dependencies = [
  "hex",
  "hkdf 0.12.4",
  "itertools",
+ "ts_keys",
  "x25519-dalek",
  "zerocopy",
  "zeroize",

--- a/ts_control/src/control_dialer.rs
+++ b/ts_control/src/control_dialer.rs
@@ -250,14 +250,13 @@ where
 
     let (handshake, init_msg) = ts_control_noise::Handshake::initialize(
         &crate::tokio::CONTROL_PROTOCOL_VERSION,
-        &machine_keys.private,
+        machine_keys,
         &control_public_key,
         CapabilityVersion::CURRENT,
     );
 
     let conn =
-        crate::tokio::upgrade_ts2021(url, &init_msg, handshake, &machine_keys.private, h1_client)
-            .await?;
+        crate::tokio::upgrade_ts2021(url, &init_msg, handshake, machine_keys, h1_client).await?;
     let conn = crate::tokio::read_challenge_packet(conn).await?;
 
     let h2_conn = ts_http_util::http2::connect(conn).await?;

--- a/ts_control/src/tokio/connect.rs
+++ b/ts_control/src/tokio/connect.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
 use ts_capabilityversion::CapabilityVersion;
 use ts_http_util::{BytesBody, ClientExt, EmptyBody, HeaderName, HeaderValue, Http2, ResponseExt};
-use ts_keys::{MachineKeyPair, MachinePrivateKey, MachinePublicKey};
+use ts_keys::{MachineKeyPair, MachinePublicKey};
 use url::Url;
 use zerocopy::network_endian::U32;
 
@@ -161,19 +161,12 @@ pub async fn connect(
 
     let (handshake, init_msg) = ts_control_noise::Handshake::initialize(
         &CONTROL_PROTOCOL_VERSION,
-        &machine_keys.private,
+        machine_keys,
         &control_public_key,
         CapabilityVersion::CURRENT,
     );
 
-    let conn = upgrade_ts2021(
-        control_url,
-        &init_msg,
-        handshake,
-        &machine_keys.private,
-        h1_client,
-    )
-    .await?;
+    let conn = upgrade_ts2021(control_url, &init_msg, handshake, machine_keys, h1_client).await?;
 
     // The early payload (challenge packet) is optional. The server may send
     // the magic prefix [FF FF FF 'T' 'S'] followed by a JSON challenge, or it
@@ -233,7 +226,7 @@ pub async fn upgrade_ts2021(
     control_url: &Url,
     init_msg: &str,
     handshake: ts_control_noise::Handshake,
-    machine_private_key: &MachinePrivateKey,
+    machine_key: &MachineKeyPair,
     h1_client: impl ts_http_util::Client<EmptyBody>,
 ) -> Result<impl AsyncRead + AsyncWrite + Unpin + 'static, ConnectionError> {
     let ts2021_url = control_url.join("/ts2021")?;
@@ -259,7 +252,7 @@ pub async fn upgrade_ts2021(
         ConnectionError::Internal(InternalErrorKind::Http)
     })?;
 
-    let conn = handshake.complete(upgraded, machine_private_key).await?;
+    let conn = handshake.complete(upgraded, machine_key).await?;
 
     tracing::debug!("upgraded control connection from HTTP/1.1 to TS2021");
 

--- a/ts_control_noise/src/handshake.rs
+++ b/ts_control_noise/src/handshake.rs
@@ -3,7 +3,7 @@ use bytes::BytesMut;
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio_util::codec::Framed;
 use ts_hexdump::{AsHexExt, Case};
-use ts_keys::{MachinePrivateKey, MachinePublicKey};
+use ts_keys::{MachineKeyPair, MachinePublicKey};
 use ts_noise::ik::SentHandshake;
 use zerocopy::{IntoBytes, TryFromBytes};
 
@@ -31,13 +31,13 @@ impl Handshake {
     /// to the control server in order to start the handshake.
     pub fn initialize(
         prologue: &str,
-        node_machine_private_key: &MachinePrivateKey,
+        node_machine_key: &MachineKeyPair,
         control_public_key: &MachinePublicKey,
         capability_version: ts_capabilityversion::CapabilityVersion,
     ) -> (Self, String) {
         let mut ciphertext = [0; SentHandshake::INIT_SIZE];
         let state = SentHandshake::new(
-            node_machine_private_key.into(),
+            node_machine_key.into(),
             control_public_key.into(),
             prologue.as_bytes(),
             &mut ciphertext,
@@ -55,7 +55,7 @@ impl Handshake {
     pub async fn complete<T: AsyncRead + Unpin>(
         mut self,
         mut conn: T,
-        node_machine_private_key: &MachinePrivateKey,
+        node_machine_key: &MachineKeyPair,
     ) -> Result<WrappedIo<T>, Error> {
         let mut hdr_bytes = [0u8; 3];
         conn.read_exact(&mut hdr_bytes[..]).await?;
@@ -78,10 +78,7 @@ impl Handshake {
             return Err(Error::BadFormat);
         }
 
-        let session = match self
-            .state
-            .try_finish(&mut packet, node_machine_private_key.into())
-        {
+        let session = match self.state.try_finish(&mut packet, node_machine_key.into()) {
             Ok(session) => session,
             Err(state) => {
                 self.state = state;

--- a/ts_keys/src/lib.rs
+++ b/ts_keys/src/lib.rs
@@ -29,6 +29,28 @@ pub enum ParseError {
     BadPrefix,
 }
 
+/// An x25519_dalek private key, and its associated public key.
+///
+/// This exists because the x25519_dalek crate doesn't have a pair type, which results in
+/// awkward APIs and pubkey recomputations when we have a strongly typed keypair of our own that
+/// we want to convert cheaply for crypto ops.
+#[derive(Clone)]
+pub struct X25519KeyPair {
+    /// The keypair's public key.
+    pub public: ::x25519_dalek::PublicKey,
+    /// The keypair's private key.
+    pub private: ::x25519_dalek::StaticSecret,
+}
+
+impl X25519KeyPair {
+    /// Return a new random keypair.
+    pub fn random() -> Self {
+        let private = ::x25519_dalek::StaticSecret::random();
+        let public = ::x25519_dalek::PublicKey::from(&private);
+        Self { public, private }
+    }
+}
+
 // The client never handles challenge private keys, so we only create a public key type rather than
 // public/private/keypair types.
 create_x25519_public_key_type!(

--- a/ts_keys/src/macros.rs
+++ b/ts_keys/src/macros.rs
@@ -266,6 +266,24 @@ macro_rules! create_x25519_keypair_types {
             }
         }
 
+        impl From<$keypair_name> for X25519KeyPair {
+            fn from(v: $keypair_name) -> Self {
+                X25519KeyPair{
+                    public: v.public.into(),
+                    private: v.private.into(),
+                }
+            }
+        }
+
+        impl From<&$keypair_name> for X25519KeyPair {
+            fn from(v: &$keypair_name) -> Self {
+                X25519KeyPair{
+                    public: (&v.public).into(),
+                    private: (&v.private).into(),
+                }
+            }
+        }
+
         impl From<$keypair_name> for ::x25519_dalek::PublicKey {
             fn from(v: $keypair_name) -> Self {
                 v.public.into()

--- a/ts_noise/Cargo.toml
+++ b/ts_noise/Cargo.toml
@@ -21,6 +21,8 @@ x25519-dalek.workspace = true
 zerocopy.workspace = true
 zeroize.workspace = true
 
+ts_keys.workspace = true
+
 [dev-dependencies]
 hex.workspace = true
 

--- a/ts_noise/src/ik.rs
+++ b/ts_noise/src/ik.rs
@@ -1,5 +1,6 @@
 //! Implementation of the Noise IK handshake pattern.
 
+use ts_keys::X25519KeyPair;
 use zerocopy::FromBytes;
 
 use crate::{
@@ -25,23 +26,18 @@ impl ReceivedHandshake {
     ///
     /// Returns a [`ReceivedHandshake`] with information about the peer on success, or
     /// None if the handshake message is invalid in some way.
-    pub fn new(
-        packet: &mut [u8],
-        prologue: &[u8],
-        my_static: &x25519_dalek::StaticSecret,
-    ) -> Option<Self> {
+    pub fn new(packet: &mut [u8], prologue: &[u8], my_static: &X25519KeyPair) -> Option<Self> {
         let packet: &mut Init<()> = Init::mut_from_bytes(packet).ok()?;
 
         let peer_ephemeral_pub = x25519_dalek::PublicKey::from(packet.ephemeral_pub);
-        let my_static_pub = x25519_dalek::PublicKey::from(my_static);
 
         let handshake = State::new(PROTOCOL)
             .mix_hash(prologue) // prologue
-            .mix_hash(my_static_pub.as_ref()) // <- s ...
+            .mix_hash(my_static.public.as_ref()) // <- s ...
             .mix_hash(&packet.ephemeral_pub) // -> e
-            .mix_dh(my_static, &peer_ephemeral_pub) // es
+            .mix_dh(&my_static.private, &peer_ephemeral_pub) // es
             .open(&mut packet.static_pub, &packet.static_pub_tag)? // s
-            .mix_dh(my_static, &packet.static_pub.into()) // ss
+            .mix_dh(&my_static.private, &packet.static_pub.into()) // ss
             .open(&mut [], &packet.payload_tag)?; // payload
 
         Some(ReceivedHandshake {
@@ -61,25 +57,20 @@ impl ReceivedHandshake {
     /// If `packet` is the wrong size.
     #[inline]
     pub fn finish(self, packet: &mut [u8]) -> Session {
-        let my_ephemeral = x25519_dalek::StaticSecret::random();
-        self.finish_with_ephemeral(packet, my_ephemeral)
+        let ephemeral = X25519KeyPair::random();
+        self.finish_with_ephemeral(packet, ephemeral)
     }
 
-    fn finish_with_ephemeral(
-        self,
-        packet: &mut [u8],
-        my_ephemeral: x25519_dalek::StaticSecret,
-    ) -> Session {
+    fn finish_with_ephemeral(self, packet: &mut [u8], my_ephemeral: X25519KeyPair) -> Session {
         assert_eq!(packet.len(), Self::RESP_SIZE);
         let response = Resp::mut_from_bytes(packet).unwrap();
 
-        let my_ephemeral_pub = x25519_dalek::PublicKey::from(&my_ephemeral);
-        response.ephemeral_pub = my_ephemeral_pub.to_bytes();
+        response.ephemeral_pub = my_ephemeral.public.to_bytes();
 
         self.state
-            .mix_hash(my_ephemeral_pub.as_ref()) // <- e
-            .mix_dh(&my_ephemeral, &self.peer_ephemeral_pub) // ee
-            .mix_dh(&my_ephemeral, &self.peer_static_pub) // se
+            .mix_hash(my_ephemeral.public.as_ref()) // <- e
+            .mix_dh(&my_ephemeral.private, &self.peer_ephemeral_pub) // ee
+            .mix_dh(&my_ephemeral.private, &self.peer_static_pub) // se
             .seal(&mut [], &mut response.auth_tag) // payload
             .finish_as_responder()
     }
@@ -102,18 +93,18 @@ impl SentHandshake {
     /// If `packet` is not [`SentHandshake::INIT_SIZE`] bytes.
     #[inline]
     pub fn new(
-        my_static: x25519_dalek::StaticSecret,
+        my_static: X25519KeyPair,
         peer_static: x25519_dalek::PublicKey,
         prologue: &[u8],
         out: &mut [u8],
     ) -> Self {
-        let ephemeral = x25519_dalek::StaticSecret::random();
+        let ephemeral = X25519KeyPair::random();
         SentHandshake::new_with_ephemeral(my_static, ephemeral, peer_static, prologue, out)
     }
 
     fn new_with_ephemeral(
-        my_static: x25519_dalek::StaticSecret,
-        my_ephemeral: x25519_dalek::StaticSecret,
+        my_static: X25519KeyPair,
+        my_ephemeral: X25519KeyPair,
         peer_static: x25519_dalek::PublicKey,
         prologue: &[u8],
         out: &mut [u8],
@@ -121,21 +112,21 @@ impl SentHandshake {
         assert_eq!(out.len(), Self::INIT_SIZE);
         let out: &mut Init<()> = Init::mut_from_bytes(out).unwrap();
 
-        out.ephemeral_pub = x25519_dalek::PublicKey::from(&my_ephemeral).to_bytes();
-        out.static_pub = x25519_dalek::PublicKey::from(&my_static).to_bytes();
+        out.ephemeral_pub = my_ephemeral.public.to_bytes();
+        out.static_pub = my_static.public.to_bytes();
 
         let state = State::new(PROTOCOL)
             .mix_hash(prologue) // prologue
             .mix_hash(peer_static.as_ref()) // <- s
             .mix_hash(&out.ephemeral_pub) // -> e
-            .mix_dh(&my_ephemeral, &peer_static) // es
+            .mix_dh(&my_ephemeral.private, &peer_static) // es
             .seal(&mut out.static_pub, &mut out.static_pub_tag) // s
-            .mix_dh(&my_static, &peer_static) // ss
+            .mix_dh(&my_static.private, &peer_static) // ss
             .seal(&mut [], &mut out.payload_tag); // payload
 
         SentHandshake {
             state,
-            my_ephemeral,
+            my_ephemeral: my_ephemeral.private,
         }
     }
 
@@ -144,11 +135,7 @@ impl SentHandshake {
     /// If successful, consumes `self` and returns keys for the new session.
     /// If the response is invalid, returns `Err(self)` to allow for another finalization
     /// attempt later.
-    pub fn try_finish(
-        self,
-        packet: &mut [u8],
-        my_static: x25519_dalek::StaticSecret,
-    ) -> Result<Session, Self> {
+    pub fn try_finish(self, packet: &mut [u8], my_static: X25519KeyPair) -> Result<Session, Self> {
         let Ok(packet) = Resp::mut_from_bytes(packet) else {
             return Err(self);
         };
@@ -159,7 +146,7 @@ impl SentHandshake {
         let ret = state
             .mix_hash(&packet.ephemeral_pub) // e
             .mix_dh(&self.my_ephemeral, &peer_ephemeral_pub) // ee
-            .mix_dh(&my_static, &peer_ephemeral_pub) // se
+            .mix_dh(&my_static.private, &peer_ephemeral_pub) // se
             .open(&mut [], &packet.auth_tag)
             .ok_or(self)? // payload
             .finish_as_initiator();
@@ -176,20 +163,20 @@ mod tests {
 
     use super::*;
 
-    fn test_key(r: Range<u8>) -> (x25519_dalek::StaticSecret, x25519_dalek::PublicKey) {
+    fn test_key(r: Range<u8>) -> X25519KeyPair {
         assert_eq!(r.len(), 32);
         let private = x25519_dalek::StaticSecret::from(r.collect_array().unwrap());
         let public = x25519_dalek::PublicKey::from(&private);
-        (private, public)
+        X25519KeyPair { private, public }
     }
 
     #[test]
     fn test_handshake() {
-        let (init_static, init_static_pub) = test_key(0..32);
-        let (init_ephemeral, _) = test_key(32..64);
+        let init_static = test_key(0..32);
+        let init_ephemeral = test_key(32..64);
 
-        let (resp_static, resp_static_pub) = test_key(64..96);
-        let (resp_ephemeral, _) = test_key(96..128);
+        let resp_static = test_key(64..96);
+        let resp_ephemeral = test_key(96..128);
 
         const PROLOGUE: &[u8] = b"TEST HANDSHAKE";
 
@@ -202,14 +189,14 @@ mod tests {
         let init_sent = SentHandshake::new_with_ephemeral(
             init_static.clone(),
             init_ephemeral,
-            resp_static_pub,
+            resp_static.public,
             PROLOGUE,
             &mut init_packet,
         );
         assert_eq!(init_packet, expected_init_packet.as_ref());
 
         let resp_recv = ReceivedHandshake::new(&mut init_packet, PROLOGUE, &resp_static).unwrap();
-        assert_eq!(resp_recv.peer_static_pub, init_static_pub);
+        assert_eq!(resp_recv.peer_static_pub, init_static.public);
 
         let mut resp_packet = [0; ReceivedHandshake::RESP_SIZE];
         let resp_session = resp_recv.finish_with_ephemeral(&mut resp_packet, resp_ephemeral);

--- a/ts_noise/src/ikpsk2.rs
+++ b/ts_noise/src/ikpsk2.rs
@@ -2,6 +2,7 @@
 
 use std::marker::PhantomData;
 
+use ts_keys::X25519KeyPair;
 use zerocopy::FromBytes;
 
 use crate::{
@@ -30,20 +31,19 @@ impl ReceivedHandshake {
     pub fn new<'packet, P: Pod>(
         packet: &'packet mut [u8],
         prologue: &[u8],
-        my_static: x25519_dalek::StaticSecret,
+        my_static: X25519KeyPair,
     ) -> Option<(Self, &'packet mut P)> {
         let packet: &mut Init<P> = Init::mut_from_bytes(packet).ok()?;
 
         let peer_ephemeral_pub = x25519_dalek::PublicKey::from(packet.ephemeral_pub);
-        let my_static_pub = x25519_dalek::PublicKey::from(&my_static);
 
         let handshake = State::new(PROTOCOL)
             .mix_hash(prologue) // prologue
-            .mix_hash(my_static_pub.as_ref()) // <- s ...
+            .mix_hash(my_static.public.as_ref()) // <- s ...
             .mix_hash_and_key(&peer_ephemeral_pub) // -> e
-            .mix_dh(&my_static, &peer_ephemeral_pub) // es
+            .mix_dh(&my_static.private, &peer_ephemeral_pub) // es
             .open(&mut packet.static_pub, &packet.static_pub_tag)? // s
-            .mix_dh(&my_static, &packet.static_pub.into()) // ss
+            .mix_dh(&my_static.private, &packet.static_pub.into()) // ss
             .open(packet.payload.as_mut_bytes(), &packet.payload_tag)?; // payload
 
         Some((
@@ -66,26 +66,25 @@ impl ReceivedHandshake {
     /// If `packet` is the wrong size.
     #[inline]
     pub fn finish(self, psk: &Psk, out: &mut [u8]) -> Session {
-        let ephemeral = x25519_dalek::StaticSecret::random();
+        let ephemeral = X25519KeyPair::random();
         self.finish_with_ephemeral(psk, ephemeral, out)
     }
 
     fn finish_with_ephemeral(
         self,
         psk: &Psk,
-        my_ephemeral: x25519_dalek::StaticSecret,
+        my_ephemeral: X25519KeyPair,
         out: &mut [u8],
     ) -> Session {
         assert_eq!(out.len(), Self::RESP_SIZE);
         let response = Resp::mut_from_bytes(out).unwrap();
 
-        let my_ephemeral_pub = x25519_dalek::PublicKey::from(&my_ephemeral);
-        response.ephemeral_pub = my_ephemeral_pub.to_bytes();
+        response.ephemeral_pub = my_ephemeral.public.to_bytes();
 
         self.state
-            .mix_hash_and_key(&my_ephemeral_pub) // <- e
-            .mix_dh(&my_ephemeral, &self.peer_ephemeral_pub) // ee
-            .mix_dh(&my_ephemeral, &self.peer_static_pub) // se
+            .mix_hash_and_key(&my_ephemeral.public) // <- e
+            .mix_dh(&my_ephemeral.private, &self.peer_ephemeral_pub) // ee
+            .mix_dh(&my_ephemeral.private, &self.peer_static_pub) // se
             .mix_psk(psk) // psk
             .seal(&mut [], &mut response.auth_tag) // payload
             .finish_as_responder()
@@ -110,19 +109,19 @@ impl<P: Pod> SentHandshake<P> {
     /// If `packet` is not [`SentHandshake::INIT_SIZE`] bytes.
     #[inline]
     pub fn new(
-        my_static: x25519_dalek::StaticSecret,
+        my_static: X25519KeyPair,
         peer_static: x25519_dalek::PublicKey,
         prologue: &[u8],
         payload: P,
         out: &mut [u8],
     ) -> Self {
-        let ephemeral = x25519_dalek::StaticSecret::random();
+        let ephemeral = X25519KeyPair::random();
         Self::new_with_ephemeral(my_static, ephemeral, peer_static, prologue, payload, out)
     }
 
     fn new_with_ephemeral(
-        my_static: x25519_dalek::StaticSecret,
-        my_ephemeral: x25519_dalek::StaticSecret,
+        my_static: X25519KeyPair,
+        my_ephemeral: X25519KeyPair,
         peer_static: x25519_dalek::PublicKey,
         prologue: &[u8],
         payload: P,
@@ -131,24 +130,22 @@ impl<P: Pod> SentHandshake<P> {
         assert_eq!(out.len(), Self::INIT_SIZE);
         let out: &mut Init<P> = Init::mut_from_bytes(out).unwrap();
 
-        let ephemeral_pub = x25519_dalek::PublicKey::from(&my_ephemeral);
-
-        out.ephemeral_pub = ephemeral_pub.to_bytes();
-        out.static_pub = x25519_dalek::PublicKey::from(&my_static).to_bytes();
+        out.ephemeral_pub = my_ephemeral.public.to_bytes();
+        out.static_pub = my_static.public.to_bytes();
         out.payload = payload;
 
         let state = State::new(PROTOCOL)
             .mix_hash(prologue) // prologue
             .mix_hash(peer_static.as_ref()) // <- s
-            .mix_hash_and_key(&ephemeral_pub) // -> e
-            .mix_dh(&my_ephemeral, &peer_static) // es
+            .mix_hash_and_key(&my_ephemeral.public) // -> e
+            .mix_dh(&my_ephemeral.private, &peer_static) // es
             .seal(&mut out.static_pub, &mut out.static_pub_tag) // s
-            .mix_dh(&my_static, &peer_static) // ss
+            .mix_dh(&my_static.private, &peer_static) // ss
             .seal(out.payload.as_mut_bytes(), &mut out.payload_tag); // payload
 
         SentHandshake {
             state,
-            my_ephemeral,
+            my_ephemeral: my_ephemeral.private,
             _phantom: PhantomData,
         }
     }
@@ -161,7 +158,7 @@ impl<P: Pod> SentHandshake<P> {
     pub fn try_finish(
         self,
         packet: &mut [u8],
-        my_static: x25519_dalek::StaticSecret,
+        my_static: X25519KeyPair,
         psk: &Psk,
     ) -> Result<Session, Self> {
         let Ok(packet) = Resp::mut_from_bytes(packet) else {
@@ -174,7 +171,7 @@ impl<P: Pod> SentHandshake<P> {
         let ret = state
             .mix_hash_and_key(&peer_ephemeral_pub) // e
             .mix_dh(&self.my_ephemeral, &peer_ephemeral_pub) // ee
-            .mix_dh(&my_static, &peer_ephemeral_pub) // se
+            .mix_dh(&my_static.private, &peer_ephemeral_pub) // se
             .mix_psk(psk) // psk
             .open(&mut [], &packet.auth_tag)
             .ok_or(self)?
@@ -192,20 +189,20 @@ mod tests {
 
     use super::*;
 
-    fn test_key(r: Range<u8>) -> (x25519_dalek::StaticSecret, x25519_dalek::PublicKey) {
+    fn test_key(r: Range<u8>) -> X25519KeyPair {
         assert_eq!(r.len(), 32);
         let private = x25519_dalek::StaticSecret::from(r.collect_array().unwrap());
         let public = x25519_dalek::PublicKey::from(&private);
-        (private, public)
+        X25519KeyPair { private, public }
     }
 
     #[test]
     fn test_handshake() {
-        let (init_static, init_static_pub) = test_key(0..32);
-        let (init_ephemeral, _) = test_key(32..64);
+        let init_static = test_key(0..32);
+        let init_ephemeral = test_key(32..64);
 
-        let (resp_static, resp_static_pub) = test_key(64..96);
-        let (resp_ephemeral, _) = test_key(96..128);
+        let resp_static = test_key(64..96);
+        let resp_ephemeral = test_key(96..128);
 
         let psk: Psk = (128..160).collect_array().unwrap();
 
@@ -221,7 +218,7 @@ mod tests {
         let init_sent = SentHandshake::<[u8; 12]>::new_with_ephemeral(
             init_static.clone(),
             init_ephemeral,
-            resp_static_pub,
+            resp_static.public,
             PROLOGUE,
             *PAYLOAD,
             &mut init_packet,
@@ -230,7 +227,7 @@ mod tests {
 
         let (resp_recv, resp_payload) =
             ReceivedHandshake::new::<[u8; 12]>(&mut init_packet, PROLOGUE, resp_static).unwrap();
-        assert_eq!(resp_recv.peer_static_pub, init_static_pub);
+        assert_eq!(resp_recv.peer_static_pub, init_static.public);
         assert_eq!(resp_payload, PAYLOAD);
 
         let mut resp_packet = [0; ReceivedHandshake::RESP_SIZE];

--- a/ts_tunnel/src/endpoint.rs
+++ b/ts_tunnel/src/endpoint.rs
@@ -393,7 +393,7 @@ impl Peer {
     ) {
         let Some(session) = self.handshake.finish(
             packet,
-            &endpoint.my_key.private,
+            &endpoint.my_key,
             &self.config.psk,
             &endpoint.my_cookie,
             Instant::now(),
@@ -515,7 +515,7 @@ impl Peer {
         // TODO most of this logic might be better in the `handshake` module.
         let session_id = endpoint.ids.allocate_session(self.id);
         let (handshake, packet) = initiate_handshake(
-            &endpoint.my_key.private,
+            &endpoint.my_key,
             &self.config.key,
             session_id,
             endpoint.timestamps.now(),

--- a/ts_tunnel/src/handshake.rs
+++ b/ts_tunnel/src/handshake.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use ts_keys::{NodeKeyPair, NodePrivateKey, NodePublicKey};
+use ts_keys::{NodeKeyPair, NodePublicKey};
 use ts_noise::ikpsk2;
 use ts_packet::PacketMut;
 use ts_time::Handle;
@@ -78,7 +78,7 @@ impl ReceivedHandshake {
 
 /// Generate a handshake initiation message for a peer.
 pub fn initiate_handshake(
-    endpoint_static: &NodePrivateKey,
+    endpoint_static: &NodeKeyPair,
     peer_static: &NodePublicKey,
     session_id: SessionId,
     timestamp: TAI64N,
@@ -190,7 +190,7 @@ impl Handshake {
     pub(crate) fn finish(
         &mut self,
         packet: &mut HandshakeResponse,
-        endpoint_static: &NodePrivateKey,
+        endpoint_static: &NodeKeyPair,
         psk: &Psk,
         cookies: &MACReceiver,
         now: Instant,
@@ -275,7 +275,7 @@ mod tests {
         let a_session = SessionId::random(); // A wants to receive at this ID
         let a_init_time = TAI64N::now();
         let (a_handshake, init_pkt) =
-            initiate_handshake(&a_static.private, &b_static.public, a_session, a_init_time);
+            initiate_handshake(&a_static, &b_static.public, a_session, a_init_time);
 
         let mut init_pkt = PacketMut::from(init_pkt.as_bytes());
         let handshake_mac = a_mac_send.write_macs(init_pkt.as_mut());
@@ -303,13 +303,9 @@ mod tests {
         // Peer A receives response
         let response_pkt = HandshakeResponse::try_mut_from_bytes(response_pkt.as_mut())
             .expect("response_pkt should be a valid handshake response message");
-        let Some(mut a_session) = a_handshake.finish(
-            response_pkt,
-            &a_static.private,
-            &psk,
-            &a_mac_recv,
-            Instant::now(),
-        ) else {
+        let Some(mut a_session) =
+            a_handshake.finish(response_pkt, &a_static, &psk, &a_mac_recv, Instant::now())
+        else {
             panic!("failed to process handshake response from peer B");
         };
 


### PR DESCRIPTION
This is sort of an RFC, it tidies up ts_noise a decent amount and avoids some pubkey recomputations, but maybe not worth it?

Two commits. The first introduces the new type and associated impls in ts_keys, the second is a mechanical refactor to use the new type in ts_noise and bubble out the function signature changes.