### PR TITLE
runtime: bump kameo to 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2596,24 +2596,27 @@ dependencies = [
 
 [[package]]
 name = "kameo"
-version = "0.19.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4af7638c67029fd6821d02813c3913c803784648725d4df4082c9b91d7cbb1"
+checksum = "fe998b05ae765a040027d9fe3187240cb840e6705fa29d86f3abaa5e96b36291"
 dependencies = [
  "downcast-rs",
  "dyn-clone",
  "futures",
  "kameo_macros",
+ "opentelemetry",
+ "rmp-serde",
  "serde",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]
 name = "kameo_actors"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57101cc01d16e87fad2cb0d6332a84bbdd3468c28d52d6929ec43d340e2e6713"
+checksum = "ecac96d16d40eddf8a1e50b597109c223695a5c9ad5f0d6b28cb0475b3fee42f"
 dependencies = [
  "futures",
  "glob",
@@ -2624,9 +2627,9 @@ dependencies = [
 
 [[package]]
 name = "kameo_macros"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13c324e2d8c8e126e63e66087448b4267e263e6cb8770c56d10a9d0d279d9e2"
+checksum = "0f200083477f64b12545688f8e0f562c31c1462827e163cb14dc2ed6c89eb888"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3138,6 +3141,20 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
 
 [[package]]
 name = "ordered-float"
@@ -4156,6 +4173,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "route_manager"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5135,7 +5171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5580,6 +5616,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/ts_runtime/Cargo.toml
+++ b/ts_runtime/Cargo.toml
@@ -31,8 +31,8 @@ ts_tunnel.workspace = true
 # Unconditionally required dependencies.
 futures.workspace = true
 ipnet.workspace = true
-kameo = "0.19"
-kameo_actors = "0.4"
+kameo = "0.21"
+kameo_actors = "0.6"
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream = { version = "0.1", default-features = false, features = ["time"] }
@@ -45,6 +45,10 @@ itertools.workspace = true
 proptest.workspace = true
 rand.workspace = true
 ts_capabilityversion.workspace = true
+
+[features]
+console = ["kameo/console"]
+otel = ["kameo/otel", "kameo/tracing"]
 
 [lints]
 workspace = true

--- a/ts_runtime/src/error.rs
+++ b/ts_runtime/src/error.rs
@@ -93,9 +93,6 @@ impl<M, E> From<SendError<M, E>> for Error {
 
 impl<E> From<HookError<E>> for Error {
     fn from(value: HookError<E>) -> Self {
-        // TODO(npry): due to https://github.com/tqwewe/kameo/pull/340, we _must not_ access `e`'s
-        // internals if it's a panic error and this function may be called via with_startup_result
-        // or any of the other `ActorRef::*_with_*` callback functions.
         match value {
             HookError::Error(_) => Self {
                 kind: ErrorKind::ReplyErr,


### PR DESCRIPTION
This diff is small because it's used by a bunch of other mutually-independent PRs &mdash; 0.21 includes supervision support and the deadlock fix mentioned in #234 (tqwewe/kameo#340). It also provides a console, which might be neat for debugging. That and the otel support are used in a later commit.