### PR TITLE
KV store: Handle non-unique index keys better

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5972,6 +5972,9 @@ dependencies = [
 [[package]]
 name = "ts_kv_store"
 version = "0.3.3"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "ts_netcheck"

--- a/ts_kv_store/Cargo.toml
+++ b/ts_kv_store/Cargo.toml
@@ -10,5 +10,8 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[dependencies]
+thiserror.workspace = true
+
 [lints]
 workspace = true

--- a/ts_kv_store/src/index.rs
+++ b/ts_kv_store/src/index.rs
@@ -86,7 +86,7 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
 
     /// Get a row of the table from the store by cloning the value.
     ///
-    /// Returns `None` if there is no value for the specified key.
+    /// Returns `AccessError::NotPresent` if there is no value for the specified key.
     pub fn get<Q>(&self, key: &Q) -> AccessResult<BaseValue<D>>
     where
         BaseValue<D>: Clone,
@@ -99,7 +99,7 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
 
     /// Get immutable access to a row of the table in the store by reference.
     ///
-    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    /// Returns `AccessError::NotPresent` (and does not call `f`) if there is no value for the specified key.
     pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> AccessResult<T>
     where
         D::Key: Borrow<Q>,
@@ -122,7 +122,7 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
 
     /// Get mutable access to a row of the table in the store in the store.
     ///
-    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    /// Returns `AccessError::NotPresent` (and does not call `f`) if there is no value for the specified key.
     pub fn with_mut<Q, T>(&self, key: &Q, f: impl FnOnce(&mut BaseValue<D>) -> T) -> AccessResult<T>
     where
         D::Key: Borrow<Q>,
@@ -265,7 +265,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
 
     /// Get a row of the table from the store by cloning the value.
     ///
-    /// Returns `None` if there is no value for the specified key.
+    /// Returns `AccessError::NotPresent` if there is no value for the specified key.
     pub fn get<Q>(&self, key: &Q) -> AccessResult<BaseValue<D>>
     where
         BaseValue<D>: Clone,
@@ -278,7 +278,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
 
     /// Get immutable access to a row of the table in the store by reference.
     ///
-    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    /// Returns `AccessError::NotPresent` (and does not call `f`) if there is no value for the specified key.
     pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> AccessResult<T>
     where
         D::Key: Borrow<Q>,
@@ -301,7 +301,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
 
     /// Get mutable access to a row of the table in the store in the store.
     ///
-    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    /// Returns `AccessError::NotPresent` (and does not call `f`) if there is no value for the specified key.
     pub fn with_mut<Q, T>(
         &mut self,
         key: &Q,
@@ -412,7 +412,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableRoTransactionalIndex<'guard, 'txn, D> {
 
     /// Get a row of the table from the store by cloning the value.
     ///
-    /// Returns `None` if there is no value for the specified key.
+    /// Returns `AccessError::NotPresent` if there is no value for the specified key.
     pub fn get<Q>(&self, key: &Q) -> AccessResult<BaseValue<D>>
     where
         BaseValue<D>: Clone,
@@ -425,7 +425,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableRoTransactionalIndex<'guard, 'txn, D> {
 
     /// Get immutable access to a row of the table in the store by reference.
     ///
-    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    /// Returns `AccessError::NotPresent` (and does not call `f`) if there is no value for the specified key.
     pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> AccessResult<T>
     where
         D::Key: Borrow<Q>,
@@ -1894,6 +1894,36 @@ mod test_poison {
         assert!(index.check_consistent().is_ok());
         assert!(index.get("Alice").is_none());
         assert!(store.table::<Users>(OWNER).is_empty());
+    }
+
+    #[test]
+    fn txn_poison_against_committed_rolled_back() {
+        let store = KvStore::new();
+        // Commit Alice(1) first, so the "Alice" name-index entry is already committed.
+        store
+            .table::<Users>(OWNER)
+            .insert(1, row("Alice", "alice1@x.com"));
+
+        {
+            // This txn collides with the *already-committed* "Alice" index entry, so the index is
+            // poisoned without it ever being recorded as `modified` within the txn.
+            let mut txn = store.begin_transaction(OWNER);
+            txn.table::<Users>().insert(2, row("Alice", "alice2@x.com"));
+            // rollback on drop
+        }
+
+        // An unrelated, valid commit must succeed — the rolled-back poison must not leak into it.
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Users>().insert(3, row("Bob", "bob@x.com"));
+        txn.commit().unwrap();
+
+        let index = store.table_by::<index::Users::name>(OWNER);
+        assert!(
+            index.check_consistent().is_ok(),
+            "index should not be poisoned after the colliding txn was rolled back"
+        );
+        assert_eq!(index.get("Alice").unwrap(), row("Alice", "alice1@x.com"));
+        assert_eq!(index.get("Bob").unwrap(), row("Bob", "bob@x.com"));
     }
 
     #[test]

--- a/ts_kv_store/src/index.rs
+++ b/ts_kv_store/src/index.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::{
-    KvStore, Owner, Result, RoTransaction, Transaction,
+    AccessResult, KvStore, Owner, Result, RoTransaction, Transaction,
     operations::{Base, BaseKey, BaseValue, IndexValue, IndexedOps, IndexedOpsMut, Ops, OpsMut},
     schema::{IndexDesc, TableDesc},
     storage::Storage,
@@ -71,6 +71,11 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
         <&Self as IndexedOps<_>>::is_empty(self)
     }
 
+    /// Returns `Ok` if the index is consistent, and an error with some kind of explanation if not.
+    pub fn check_consistent(&self) -> Result<()> {
+        <&Self as IndexedOps<_>>::check_consistent(self)
+    }
+
     /// Clear the base table by removing all its KVs, but preserving ownership.
     pub fn clear(&self)
     where
@@ -82,7 +87,7 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     /// Get a row of the table from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<Q>(&self, key: &Q) -> Option<BaseValue<D>>
+    pub fn get<Q>(&self, key: &Q) -> AccessResult<BaseValue<D>>
     where
         BaseValue<D>: Clone,
         D::Key: Borrow<Q>,
@@ -95,7 +100,7 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> Option<T>
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> AccessResult<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -118,7 +123,7 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     /// Get mutable access to a row of the table in the store in the store.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with_mut<Q, T>(&self, key: &Q, f: impl FnOnce(&mut BaseValue<D>) -> T) -> Option<T>
+    pub fn with_mut<Q, T>(&self, key: &Q, f: impl FnOnce(&mut BaseValue<D>) -> T) -> AccessResult<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -246,6 +251,10 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
         <&Self as IndexedOps<_>>::is_empty(self)
     }
 
+    pub fn check_consistent(&self) -> Result<()> {
+        <&Self as IndexedOps<_>>::check_consistent(self)
+    }
+
     /// Clear the base table by removing all its KVs, but preserving ownership.
     pub fn clear(&mut self)
     where
@@ -257,7 +266,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
     /// Get a row of the table from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<Q>(&self, key: &Q) -> Option<BaseValue<D>>
+    pub fn get<Q>(&self, key: &Q) -> AccessResult<BaseValue<D>>
     where
         BaseValue<D>: Clone,
         D::Key: Borrow<Q>,
@@ -270,7 +279,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> Option<T>
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> AccessResult<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -293,7 +302,11 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
     /// Get mutable access to a row of the table in the store in the store.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with_mut<Q, T>(&mut self, key: &Q, f: impl FnOnce(&mut BaseValue<D>) -> T) -> Option<T>
+    pub fn with_mut<Q, T>(
+        &mut self,
+        key: &Q,
+        f: impl FnOnce(&mut BaseValue<D>) -> T,
+    ) -> AccessResult<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -393,10 +406,14 @@ impl<'guard, 'txn, D: IndexDesc> KvTableRoTransactionalIndex<'guard, 'txn, D> {
         <&Self as IndexedOps<_>>::is_empty(self)
     }
 
+    pub fn check_consistent(&self) -> Result<()> {
+        <&Self as IndexedOps<_>>::check_consistent(self)
+    }
+
     /// Get a row of the table from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<Q>(&self, key: &Q) -> Option<BaseValue<D>>
+    pub fn get<Q>(&self, key: &Q) -> AccessResult<BaseValue<D>>
     where
         BaseValue<D>: Clone,
         D::Key: Borrow<Q>,
@@ -409,7 +426,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableRoTransactionalIndex<'guard, 'txn, D> {
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> Option<T>
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> AccessResult<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -447,7 +464,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableRoTransactionalIndex<'guard, 'txn, D> {
 
 #[cfg(test)]
 mod test {
-    use crate::{Error, tables};
+    use crate::{AccessErrorExt, Error, tables};
 
     #[derive(Clone, Debug, PartialEq)]
     pub struct Row {
@@ -584,7 +601,7 @@ mod test {
         let len = store
             .table_by::<index::Users::name>(OWNER)
             .with("Alice", |v| v.name.len());
-        assert_eq!(len, Some(5));
+        assert_eq!(len.unwrap_opt(), Some(5));
     }
 
     #[test]
@@ -658,7 +675,8 @@ mod test {
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         store
             .table_by::<index::Users::name>(OWNER)
-            .with_mut("Alice", |v| v.name.push_str(" Smith"));
+            .with_mut("Alice", |v| v.name.push_str(" Smith"))
+            .unwrap();
         let value = store.table::<Users>(OWNER).get(&1).unwrap();
         assert_eq!(value.name, "Alice Smith");
     }
@@ -671,7 +689,8 @@ mod test {
             .table_by::<index::Users::name>(OWNER)
             .with_mut("Alice", |v| {
                 v.name = "Charlie".to_owned();
-            });
+            })
+            .unwrap();
         assert!(
             store
                 .table_by::<index::Users::name>(OWNER)
@@ -870,8 +889,11 @@ mod test {
                 .is_none()
         );
         assert_eq!(
-            store.table_by::<index::Users::name>(OWNER).get("Charlie"),
-            Some(row("Charlie"))
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Charlie")
+                .unwrap(),
+            row("Charlie"),
         );
     }
 
@@ -889,8 +911,11 @@ mod test {
                 .is_none()
         );
         assert_eq!(
-            store.table_by::<index::Users::name>(OWNER).get("Charlie"),
-            Some(row("Charlie"))
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Charlie")
+                .unwrap(),
+            row("Charlie")
         );
     }
 
@@ -917,7 +942,7 @@ mod test {
 
 #[cfg(test)]
 mod test_two_indexes {
-    use crate::tables;
+    use crate::{AccessErrorExt, tables};
 
     #[derive(Clone, Debug, PartialEq)]
     pub struct Person {
@@ -965,14 +990,16 @@ mod test_two_indexes {
         assert_eq!(
             store
                 .table_by::<index::People::email>(OWNER)
-                .get("a@example.com"),
-            Some(person("a@example.com", b"alice"))
+                .get("a@example.com")
+                .unwrap(),
+            person("a@example.com", b"alice")
         );
         assert_eq!(
             store
                 .table_by::<index::People::username>(OWNER)
-                .get(b"alice".as_slice()),
-            Some(person("a@example.com", b"alice"))
+                .get(b"alice".as_slice())
+                .unwrap(),
+            person("a@example.com", b"alice")
         );
     }
 
@@ -985,14 +1012,16 @@ mod test_two_indexes {
         assert_eq!(
             store
                 .table_by::<index::People::email>(OWNER)
-                .get("a@example.com"),
-            Some(person("a@example.com", b"alice"))
+                .get("a@example.com")
+                .unwrap(),
+            person("a@example.com", b"alice")
         );
         assert_eq!(
             store
                 .table_by::<index::People::username>(OWNER)
-                .get(b"alice".as_slice()),
-            Some(person("a@example.com", b"alice"))
+                .get(b"alice".as_slice())
+                .unwrap(),
+            person("a@example.com", b"alice")
         );
     }
 
@@ -1009,14 +1038,16 @@ mod test_two_indexes {
         assert_eq!(
             store
                 .table_by::<index::People::email>(OWNER)
-                .get("a@example.com"),
-            Some(person("a@example.com", b"alice"))
+                .get("a@example.com")
+                .unwrap(),
+            person("a@example.com", b"alice")
         );
         assert_eq!(
             store
                 .table_by::<index::People::username>(OWNER)
-                .get(b"bob".as_slice()),
-            Some(person("b@example.com", b"bob"))
+                .get(b"bob".as_slice())
+                .unwrap(),
+            person("b@example.com", b"bob")
         );
     }
 
@@ -1218,7 +1249,7 @@ mod test_two_indexes {
 
 #[cfg(test)]
 mod test_transactional_index {
-    use crate::tables;
+    use crate::{AccessErrorExt, tables};
 
     #[derive(Clone, Debug, PartialEq)]
     pub struct Row {
@@ -1252,13 +1283,16 @@ mod test_transactional_index {
         let mut txn = store.begin_transaction(OWNER);
         txn.table_by::<index::Users::name>().insert(1, row("Alice"));
         assert_eq!(
-            txn.table_by::<index::Users::name>().get("Alice"),
-            Some(row("Alice"))
+            txn.table_by::<index::Users::name>().get("Alice").unwrap(),
+            row("Alice")
         );
         txn.commit().unwrap();
         assert_eq!(
-            store.table_by::<index::Users::name>(OWNER).get("Alice"),
-            Some(row("Alice"))
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Alice")
+                .unwrap(),
+            row("Alice")
         );
 
         let mut txn = store.begin_transaction(OWNER);
@@ -1287,8 +1321,9 @@ mod test_transactional_index {
         txn.table_by::<index::Users::name>().insert(1, row("Alice"));
         assert_eq!(
             txn.table_by::<index::Users::name>()
-                .with("Alice", |v| v.name.len()),
-            Some(5)
+                .with("Alice", |v| v.name.len())
+                .unwrap(),
+            5
         );
     }
 
@@ -1298,14 +1333,15 @@ mod test_transactional_index {
         let mut txn = store.begin_transaction(OWNER);
         txn.table_by::<index::Users::name>().insert(1, row("Alice"));
         txn.table_by::<index::Users::name>()
-            .with_mut("Alice", |v| v.name = "Bob".to_owned());
+            .with_mut("Alice", |v| v.name = "Bob".to_owned())
+            .unwrap();
         assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
         assert_eq!(
-            txn.table_by::<index::Users::name>().get("Bob"),
-            Some(Row {
+            txn.table_by::<index::Users::name>().get("Bob").unwrap(),
+            Row {
                 name: "Bob".to_owned(),
                 age: 0
-            })
+            }
         );
     }
 
@@ -1315,13 +1351,14 @@ mod test_transactional_index {
         let mut txn = store.begin_transaction(OWNER);
         txn.table_by::<index::Users::name>().insert(1, row("Alice"));
         txn.table_by::<index::Users::name>()
-            .with_mut("Alice", |v| v.age = 42);
+            .with_mut("Alice", |v| v.age = 42)
+            .unwrap();
         assert_eq!(
-            txn.table_by::<index::Users::name>().get("Alice"),
-            Some(Row {
+            txn.table_by::<index::Users::name>().get("Alice").unwrap(),
+            Row {
                 name: "Alice".to_owned(),
                 age: 42
-            })
+            }
         );
     }
 
@@ -1365,11 +1402,11 @@ mod test_transactional_index {
             .for_each_mut(|_, v| v.name = "Charlie".to_owned());
         assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
         assert_eq!(
-            txn.table_by::<index::Users::name>().get("Charlie"),
-            Some(Row {
+            txn.table_by::<index::Users::name>().get("Charlie").unwrap(),
+            Row {
                 name: "Charlie".to_owned(),
                 age: 0
-            })
+            }
         );
     }
 
@@ -1379,8 +1416,8 @@ mod test_transactional_index {
         let mut txn = store.begin_transaction(OWNER);
         txn.table::<Users>().insert(1, row("Alice"));
         assert_eq!(
-            txn.table_by::<index::Users::name>().get("Alice"),
-            Some(row("Alice"))
+            txn.table_by::<index::Users::name>().get("Alice").unwrap(),
+            row("Alice")
         );
     }
 
@@ -1393,11 +1430,11 @@ mod test_transactional_index {
             .with_mut(&1, |v| v.name = "Bob".to_owned());
         assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
         assert_eq!(
-            txn.table_by::<index::Users::name>().get("Bob"),
-            Some(Row {
+            txn.table_by::<index::Users::name>().get("Bob").unwrap(),
+            Row {
                 name: "Bob".to_owned(),
                 age: 0
-            })
+            }
         );
     }
 
@@ -1430,11 +1467,11 @@ mod test_transactional_index {
             .for_each_mut(|_, v| v.name = "Charlie".to_owned());
         assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
         assert_eq!(
-            txn.table_by::<index::Users::name>().get("Charlie"),
-            Some(Row {
+            txn.table_by::<index::Users::name>().get("Charlie").unwrap(),
+            Row {
                 name: "Charlie".to_owned(),
                 age: 0
-            })
+            }
         );
     }
 
@@ -1451,8 +1488,8 @@ mod test_transactional_index {
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         let txn = store.begin_ro_transaction(OWNER);
         assert_eq!(
-            txn.table_by::<index::Users::name>().get("Alice"),
-            Some(row("Alice"))
+            txn.table_by::<index::Users::name>().get("Alice").unwrap(),
+            row("Alice")
         );
     }
 
@@ -1463,8 +1500,9 @@ mod test_transactional_index {
         let txn = store.begin_ro_transaction(OWNER);
         assert_eq!(
             txn.table_by::<index::Users::name>()
-                .with("Alice", |v| v.name.len()),
-            Some(5)
+                .with("Alice", |v| v.name.len())
+                .unwrap(),
+            5
         );
     }
 
@@ -1554,11 +1592,15 @@ mod test_transactional_index {
         {
             let mut txn = store.begin_transaction(OWNER);
             txn.table_by::<index::Users::name>()
-                .with_mut("Alice", |v| v.name = "Bob".to_owned());
+                .with_mut("Alice", |v| v.name = "Bob".to_owned())
+                .unwrap();
         }
         assert_eq!(
-            store.table_by::<index::Users::name>(OWNER).get("Alice"),
-            Some(row("Alice"))
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Alice")
+                .unwrap(),
+            row("Alice")
         );
         assert!(
             store
@@ -1578,8 +1620,11 @@ mod test_transactional_index {
             txn.table_by::<index::Users::name>().remove("Alice");
         }
         assert_eq!(
-            store.table_by::<index::Users::name>(OWNER).get("Alice"),
-            Some(row("Alice"))
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Alice")
+                .unwrap(),
+            row("Alice")
         );
         assert_eq!(store.table::<Users>(OWNER).get(&1), Some(row("Alice")));
     }
@@ -1594,12 +1639,18 @@ mod test_transactional_index {
             txn.table_by::<index::Users::name>().clear();
         }
         assert_eq!(
-            store.table_by::<index::Users::name>(OWNER).get("Alice"),
-            Some(row("Alice"))
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Alice")
+                .unwrap(),
+            row("Alice")
         );
         assert_eq!(
-            store.table_by::<index::Users::name>(OWNER).get("Bob"),
-            Some(row("Bob"))
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Bob")
+                .unwrap(),
+            row("Bob")
         );
     }
 
@@ -1613,14 +1664,267 @@ mod test_transactional_index {
         txn.commit().unwrap();
 
         assert_eq!(
-            store.table_by::<index::Users::name>(OWNER).get("Alice"),
-            Some(row("Alice"))
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Alice")
+                .unwrap(),
+            row("Alice")
         );
         assert_eq!(
-            store.table_by::<index::Users::name>(OWNER).get("Bob"),
-            Some(row("Bob"))
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .get("Bob")
+                .unwrap(),
+            row("Bob")
         );
         assert_eq!(store.table::<Users>(OWNER).get(&1), Some(row("Alice")));
         assert_eq!(store.table::<Users>(OWNER).get(&2), Some(row("Bob")));
+    }
+}
+
+#[cfg(test)]
+mod test_poison {
+    use crate::{AccessError, AccessErrorExt, Error, tables};
+
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct Row {
+        pub name: String,
+        pub email: String,
+    }
+
+    fn row(name: &str, email: &str) -> Row {
+        Row {
+            name: name.to_owned(),
+            email: email.to_owned(),
+        }
+    }
+
+    tables!(
+        Users(u32 => Row; index(name: String); index(email: String)),
+        AssertingUsers(u32 => Row; index(name: String; assert_unique))
+    );
+
+    const OWNER: &str = "owner";
+
+    #[test]
+    fn ops_return_error_when_poisoned() {
+        let store = KvStore::new();
+        store
+            .table::<Users>(OWNER)
+            .insert(1, row("Alice", "alice1@x.com"));
+        store
+            .table::<Users>(OWNER)
+            .insert(2, row("Alice", "alice2@x.com"));
+
+        let index_name = store.table_by::<index::Users::name>(OWNER);
+        assert_eq!(
+            index_name.check_consistent(),
+            Err(Error::NonUniqueIndexKey("Users by name"))
+        );
+
+        let result = index_name.get("Alice");
+        assert!(matches!(result, Err(AccessError::NonUniqueIndexKey(_))));
+        assert!(!result.is_none());
+        assert!(!result.is_some());
+
+        // The `panic`s check that the closure is not called.
+        let result = index_name.with("Alice", |_| panic!());
+        assert!(matches!(result, Err(AccessError::NonUniqueIndexKey(_))));
+
+        let result = index_name.with_mut("Alice", |_| panic!());
+        assert!(matches!(result, Err(AccessError::NonUniqueIndexKey(_))));
+    }
+
+    #[test]
+    fn check_consistent_ok_when_unique() {
+        let store = KvStore::new();
+        store
+            .table::<Users>(OWNER)
+            .insert(1, row("Alice", "alice1@x.com"));
+        assert!(
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .check_consistent()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn poisoned_via_index_insert() {
+        let store = KvStore::new();
+        let index = store.table_by::<index::Users::name>(OWNER);
+        index.insert(1, row("Alice", "alice1@x.com"));
+        index.insert(2, row("Alice", "alice2@x.com"));
+
+        assert!(matches!(
+            index.check_consistent(),
+            Err(Error::NonUniqueIndexKey(_))
+        ));
+        assert!(matches!(
+            index.get("Alice"),
+            Err(AccessError::NonUniqueIndexKey(_))
+        ));
+    }
+
+    #[test]
+    fn base_table_unaffected_when_index_poisoned() {
+        let store = KvStore::new();
+        store
+            .table::<Users>(OWNER)
+            .insert(1, row("Alice", "alice1@x.com"));
+        store
+            .table::<Users>(OWNER)
+            .insert(2, row("Alice", "alice2@x.com"));
+
+        // The `name` index is poisoned, but the base table can still be read by primary key.
+        assert_eq!(
+            store.table::<Users>(OWNER).get(&1),
+            Some(row("Alice", "alice1@x.com"))
+        );
+        assert_eq!(
+            store.table::<Users>(OWNER).get(&2),
+            Some(row("Alice", "alice2@x.com"))
+        );
+    }
+
+    #[test]
+    fn sibling_index_not_poisoned() {
+        let store = KvStore::new();
+        store
+            .table::<Users>(OWNER)
+            .insert(1, row("Alice", "alice1@x.com"));
+        store
+            .table::<Users>(OWNER)
+            .insert(2, row("Alice", "alice2@x.com"));
+
+        // `name` is poisoned (both "Alice")...
+        assert!(matches!(
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .check_consistent(),
+            Err(Error::NonUniqueIndexKey(_))
+        ));
+        // ...but `email` has distinct keys and stays consistent.
+        let email_index = store.table_by::<index::Users::email>(OWNER);
+        assert!(email_index.check_consistent().is_ok());
+        assert_eq!(
+            email_index.get("alice1@x.com").unwrap(),
+            row("Alice", "alice1@x.com")
+        );
+        assert_eq!(
+            email_index.get("alice2@x.com").unwrap(),
+            row("Alice", "alice2@x.com")
+        );
+    }
+
+    #[test]
+    fn clear_unpoisons() {
+        let store = KvStore::new();
+        store
+            .table::<Users>(OWNER)
+            .insert(1, row("Alice", "alice1@x.com"));
+        store
+            .table::<Users>(OWNER)
+            .insert(2, row("Alice", "alice2@x.com"));
+
+        let index = store.table_by::<index::Users::name>(OWNER);
+        assert!(index.check_consistent().is_err());
+
+        index.clear();
+        assert!(index.check_consistent().is_ok());
+        assert!(index.get("Alice").is_none());
+    }
+
+    #[test]
+    fn txn_get_returns_error_when_poisoned() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Users>().insert(1, row("Alice", "alice1@x.com"));
+        txn.table::<Users>().insert(2, row("Alice", "alice2@x.com"));
+
+        assert!(matches!(
+            txn.table_by::<index::Users::name>().get("Alice"),
+            Err(AccessError::NonUniqueIndexKey(_))
+        ));
+    }
+
+    #[test]
+    fn txn_check_consistent_errors_when_poisoned() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Users>().insert(1, row("Alice", "alice1@x.com"));
+        txn.table::<Users>().insert(2, row("Alice", "alice2@x.com"));
+
+        assert!(matches!(
+            txn.table_by::<index::Users::name>().check_consistent(),
+            Err(Error::NonUniqueIndexKey(_))
+        ));
+    }
+
+    #[test]
+    fn txn_commit_fails_when_index_poisoned() {
+        let store = KvStore::new();
+        {
+            let mut txn = store.begin_transaction(OWNER);
+            txn.table::<Users>().insert(1, row("Alice", "alice1@x.com"));
+            txn.table::<Users>().insert(2, row("Alice", "alice2@x.com"));
+            assert!(matches!(txn.commit(), Err(Error::NonUniqueIndexKey(_))));
+        }
+
+        // The failed commit rolled everything back: the store is clean and consistent.
+        assert!(store.table::<Users>(OWNER).get(&1).is_none());
+        assert!(store.table::<Users>(OWNER).get(&2).is_none());
+        assert!(
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .check_consistent()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn txn_poison_rolled_back_on_drop() {
+        let store = KvStore::new();
+        {
+            let mut txn = store.begin_transaction(OWNER);
+            txn.table::<Users>().insert(1, row("Alice", "alice1@x.com"));
+            txn.table::<Users>().insert(2, row("Alice", "alice2@x.com"));
+            // dropped without committing
+        }
+
+        let index = store.table_by::<index::Users::name>(OWNER);
+        assert!(index.check_consistent().is_ok());
+        assert!(index.get("Alice").is_none());
+        assert!(store.table::<Users>(OWNER).is_empty());
+    }
+
+    #[test]
+    fn assert_unique_distinct_keys_ok() {
+        let store = KvStore::new();
+        store
+            .table::<AssertingUsers>(OWNER)
+            .insert(1, row("Alice", "alice1@x.com"));
+        store
+            .table::<AssertingUsers>(OWNER)
+            .insert(2, row("Bob", "bob@x.com"));
+        assert_eq!(
+            store
+                .table_by::<index::AssertingUsers::name>(OWNER)
+                .get("Alice")
+                .unwrap(),
+            row("Alice", "alice1@x.com")
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "non-unique")]
+    fn assert_unique_duplicate_base_insert_panics() {
+        let store = KvStore::new();
+        store
+            .table::<AssertingUsers>(OWNER)
+            .insert(1, row("Alice", "alice1@x.com"));
+        store
+            .table::<AssertingUsers>(OWNER)
+            .insert(2, row("Alice", "alice2@x.com"));
     }
 }

--- a/ts_kv_store/src/index.rs
+++ b/ts_kv_store/src/index.rs
@@ -1724,10 +1724,8 @@ mod test_poison {
 
         let result = index_name.get("Alice");
         assert!(matches!(result, Err(AccessError::NonUniqueIndexKey(_))));
-        assert!(!result.is_none());
-        assert!(!result.is_some());
 
-        // The `panic`s check that the closure is not called.
+        // The `panic`s ensure that the closure is not called.
         let result = index_name.with("Alice", |_| panic!());
         assert!(matches!(result, Err(AccessError::NonUniqueIndexKey(_))));
 

--- a/ts_kv_store/src/lib.rs
+++ b/ts_kv_store/src/lib.rs
@@ -78,8 +78,8 @@
 //! The key type is `Url` and the value type is `u64`.
 //!
 //! Index fields must uniquely identify a row in the base table. If multiple rows in the base table
-//! have the same key in the index, then behavior is unspecified (might give partial or incorrect
-//! result, might panic, etc.).
+//! have the same key in the index, then either a panic is triggered, or accessing or committing a
+//! non-unique index will cause an error. See the schema macro docs for more.
 //!
 //! # Async access
 //!
@@ -246,7 +246,7 @@ impl<'store, TableStorage: schema::GeneratedStorage> operations::OpsMut<TableSto
 pub type Owner = &'static str;
 
 /// An error from a [`KvStore`].
-#[derive(thiserror::Error, Debug, Clone)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq)]
 pub enum Error {
     /// A table was expected to not be initialized, but was by the specified `Owner`.
     #[error("A table has already been initialized with owner `{0}`")]
@@ -254,7 +254,87 @@ pub enum Error {
     /// An inconsistency caused a transaction to fail. It has not been committed and can be re-tried.
     #[error("Transaction Failed")]
     TransactionFailed,
+    /// An index had multiple primary keys for a single index key. If returned when committing a
+    /// transaction, the transaction will not have been committed.
+    #[error("An attempt to store a non-unique index key in `{0}`")]
+    NonUniqueIndexKey(&'static str),
+}
+
+/// An error occuring during accessing of the store.
+#[derive(thiserror::Error, Debug, Clone, PartialEq)]
+pub enum AccessError {
+    /// The requested key is not present in the store.
+    #[error("Key not found")]
+    NotPresent,
+    /// An index had multiple primary keys for a single index key. If returned when committing a
+    /// transaction, the transaction will not have been committed.
+    #[error("An attempt to store a non-unique index key in `{0}`")]
+    NonUniqueIndexKey(&'static str),
 }
 
 /// `Result` alias for a KvStore [`Error`].
 pub type Result<T> = std::result::Result<T, Error>;
+
+/// `Result` alias for a KvStore [`AccessError`].
+pub type AccessResult<T> = std::result::Result<T, AccessError>;
+
+/// Helper trait for making it easier for [`AccessError`] and `Option` to interoperate.
+///
+/// The key observation is that `Result<T, AccessError>` is logically equivalent to `Result<Option<T>, Error>`
+/// (well a 'subtype' of sorts). This trait allows treating `Result<T, AccessError>` a bit more like
+/// an `Option` in various ways so that using functions which return `Result<T, AccessError>` can be
+/// more ergonomic. (Annoyingly we can't implement helpers directly on `Result` or make conversion
+/// via `From` work).
+pub trait AccessErrorExt<T> {
+    /// Convert a `Result<T, AccessError>` into `Result<Option<T>, Error>`.
+    fn try_opt(self) -> Result<Option<T>>;
+    /// Convert a `Result<T, AccessError>` into `Option<T>`, panicking if the `AccessError` is anything
+    /// other than `NotPresent`.
+    fn unwrap_opt(self) -> Option<T>;
+    /// Convert a `&Result<T, AccessError>` into `&Option<T>`, panicking if the `AccessError` is anything
+    /// other than `NotPresent`.
+    fn unwrap_opt_ref(&self) -> Option<&T>;
+    /// True if self is `Ok`, i.e., there was no error and the requested key was present.
+    fn is_some(&self) -> bool;
+    /// True if self is `Err(AccessError::NotPresent)`, i.e., there was no error and the requested
+    /// key was not present.
+    fn is_none(&self) -> bool;
+}
+
+impl<T> AccessErrorExt<T> for AccessResult<T> {
+    fn try_opt(self) -> Result<Option<T>> {
+        match self {
+            Ok(t) => Ok(Some(t)),
+            Err(AccessError::NotPresent) => Ok(None),
+            Err(AccessError::NonUniqueIndexKey(t)) => Err(Error::NonUniqueIndexKey(t)),
+        }
+    }
+
+    fn unwrap_opt(self) -> Option<T> {
+        match self {
+            Ok(t) => Some(t),
+            Err(AccessError::NotPresent) => None,
+            Err(e @ AccessError::NonUniqueIndexKey(_)) => {
+                panic!("Expected `Ok` or not present, found: {e}")
+            }
+        }
+    }
+
+    fn unwrap_opt_ref(&self) -> Option<&T> {
+        match self {
+            Ok(t) => Some(t),
+            Err(AccessError::NotPresent) => None,
+            Err(e @ AccessError::NonUniqueIndexKey(_)) => {
+                panic!("Expected `Ok` or not present, found: {e}")
+            }
+        }
+    }
+
+    fn is_some(&self) -> bool {
+        self.is_ok()
+    }
+
+    fn is_none(&self) -> bool {
+        matches!(self, Err(AccessError::NotPresent))
+    }
+}

--- a/ts_kv_store/src/lib.rs
+++ b/ts_kv_store/src/lib.rs
@@ -246,12 +246,13 @@ impl<'store, TableStorage: schema::GeneratedStorage> operations::OpsMut<TableSto
 pub type Owner = &'static str;
 
 /// An error from a [`KvStore`].
-// TODO derive(Error)
-#[derive(Debug, Clone)]
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum Error {
     /// A table was expected to not be initialized, but was by the specified `Owner`.
+    #[error("A table has already been initialized with owner `{0}`")]
     AlreadyInit(Owner),
     /// An inconsistency caused a transaction to fail. It has not been committed and can be re-tried.
+    #[error("Transaction Failed")]
     TransactionFailed,
 }
 

--- a/ts_kv_store/src/operations.rs
+++ b/ts_kv_store/src/operations.rs
@@ -233,7 +233,7 @@ pub(crate) trait IndexedOps<TableStorage: schema::GeneratedStorage>:
 
         if index.is_poisoned(storage.txn_id()) {
             Err(crate::Error::NonUniqueIndexKey(
-                <Self::IndexDesc as TableDesc>::name(),
+                <Self::IndexDesc as TableDesc>::NAME,
             ))
         } else {
             Ok(())
@@ -253,7 +253,7 @@ pub(crate) trait IndexedOps<TableStorage: schema::GeneratedStorage>:
         let index = <Self::IndexDesc as TableDesc>::get_table(&storage.tables);
         if index.is_poisoned(storage.txn_id()) {
             return Err(AccessError::NonUniqueIndexKey(
-                <Self::IndexDesc as TableDesc>::name(),
+                <Self::IndexDesc as TableDesc>::NAME,
             ));
         }
         let base_key = index
@@ -281,7 +281,7 @@ pub(crate) trait IndexedOps<TableStorage: schema::GeneratedStorage>:
         let index = <Self::IndexDesc>::get_table(&storage.tables);
         if index.is_poisoned(storage.txn_id()) {
             return Err(AccessError::NonUniqueIndexKey(
-                <Self::IndexDesc as TableDesc>::name(),
+                <Self::IndexDesc as TableDesc>::NAME,
             ));
         }
         let base_key = index
@@ -529,7 +529,7 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
         );
         if index.is_poisoned(txn_id) {
             return Err(AccessError::NonUniqueIndexKey(
-                <Self::IndexDesc as TableDesc>::name(),
+                <Self::IndexDesc as TableDesc>::NAME,
             ));
         }
         base.assert_owner(owner);

--- a/ts_kv_store/src/operations.rs
+++ b/ts_kv_store/src/operations.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use crate::{
-    IndexIterator, Owner, Result, TableIterator, iter,
+    AccessError, AccessResult, IndexIterator, Owner, Result, TableIterator, iter,
     schema::{self, IndexDesc, TableDesc},
     storage::Storage,
 };
@@ -226,7 +226,21 @@ pub(crate) trait IndexedOps<TableStorage: schema::GeneratedStorage>:
         base.is_empty(storage.txn_id())
     }
 
-    fn get<Q>(self, key: &Q, _owner: Owner) -> Option<BaseValue<Self::IndexDesc>>
+    fn check_consistent(self) -> Result<()> {
+        let storage = self.read_lock();
+        let storage = storage.storage();
+        let index = <Self::IndexDesc as TableDesc>::get_table(&storage.tables);
+
+        if index.is_poisoned(storage.txn_id()) {
+            Err(crate::Error::NonUniqueIndexKey(
+                <Self::IndexDesc as TableDesc>::name(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn get<Q>(self, key: &Q, _owner: Owner) -> AccessResult<BaseValue<Self::IndexDesc>>
     where
         IndexKey<Self::IndexDesc>: Borrow<Q>,
         IndexValue<Self::IndexDesc>: Hash + Eq,
@@ -237,8 +251,17 @@ pub(crate) trait IndexedOps<TableStorage: schema::GeneratedStorage>:
         let storage = storage.storage();
         let base = Base::<Self::IndexDesc>::get_table(&storage.tables);
         let index = <Self::IndexDesc as TableDesc>::get_table(&storage.tables);
-        let base_key = index.get(key, storage.txn_id())?;
-        base.get(base_key, storage.txn_id()).cloned()
+        if index.is_poisoned(storage.txn_id()) {
+            return Err(AccessError::NonUniqueIndexKey(
+                <Self::IndexDesc as TableDesc>::name(),
+            ));
+        }
+        let base_key = index
+            .get(key, storage.txn_id())
+            .ok_or(AccessError::NotPresent)?;
+        base.get(base_key, storage.txn_id())
+            .cloned()
+            .ok_or(AccessError::NotPresent)
     }
 
     fn with<Q, T>(
@@ -246,7 +269,7 @@ pub(crate) trait IndexedOps<TableStorage: schema::GeneratedStorage>:
         key: &Q,
         f: impl FnOnce(&BaseValue<Self::IndexDesc>) -> T,
         _owner: Owner,
-    ) -> Option<T>
+    ) -> AccessResult<T>
     where
         IndexKey<Self::IndexDesc>: Borrow<Q>,
         IndexValue<Self::IndexDesc>: Hash + Eq,
@@ -256,10 +279,19 @@ pub(crate) trait IndexedOps<TableStorage: schema::GeneratedStorage>:
         let storage = storage.storage();
         let base = Base::<Self::IndexDesc>::get_table(&storage.tables);
         let index = <Self::IndexDesc>::get_table(&storage.tables);
-        let base_key = index.get(key, storage.txn_id())?;
-        let value = base.get(base_key, storage.txn_id())?;
+        if index.is_poisoned(storage.txn_id()) {
+            return Err(AccessError::NonUniqueIndexKey(
+                <Self::IndexDesc as TableDesc>::name(),
+            ));
+        }
+        let base_key = index
+            .get(key, storage.txn_id())
+            .ok_or(AccessError::NotPresent)?;
+        let value = base
+            .get(base_key, storage.txn_id())
+            .ok_or(AccessError::NotPresent)?;
 
-        Some(f(value))
+        Ok(f(value))
     }
 
     fn iter<'guard>(
@@ -480,7 +512,7 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
         key: &Q,
         f: impl FnOnce(&mut BaseValue<Self::IndexDesc>) -> T,
         owner: Owner,
-    ) -> Option<T>
+    ) -> AccessResult<T>
     where
         IndexKey<Self::IndexDesc>: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -495,10 +527,16 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
         let (base, index) = schema::get_two_tables_mut::<_, Base<Self::IndexDesc>, Self::IndexDesc>(
             &mut storage.tables,
         );
+        if index.is_poisoned(txn_id) {
+            return Err(AccessError::NonUniqueIndexKey(
+                <Self::IndexDesc as TableDesc>::name(),
+            ));
+        }
         base.assert_owner(owner);
 
-        let base_key = index.get(key, txn_id)?;
+        let base_key = index.get(key, txn_id).ok_or(AccessError::NotPresent)?;
         base.with_mut(base_key, f, txn_id, max_committed_id)
+            .ok_or(AccessError::NotPresent)
     }
 
     fn remove<Q>(self, key: &Q, owner: Owner)

--- a/ts_kv_store/src/schema.rs
+++ b/ts_kv_store/src/schema.rs
@@ -66,6 +66,8 @@ pub trait MutSingleton: Singleton {
 ///
 /// Prefer to use the macros in this module rather than this trait directly.
 pub trait TableDesc: Sized + 'static {
+    /// The name of the table.
+    const NAME: &'static str;
     /// The type of the key.
     type Key: Hash + Eq + Clone;
     /// The type of the value.
@@ -75,8 +77,6 @@ pub trait TableDesc: Sized + 'static {
     /// The storage type for keeping this table's indexes.
     type Indexes: IndexStorage<Self::Key, Self::Value>;
 
-    /// Return the name of the table.
-    fn name() -> &'static str;
     /// Get a reference to the table in storage.
     fn get_table(storage: &Self::Storage) -> &Table<Self, Self::Indexes>;
     /// Get a mutable reference to the table in storage.
@@ -396,14 +396,12 @@ macro_rules! tables {
             pub struct $name;
 
             impl $crate::schema::TableDesc for $name {
+                const NAME: &'static str = stringify!($name);
                 type Key = $key_ty;
                 type Value = $value_ty;
                 type Storage = TableStorage;
                 type Indexes = index::$name::Indexes;
 
-                fn name() -> &'static str {
-                    stringify!($name)
-                }
                 fn get_table(storage: &TableStorage) -> &$crate::storage::Table<Self, Self::Indexes> {
                     &storage.$name
                 }
@@ -414,14 +412,12 @@ macro_rules! tables {
 
             $(
                 impl $crate::schema::TableDesc for index::$name::$field where $field_ty: Clone {
+                    const NAME: &'static str = stringify!($name by $field);
                     type Key = $field_ty;
                     type Value = $key_ty;
                     type Storage = TableStorage;
                     type Indexes = ();
 
-                    fn name() -> &'static str {
-                        stringify!($name by $field)
-                    }
                     fn get_table(storage: &TableStorage) -> &$crate::storage::Table<Self, Self::Indexes> {
                         &storage.$name.indexes.$field
                     }
@@ -572,15 +568,15 @@ macro_rules! on_insert_each {
     ) => {
         for index_key in index::$name::Indexes::$field($value) {
             let unique = $self.$field.get::<$field_ty>(&index_key, $txn_id).is_none();
-            $self
-                .$field
-                .insert(index_key, $key.to_owned(), $txn_id, $max_committed_id);
             assert!(
                 unique,
                 "Index key is non-unique for index `{}` of table `{}`",
-                stringify!($name),
                 stringify!($field),
+                stringify!($name),
             );
+            $self
+                .$field
+                .insert(index_key, $key.to_owned(), $txn_id, $max_committed_id);
         }
     };
     (

--- a/ts_kv_store/src/schema.rs
+++ b/ts_kv_store/src/schema.rs
@@ -372,16 +372,15 @@ macro_rules! match_helper_rhs_mut {
 ///     &'static str => Node;
 ///     index(a: u32);
 ///     index(b: String; assert_unique);
-///     index(c: String = |node: &Node| Some(format!("{}-{}", node.a, node.b)));
+///     index(c: String = |node: &Node| [format!("{}-{}", node.a, node.b)]);
 ///   )
 /// );
 /// ```
 ///
 /// This will create indexes on nodes for fields `a`, `b`, and `c`. `c`'s index key is
 /// computed by the specified closure, which is expected to return
-/// `impl IntoIterator<Item = I>` (where `I` is the index key type). Most commonly, this
-/// will likely be `Option`: you might want to return `None` in some cases if the value has
-/// an optional field or an index key can't be produced.
+/// `impl IntoIterator<Item = I>` (where `I` is the index key type), for example an `Option<I>` for
+/// zero or one index keys per value.
 ///
 /// Index fields must uniquely identify a row in the base table. If multiple rows in the base table
 /// have the same key in the index, then by default the index will be 'poisoned' and accessing the
@@ -489,7 +488,7 @@ macro_rules! tables {
             impl index::$name::Indexes {
                 $(
                     fn $field(val: &$value_ty) -> impl IntoIterator<Item = $field_ty> {
-                        ($crate::get_index_expr!($value_ty, $field, $field_ty $(, $get_idx)?))(val)
+                        ($crate::get_index_fn!($value_ty, $field $(, $get_idx)?))(val)
                     }
                 )*
             }
@@ -537,11 +536,11 @@ macro_rules! tables {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! get_index_expr {
-    ($value_ty:ty, $field:ident, $field_ty:ty) => {
-        |value: &$value_ty| Some(value.$field.clone())
+macro_rules! get_index_fn {
+    ($value_ty:ty, $field:ident) => {
+        |value: &$value_ty| [value.$field.clone()]
     };
-    ($value_ty:ty, $field:ident, $field_ty:ty, $get_idx:expr) => {
+    ($value_ty:ty, $field:ident, $get_idx:expr) => {
         $get_idx
     };
 }
@@ -571,11 +570,11 @@ macro_rules! on_insert_each {
         $field_ty:ty;
         ($self:ident, $key:ident, $value:ident, $txn_id:ident, $max_committed_id:ident); assert_unique
     ) => {
-        for value in index::$name::Indexes::$field($value) {
-            let unique = $self.$field.get(&value, $txn_id).is_none();
+        for index_key in index::$name::Indexes::$field($value) {
+            let unique = $self.$field.get::<$field_ty>(&index_key, $txn_id).is_none();
             $self
                 .$field
-                .insert(value, $key.to_owned(), $txn_id, $max_committed_id);
+                .insert(index_key, $key.to_owned(), $txn_id, $max_committed_id);
             assert!(
                 unique,
                 "Index key is non-unique for index `{}` of table `{}`",
@@ -590,12 +589,12 @@ macro_rules! on_insert_each {
         $field_ty:ty;
         ($self:ident, $key:ident, $value:ident, $txn_id:ident, $max_committed_id:ident)
     ) => {
-        for value in index::$name::Indexes::$field($value) {
-            let unique = $self.$field.get(&value, $txn_id).is_none();
+        for index_key in index::$name::Indexes::$field($value) {
+            let unique = $self.$field.get::<$field_ty>(&index_key, $txn_id).is_none();
             if unique {
                 $self
                     .$field
-                    .insert(value, $key.to_owned(), $txn_id, $max_committed_id);
+                    .insert(index_key, $key.to_owned(), $txn_id, $max_committed_id);
             } else {
                 $self.$field.set_poisoned($txn_id);
             }
@@ -654,7 +653,10 @@ mod test {
         pub struct BarT {
             a: String,
         }
-        tables!(Foo(&'static str => String), Bar(u32 => BarT; index(a: String; assert_unique)));
+        tables!(
+            Foo(&'static str => String; index(len: usize = |v: &String| [v.len()])),
+            Bar(u32 => BarT; index(a: String; assert_unique))
+        );
 
         let store = KvStore::new();
         store.table::<Bar>("owner").insert(
@@ -667,6 +669,12 @@ mod test {
             .table_by::<index::Bar::a>("owner")
             .get("hello")
             .unwrap();
-        assert_eq!(value.a, "hello")
+        assert_eq!(value.a, "hello");
+
+        store
+            .table::<Foo>("owner")
+            .insert("foo", "hello".to_owned());
+        let value = store.table_by::<index::Foo::len>("owner").get(&5).unwrap();
+        assert_eq!(value, "hello");
     }
 }

--- a/ts_kv_store/src/schema.rs
+++ b/ts_kv_store/src/schema.rs
@@ -72,9 +72,11 @@ pub trait TableDesc: Sized + 'static {
     type Value: Any + Send + Sync;
     /// The storage for the table.
     type Storage: GeneratedStorage;
-    /// The storage type for keeping this tables indexes.
+    /// The storage type for keeping this table's indexes.
     type Indexes: IndexStorage<Self::Key, Self::Value>;
 
+    /// Return the name of the table.
+    fn name() -> &'static str;
     /// Get a reference to the table in storage.
     fn get_table(storage: &Self::Storage) -> &Table<Self, Self::Indexes>;
     /// Get a mutable reference to the table in storage.
@@ -338,17 +340,6 @@ macro_rules! match_helper_rhs_mut {
     };
 }
 
-#[doc(hidden)]
-#[macro_export]
-macro_rules! _get_index {
-    ($value_ty:ty, $field:ident, $field_ty:ty) => {
-        |value: &$value_ty| Some(value.$field.clone())
-    };
-    ($value_ty:ty, $field:ident, $field_ty:ty, $get_idx:expr) => {
-        $get_idx
-    };
-}
-
 /// Declare the tables in a key/value store. Generates the store itself with the specified tables.
 ///
 /// The syntax is `tables!(Name(KeyType, ValueType indexes?),*)`, where `Name` is an identifier to name
@@ -377,7 +368,12 @@ macro_rules! _get_index {
 /// # use ts_kv_store::tables;
 /// # pub struct Node { a: u32, b: String };
 /// tables!(
-///   Nodes(&'static str => Node; index(a: u32); index(b: String); index(c: String = |node: &Node| Some(format!("{}-{}", node.a, node.b))))
+///   Nodes(
+///     &'static str => Node;
+///     index(a: u32);
+///     index(b: String; assert_unique);
+///     index(c: String = |node: &Node| Some(format!("{}-{}", node.a, node.b)));
+///   )
 /// );
 /// ```
 ///
@@ -388,13 +384,13 @@ macro_rules! _get_index {
 /// an optional field or an index key can't be produced.
 ///
 /// Index fields must uniquely identify a row in the base table. If multiple rows in the base table
-/// have the same key in the index, then behavior is unspecified (might give partial or incorrect
-/// result, might panic, etc.). The type of the primary key of the data must be `Clone` (since it
-/// will be cloned when inserted into the index), and the index type must be `Clone` as well if a
-/// closure isn't specified (the behavior in this case is `|value| Some(value.$field.clone)`).
+/// have the same key in the index, then by default the index will be 'poisoned' and accessing the
+/// index or trying to commit a transaction where an index is poisoned will return an error (`NonUniqueIndexKey`).
+/// By adding `assert_unique` to an index declaration (after the index field, separated with a semicolon),
+/// attempting to store multiple rows with the same index key will cause a panic.
 #[macro_export]
 macro_rules! tables {
-    ($($name: ident ($key_ty: ty => $value_ty: ty $(; index($field: ident: $field_ty: ty $(= $get_idx:expr)?))* $(;)?)),*) => {
+    ($($name: ident ($key_ty: ty => $value_ty: ty $(; index($field: ident: $field_ty: ty $(= $get_idx: expr)? $(; $unique:ident)?))* $(;)?)),*) => {
         $(
             /// Describes a table in the KV store.
             #[derive(Default)]
@@ -406,6 +402,9 @@ macro_rules! tables {
                 type Storage = TableStorage;
                 type Indexes = index::$name::Indexes;
 
+                fn name() -> &'static str {
+                    stringify!($name)
+                }
                 fn get_table(storage: &TableStorage) -> &$crate::storage::Table<Self, Self::Indexes> {
                     &storage.$name
                 }
@@ -421,6 +420,9 @@ macro_rules! tables {
                     type Storage = TableStorage;
                     type Indexes = ();
 
+                    fn name() -> &'static str {
+                        stringify!($name by $field)
+                    }
                     fn get_table(storage: &TableStorage) -> &$crate::storage::Table<Self, Self::Indexes> {
                         &storage.$name.indexes.$field
                     }
@@ -487,7 +489,7 @@ macro_rules! tables {
             impl index::$name::Indexes {
                 $(
                     fn $field(val: &$value_ty) -> impl IntoIterator<Item = $field_ty> {
-                        ($crate::_get_index!($value_ty, $field, $field_ty $(, $get_idx)?))(val)
+                        ($crate::get_index_expr!($value_ty, $field, $field_ty $(, $get_idx)?))(val)
                     }
                 )*
             }
@@ -499,19 +501,7 @@ macro_rules! tables {
                     )*
                 }
 
-                fn on_insert<Q>(&mut self, _key: &Q, _value: &$value_ty, _txn_id: $crate::transactions::TxnId, _max_committed_id: $crate::transactions::TxnId)
-                where
-                    $key_ty: std::borrow::Borrow<Q>,
-                    Q: ?Sized + std::hash::Hash + Eq + std::borrow::ToOwned<Owned = $key_ty>
-                {
-                    $({
-                        for value in index::$name::Indexes::$field(_value) {
-                            let unique = self.$field.get(&value, _txn_id).is_none();
-                            self.$field.insert(value, _key.to_owned(), _txn_id, _max_committed_id);
-                            debug_assert!(unique, "Index key is non-unique for index `{}` of table `{}`", stringify!($name), stringify!($field));
-                        }
-                    })*
-                }
+                $crate::on_insert!($name, $key_ty, $value_ty, $(index($field: $field_ty $(; $unique)?),)*);
 
                 fn on_remove(&mut self, _value: &$value_ty, _txn_id: $crate::transactions::TxnId, _max_committed_id: $crate::transactions::TxnId) {
                     $({
@@ -540,6 +530,74 @@ macro_rules! tables {
 
             fn deref(&self) -> &Self::Target {
                 &self.0
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! get_index_expr {
+    ($value_ty:ty, $field:ident, $field_ty:ty) => {
+        |value: &$value_ty| Some(value.$field.clone())
+    };
+    ($value_ty:ty, $field:ident, $field_ty:ty, $get_idx:expr) => {
+        $get_idx
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! on_insert {
+    ($name: ident, $key_ty: ty, $value_ty: ty, $(index($field: ident: $field_ty: ty $(; $unique:ident)?),)*) => {
+        fn on_insert<Q>(&mut self, _key: &Q, _value: &$value_ty, _txn_id: $crate::transactions::TxnId, _max_committed_id: $crate::transactions::TxnId)
+        where
+            $key_ty: std::borrow::Borrow<Q>,
+            Q: ?Sized + std::hash::Hash + Eq + std::borrow::ToOwned<Owned = $key_ty>
+        {
+            $(
+                $crate::on_insert_each!($name, $field: $field_ty; (self, _key, _value, _txn_id, _max_committed_id) $(; $unique)?);
+            )*
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! on_insert_each {
+    (
+        $name:ident,
+        $field:ident :
+        $field_ty:ty;
+        ($self:ident, $key:ident, $value:ident, $txn_id:ident, $max_committed_id:ident); assert_unique
+    ) => {
+        for value in index::$name::Indexes::$field($value) {
+            let unique = $self.$field.get(&value, $txn_id).is_none();
+            $self
+                .$field
+                .insert(value, $key.to_owned(), $txn_id, $max_committed_id);
+            assert!(
+                unique,
+                "Index key is non-unique for index `{}` of table `{}`",
+                stringify!($name),
+                stringify!($field),
+            );
+        }
+    };
+    (
+        $name:ident,
+        $field:ident :
+        $field_ty:ty;
+        ($self:ident, $key:ident, $value:ident, $txn_id:ident, $max_committed_id:ident)
+    ) => {
+        for value in index::$name::Indexes::$field($value) {
+            let unique = $self.$field.get(&value, $txn_id).is_none();
+            if unique {
+                $self
+                    .$field
+                    .insert(value, $key.to_owned(), $txn_id, $max_committed_id);
+            } else {
+                $self.$field.set_poisoned($txn_id);
             }
         }
     };
@@ -596,7 +654,7 @@ mod test {
         pub struct BarT {
             a: String,
         }
-        tables!(Foo(&'static str => String), Bar(u32 => BarT; index(a: String)));
+        tables!(Foo(&'static str => String), Bar(u32 => BarT; index(a: String; assert_unique)));
 
         let store = KvStore::new();
         store.table::<Bar>("owner").insert(

--- a/ts_kv_store/src/schema.rs
+++ b/ts_kv_store/src/schema.rs
@@ -506,7 +506,9 @@ macro_rules! tables {
                 {
                     $({
                         for value in index::$name::Indexes::$field(_value) {
+                            let unique = self.$field.get(&value, _txn_id).is_none();
                             self.$field.insert(value, _key.to_owned(), _txn_id, _max_committed_id);
+                            debug_assert!(unique, "Index key is non-unique for index `{}` of table `{}`", stringify!($name), stringify!($field));
                         }
                     })*
                 }

--- a/ts_kv_store/src/storage.rs
+++ b/ts_kv_store/src/storage.rs
@@ -592,12 +592,13 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
         self.poisoned.set(true, txn_id);
     }
 
-    pub fn is_poisoned(&self, txn_id: TxnId) -> bool {
+    pub(crate) fn is_poisoned(&self, txn_id: TxnId) -> bool {
         *self.poisoned.get(txn_id).unwrap_or(&false)
     }
 
     pub fn gc_txn(&mut self, txn_id: TxnId) {
         self.delete_mask = DeleteMask::None;
+        self.poisoned.gc_txn(txn_id);
 
         let Some(modified) = &self.modified else {
             return;
@@ -607,8 +608,6 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
             modified.txn_id, txn_id,
             "Found mismatched modified set to GC"
         );
-
-        self.poisoned.gc_txn(txn_id);
 
         for k in &modified.keys {
             if let Some(value) = self.data.get_mut(k) {
@@ -637,7 +636,7 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
         }
 
         if self.is_poisoned(txn_id) {
-            return Err(crate::Error::NonUniqueIndexKey(D::name()));
+            return Err(crate::Error::NonUniqueIndexKey(D::NAME));
         }
 
         match &self.delete_mask {

--- a/ts_kv_store/src/storage.rs
+++ b/ts_kv_store/src/storage.rs
@@ -556,6 +556,10 @@ pub struct Table<D: schema::TableDesc, I> {
     ///
     /// Can be an over-approximation, but not an under-approximation.
     modified: Option<TxnMutations<D::Key>>,
+    /// A flag indicating if the table has become inconsistent.
+    ///
+    /// Currently this is used for indexes if multiple primary keys are stored for a single index key.
+    poisoned: VersionedValue<bool>,
     /// All indexes of this table (empty if there are no indexes or this table itself is an index).
     pub indexes: I,
 }
@@ -567,6 +571,7 @@ impl<D: schema::TableDesc, I: Default> Default for Table<D, I> {
             data: HashMap::new(),
             delete_mask: DeleteMask::None,
             modified: None,
+            poisoned: VersionedValue::new(false, TxnId::FIRST),
             indexes: I::default(),
         }
     }
@@ -583,6 +588,14 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
         }
     }
 
+    pub fn set_poisoned(&mut self, txn_id: TxnId) {
+        self.poisoned.set(true, txn_id);
+    }
+
+    pub fn is_poisoned(&self, txn_id: TxnId) -> bool {
+        *self.poisoned.get(txn_id).unwrap_or(&false)
+    }
+
     pub fn gc_txn(&mut self, txn_id: TxnId) {
         self.delete_mask = DeleteMask::None;
 
@@ -594,6 +607,8 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
             modified.txn_id, txn_id,
             "Found mismatched modified set to GC"
         );
+
+        self.poisoned.gc_txn(txn_id);
 
         for k in &modified.keys {
             if let Some(value) = self.data.get_mut(k) {
@@ -619,6 +634,10 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
             && modified.txn_id != txn_id
         {
             return Err(Error::TransactionFailed);
+        }
+
+        if self.is_poisoned(txn_id) {
+            return Err(crate::Error::NonUniqueIndexKey(D::name()));
         }
 
         match &self.delete_mask {
@@ -693,6 +712,9 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
     {
+        if self.is_poisoned(txn_id) {
+            return None;
+        }
         get_from_table::<D, Q>(&self.delete_mask, &self.data, key, txn_id)
     }
 
@@ -830,6 +852,8 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
                 "current transaction id less than committed id: {txn_id:?} < {max_committed_id:?}"
             );
         }
+
+        self.poisoned.set(false, txn_id);
 
         self.indexes.clear(txn_id, max_committed_id);
     }

--- a/ts_kv_store/src/storage.rs
+++ b/ts_kv_store/src/storage.rs
@@ -688,7 +688,7 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
         }
     }
 
-    pub(crate) fn get<Q>(&self, key: &Q, txn_id: TxnId) -> Option<&D::Value>
+    pub fn get<Q>(&self, key: &Q, txn_id: TxnId) -> Option<&D::Value>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -748,7 +748,6 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
         D::Value: Clone,
     {
         // TODO could be more efficient by only updating if value is changed
-
         match &mut self.delete_mask {
             DeleteMask::None => Self::iter_data_mut(&mut self.data, txn_id).for_each(|(k, v)| {
                 self.indexes.on_remove(v, txn_id, max_committed_id);


### PR DESCRIPTION
Part of #217

This changes the default behaviour on non-unique index keys to poisoning the index causing commit to fail (or get to return an error). Also permits forcing a panic (useful for debugging or perhaps where uniqueness is always guaranteed) using an `assert_unique` flag.

Also does a few small misc changes thrown in.

AI declaration: I used Claude for generating tests (and I've reviewed and refactored those) and do a few sed-but-smart tasks (all reviewed)