### PR TITLE
runtime: write a Task actor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5429,6 +5429,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-test"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
+dependencies = [
+ "futures-core",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5437,6 +5448,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -6253,6 +6265,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "tokio-test",
+ "tokio-util",
  "tracing",
  "ts_bart",
  "ts_bart_packetfilter",

--- a/ts_runtime/Cargo.toml
+++ b/ts_runtime/Cargo.toml
@@ -35,6 +35,7 @@ kameo = "0.21"
 kameo_actors = "0.6"
 thiserror.workspace = true
 tokio.workspace = true
+tokio-util = { workspace = true, features = ["rt"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["time"] }
 tracing.workspace = true
 smallvec.workspace = true
@@ -45,6 +46,7 @@ chrono.workspace = true
 itertools.workspace = true
 proptest.workspace = true
 rand.workspace = true
+tokio-test = "0.4"
 ts_capabilityversion.workspace = true
 
 [features]
@@ -53,3 +55,6 @@ otel = ["kameo/otel", "kameo/tracing"]
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["tokio-test"]

--- a/ts_runtime/src/control_runner.rs
+++ b/ts_runtime/src/control_runner.rs
@@ -8,10 +8,9 @@ use futures::StreamExt;
 use kameo::{
     actor::{ActorRef, Spawn},
     message::{Context, StreamMessage},
-    prelude::Message,
+    prelude::{Message, ReplySender},
     reply::DelegatedReply,
 };
-use tokio::sync::watch;
 use ts_control::{AsyncControlClient, Error as ControlError, Node, StateUpdate};
 
 use crate::derp_latency::{DerpLatencyMeasurement, DerpLatencyMeasurer};
@@ -23,10 +22,12 @@ pub struct ControlRunner {
     client: AsyncControlClient,
     params: Params,
 
-    self_node: watch::Sender<Option<Node>>,
+    self_node: Option<Node>,
+    pending: Vec<PendingRequest>,
 }
 
 /// Control runner args.
+#[derive(Clone)]
 pub struct Params {
     /// Control config.
     pub(crate) config: ts_control::Config,
@@ -88,29 +89,9 @@ impl kameo::Actor for ControlRunner {
         Ok(Self {
             client,
             params,
-            self_node: Default::default(),
+            self_node: None,
+            pending: Default::default(),
         })
-    }
-}
-
-impl ControlRunner {
-    fn with_self_node<F, R>(&self, f: F) -> impl Future<Output = Option<R>> + use<F, R>
-    where
-        F: FnOnce(&Node) -> R,
-    {
-        let mut sub = self.self_node.subscribe();
-        let mut shutdown = self.params.env.shutdown.clone();
-
-        async move {
-            tokio::select! {
-                _ = shutdown.wait_for(|x| *x) => {
-                    None
-                },
-                node = sub.wait_for(Option::is_some) => {
-                    Some(f(node.ok()?.as_ref()?))
-                },
-            }
-        }
     }
 }
 
@@ -119,18 +100,16 @@ impl ControlRunner {
     /// Fetch the IPv4 address for this tailscale device.
     #[message(ctx)]
     pub fn ipv4(
-        &self,
+        &mut self,
         ctx: &mut Context<Self, DelegatedReply<Option<Ipv4Addr>>>,
     ) -> DelegatedReply<Option<Ipv4Addr>> {
+        if let Some(node) = &self.self_node {
+            return ctx.reply(Some(node.tailnet_address.ipv4.addr()));
+        }
+
         let (deleg, replier) = ctx.reply_sender();
-
         if let Some(replier) = replier {
-            let fut = self.with_self_node(|node| node.tailnet_address.ipv4.addr());
-
-            tokio::spawn(async move {
-                let ip = fut.await;
-                replier.send(ip);
-            });
+            self.pending.push(PendingRequest::Ipv4(replier));
         }
 
         deleg
@@ -139,18 +118,16 @@ impl ControlRunner {
     /// Fetch the IPv6 address for this tailscale device.
     #[message(ctx)]
     pub fn ipv6(
-        &self,
+        &mut self,
         ctx: &mut Context<Self, DelegatedReply<Option<Ipv6Addr>>>,
     ) -> DelegatedReply<Option<Ipv6Addr>> {
+        if let Some(node) = &self.self_node {
+            return ctx.reply(Some(node.tailnet_address.ipv6.addr()));
+        }
+
         let (deleg, replier) = ctx.reply_sender();
-
         if let Some(replier) = replier {
-            let fut = self.with_self_node(|node| node.tailnet_address.ipv6.addr());
-
-            tokio::spawn(async move {
-                let ip = fut.await;
-                replier.send(ip);
-            });
+            self.pending.push(PendingRequest::Ipv6(replier));
         }
 
         deleg
@@ -159,21 +136,41 @@ impl ControlRunner {
     /// Fetch the self node for this tailscale device.
     #[message(ctx)]
     pub fn self_node(
-        &self,
+        &mut self,
         ctx: &mut Context<Self, DelegatedReply<Option<Node>>>,
     ) -> DelegatedReply<Option<Node>> {
+        if let Some(node) = &self.self_node {
+            return ctx.reply(Some(node.clone()));
+        }
+
         let (deleg, replier) = ctx.reply_sender();
-
         if let Some(replier) = replier {
-            let node = self.with_self_node(|node| node.clone());
-
-            tokio::spawn(async move {
-                let node = node.await;
-                replier.send(node)
-            });
+            self.pending.push(PendingRequest::SelfNode(replier));
         }
 
         deleg
+    }
+}
+
+enum PendingRequest {
+    Ipv4(ReplySender<Option<Ipv4Addr>>),
+    Ipv6(ReplySender<Option<Ipv6Addr>>),
+    SelfNode(ReplySender<Option<Node>>),
+}
+
+impl PendingRequest {
+    fn respond(self, node: &Node) {
+        match self {
+            PendingRequest::Ipv4(sender) => {
+                sender.send(Some(node.tailnet_address.ipv4.addr()));
+            }
+            PendingRequest::Ipv6(sender) => {
+                sender.send(Some(node.tailnet_address.ipv6.addr()));
+            }
+            PendingRequest::SelfNode(sender) => {
+                sender.send(Some(node.clone()));
+            }
+        }
     }
 }
 
@@ -192,7 +189,7 @@ impl Message<StreamMessage<Arc<StateUpdate>, (), ()>> for ControlRunner {
 
             StreamMessage::Next(msg) => {
                 if let Some(node) = msg.node.as_ref() {
-                    self.self_node.send_replace(Some(node.clone()));
+                    self.self_node = Some(node.clone());
                 }
 
                 if let Err(e) = self.params.env.publish(msg).await {
@@ -202,6 +199,12 @@ impl Message<StreamMessage<Arc<StateUpdate>, (), ()>> for ControlRunner {
 
             StreamMessage::Finished(_) => {
                 tracing::error!("state update stream terminated")
+            }
+        }
+
+        if let Some(node) = &self.self_node {
+            for req in self.pending.drain(..) {
+                req.respond(node);
             }
         }
     }

--- a/ts_runtime/src/dataplane.rs
+++ b/ts_runtime/src/dataplane.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use kameo::{
-    actor::ActorRef,
+    actor::{ActorRef, Spawn},
     message::{Context, Message},
 };
 use tokio::sync::mpsc;
@@ -9,7 +9,7 @@ use ts_packet::PacketMut;
 use ts_transport::{OverlayTransportId, PeerId, UnderlayTransportId};
 
 use crate::{
-    Error,
+    Error, Task,
     env::Env,
     packetfilter::PacketFilterState,
     peer_tracker::PeerState,
@@ -31,13 +31,6 @@ pub type UnderlayFromDataplane = mpsc::UnboundedReceiver<(PeerId, Vec<PacketMut>
 
 pub struct DataplaneActor {
     dataplane: Arc<ts_dataplane::async_tokio::DataPlane>,
-    task: tokio::task::JoinHandle<()>,
-}
-
-impl Drop for DataplaneActor {
-    fn drop(&mut self) {
-        self.task.abort();
-    }
 }
 
 #[kameo::messages]
@@ -78,14 +71,15 @@ impl kameo::Actor for DataplaneActor {
 
         let task_dataplane = dataplane.clone();
 
-        let task = tokio::task::spawn(async move {
+        Task::spawn_link(&slf, async move {
             task_dataplane.run().await;
-        });
+        })
+        .await;
 
         tracing::trace!("dataplane running");
         env.register(None, &slf).await?;
 
-        Ok(Self { dataplane, task })
+        Ok(Self { dataplane })
     }
 }
 

--- a/ts_runtime/src/lib.rs
+++ b/ts_runtime/src/lib.rs
@@ -10,7 +10,7 @@ use kameo::{
     mailbox::Signal,
 };
 use netstack::netcore::Channel;
-use tokio::sync::watch;
+use tokio::sync::{Mutex, watch};
 
 use crate::{
     control_runner::ControlRunner, dataplane::DataplaneActor, multiderp::Multiderp,
@@ -137,8 +137,12 @@ impl Runtime {
 
         let peer_tracker = PeerTracker::spawn(env.clone());
 
-        let netstack =
-            NetstackActor::spawn((env.clone(), Default::default(), netstack_up, netstack_down));
+        let netstack = NetstackActor::spawn((
+            env.clone(),
+            Default::default(),
+            netstack_up,
+            Arc::new(Mutex::new(netstack_down)),
+        ));
 
         let control = ControlRunner::spawn(control_runner::Params {
             config,

--- a/ts_runtime/src/lib.rs
+++ b/ts_runtime/src/lib.rs
@@ -33,10 +33,12 @@ mod retained_bus;
 mod route_updater;
 mod src_filter;
 mod stunner;
+mod task;
 
 pub(crate) use env::Env;
 pub use error::{Error, ErrorKind};
 pub use registry::Registry;
+pub use task::{ErasedTask, Task};
 
 use crate::peer_tracker::PeerTracker;
 

--- a/ts_runtime/src/netstack_actor.rs
+++ b/ts_runtime/src/netstack_actor.rs
@@ -1,24 +1,24 @@
 use std::sync::Arc;
 
 use kameo::{
-    actor::ActorRef,
+    actor::{ActorRef, Spawn},
     message::{Context, Message},
 };
 use netstack::{
     HasChannel,
     netcore::{Channel, NetstackControl},
 };
-use tokio::task::JoinSet;
+use tokio::sync::Mutex;
 use ts_packet::PacketMut;
 
 use crate::{
     Error,
     dataplane::{OverlayFromDataplane, OverlayToDataplane},
     env::Env,
+    task::Task,
 };
 
 pub struct NetstackActor {
-    _joinset: JoinSet<()>,
     channel: Channel,
 }
 
@@ -27,12 +27,12 @@ impl kameo::Actor for NetstackActor {
         Env,
         netstack::netcore::Config,
         OverlayToDataplane,
-        OverlayFromDataplane,
+        Arc<Mutex<OverlayFromDataplane>>,
     );
     type Error = Error;
 
     async fn on_start(
-        (env, config, netstack_up, mut netstack_down): Self::Args,
+        (env, config, netstack_up, netstack_down): Self::Args,
         slf: ActorRef<Self>,
     ) -> Result<Self, Self::Error> {
         env.subscribe::<Arc<ts_control::StateUpdate>>(&slf).await?;
@@ -46,13 +46,12 @@ impl kameo::Actor for NetstackActor {
         ) = netstack::piped(config);
         let channel = netstack.command_channel();
 
-        let mut joinset = JoinSet::new();
-
-        joinset.spawn(async move {
+        Task::spawn_link(&slf, async move {
             netstack.run_tokio().await;
-        });
+        })
+        .await;
 
-        joinset.spawn(async move {
+        Task::spawn_link(&slf, async move {
             while let Some(buf) = netstack_down_rx.recv_async().await {
                 if netstack_up.send(vec![buf.to_vec().into()]).is_err() {
                     break;
@@ -60,9 +59,15 @@ impl kameo::Actor for NetstackActor {
             }
 
             tracing::warn!("netstack downlink shut down!");
-        });
+        })
+        .await;
 
-        joinset.spawn(async move {
+        Task::spawn_link(&slf, async move {
+            // NetstackActor is supervised, so the same netstack down channel may be handed to
+            // another actor instance if this one panics. We hold this mutex open indefinitely,
+            // relying on the Drop of this future to clean it up when the owning joinset drops.
+            let mut netstack_down = netstack_down.lock().await;
+
             while let Some(bufs) = netstack_down.recv().await {
                 for buf in bufs {
                     let buf: PacketMut = buf;
@@ -71,14 +76,12 @@ impl kameo::Actor for NetstackActor {
             }
 
             tracing::warn!("netstack uplink shut down!");
-        });
+        })
+        .await;
 
         env.register(None, &slf).await?;
 
-        Ok(Self {
-            _joinset: joinset,
-            channel,
-        })
+        Ok(Self { channel })
     }
 }
 

--- a/ts_runtime/src/task.rs
+++ b/ts_runtime/src/task.rs
@@ -1,0 +1,246 @@
+use core::{marker::PhantomData, panic::AssertUnwindSafe, pin::Pin};
+
+use futures::FutureExt;
+use kameo::{
+    actor::{ActorRef, WeakActorRef},
+    error::{ActorStopReason, Infallible},
+    message::{Context, Message},
+};
+use tokio_util::task::AbortOnDropHandle;
+
+/// An actor that runs a future and is associated bidirectionally with its lifecycle: the actor
+/// dying stops the task, and the task dying kills the actor.
+///
+/// To support background tasks, [`Task`] holds its own [`ActorRef`] -- it doesn't die if you don't
+/// hold a reference to it.
+///
+/// Kameo doesn't natively provide functionality for this -- [`ActorRef::attach_stream`] is the
+/// closest thing, but it doesn't fit the mental model of a background task that doesn't necessarily
+/// produce messages. So instead this is a thin wrapper around [`tokio::spawn`], and the inner
+/// future kills the actor if the future completes.
+///
+/// [`Task`] implements [`Message<Infallible>`] so it can be addressed as a type-erased
+/// [`Recipient`][kameo::prelude::Recipient] even though it doesn't accept any messages.
+///
+/// If you need to be generic over the task future or would need to name the type of an anonymous
+/// future, it's recommended to box the future and use [`ErasedTask`] as the task type.
+///
+/// # Examples
+///
+/// Spawning a task that shares lifecycle with a parent:
+///
+/// ```
+/// # use ts_runtime::Task;
+/// # use core::time::Duration;
+/// # use futures::FutureExt;
+/// # use kameo::prelude::{Actor, Spawn, ActorRef};
+/// struct Parent;
+///
+/// impl Actor for Parent {
+///     type Error = ();
+///     type Args = ();
+///
+///     async fn on_start(_: (), slf: ActorRef<Self>) -> Result<Self, ()> {
+///         Task::spawn_link(&slf, async move {
+///             for i in 0.. {
+///                 println!("{i}");
+///                 tokio::time::sleep(Duration::from_millis(25)).await;
+///             }
+///         });
+///
+///         // ... other self-init ...
+///
+///         Ok(Self)
+///     }
+/// }
+///
+/// # tokio_test::block_on(async move {
+/// let parent = Parent::spawn(());
+/// tokio::time::sleep(Duration::from_millis(99)).await;
+/// parent.kill();
+/// // prints 0, 1, 2, 3, then the parent and task are killed
+/// # });
+/// ```
+pub struct Task<Fut>(Option<AbortOnDropHandle<()>>, PhantomData<Fut>);
+
+/// A [`Task`] that was spawned with a boxed future.
+///
+/// This can be used to operate generically over collections of tasks with different worker futures.
+pub type ErasedTask = Task<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>;
+
+/// Run the task future.
+///
+/// The `slf` as a strong [`ActorRef`] held throughout this future is load-bearing for the way we
+/// expect to use [`Task`]: the [`Task`] keeps itself alive as long as its worker future is running
+/// (a strong ref means kameo won't gc it).
+async fn run_fut<Fut>(fut: Fut, slf: ActorRef<Task<Fut>>)
+where
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    match AssertUnwindSafe(fut).catch_unwind().await {
+        Ok(_) => {
+            if slf.stop_gracefully().await.is_err() {
+                slf.kill();
+            }
+        }
+        Err(e) => {
+            slf.kill();
+
+            std::panic::resume_unwind(e)
+        }
+    }
+}
+
+impl<Fut> kameo::Actor for Task<Fut>
+where
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    type Args = Fut;
+    type Error = core::convert::Infallible;
+
+    async fn on_start(fut: Self::Args, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(Self(
+            Some(AbortOnDropHandle::new(tokio::spawn(run_fut(fut, slf)))),
+            PhantomData,
+        ))
+    }
+
+    // In case there's a condition where the actor is retained in memory for a while after it's
+    // stopped, explicitly trigger abort here rather than waiting for the actor to be dropped.
+    //
+    // The AbortOnDropHandle conversely ensures that the task is aborted if `on_stop` is not called.
+    async fn on_stop(
+        &mut self,
+        slf: WeakActorRef<Self>,
+        reason: ActorStopReason,
+    ) -> Result<(), Self::Error> {
+        tracing::trace!(?slf, ?reason, "task stopping");
+
+        // Unwrap is safe: on_stop is called exactly once and the option is always populated by
+        // actor construction.
+        //
+        // This ensures that the task is aborted at the end of this scope if it's not already
+        // finished (checked in the next block).
+        let handle = self.0.take().unwrap();
+
+        if handle.is_finished()
+            && let Err(e) = handle.detach().await
+        {
+            // The task was never canceled because it was still in the abort handle (the
+            // only way this particular task would be canceled), so the error must be due to
+            // a panic. Rethrow it here to make it appear as this actor's panic to kameo.
+            std::panic::resume_unwind(e.into_panic())
+        }
+
+        Ok(())
+    }
+}
+
+impl<Fut> Message<Infallible> for Task<Fut>
+where
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    type Reply = Infallible;
+
+    async fn handle(&mut self, _: Infallible, _: &mut Context<Self, Self::Reply>) -> Infallible {
+        unreachable!()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::Duration,
+    };
+
+    use kameo::{actor::Spawn, error::HookError};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn kill_stops_task() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+
+        let task = Task::spawn(async move {
+            loop {
+                tx.send(()).await.unwrap();
+            }
+        });
+
+        // can receive as many messages as we want
+        for _ in 0..5 {
+            rx.recv().await.unwrap();
+        }
+
+        task.kill();
+        task.wait_for_shutdown().await;
+
+        // drain final buffered message
+        rx.recv().await.unwrap();
+
+        assert!(rx.is_closed());
+        assert!(rx.is_empty());
+    }
+
+    #[tokio::test]
+    async fn task_complete_stops_actor() {
+        let notify = Arc::new(tokio::sync::Notify::new());
+        let completed = Arc::new(AtomicBool::new(false));
+
+        let task = Task::spawn({
+            let notify = notify.clone();
+            let completed = completed.clone();
+
+            async move {
+                notify.notified().await;
+                completed.store(true, Ordering::SeqCst);
+            }
+        });
+
+        assert!(task.is_alive());
+        assert!(!completed.load(Ordering::SeqCst));
+
+        notify.notify_one();
+
+        tokio::time::timeout(Duration::from_millis(100), task.wait_for_shutdown())
+            .await
+            .unwrap();
+
+        assert!(!task.is_alive());
+        assert!(completed.load(Ordering::SeqCst));
+
+        let result = task.get_shutdown_result().unwrap();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn task_panic_stops_actor() {
+        let notify = Arc::new(tokio::sync::Notify::new());
+
+        let task = Task::spawn({
+            let notify = notify.clone();
+
+            async move {
+                notify.notified().await;
+                panic!();
+            }
+        });
+
+        assert!(task.is_alive());
+
+        notify.notify_one();
+
+        tokio::time::timeout(Duration::from_millis(100), task.wait_for_shutdown())
+            .await
+            .unwrap();
+
+        assert!(!task.is_alive());
+
+        let result = task.get_shutdown_result().unwrap().unwrap_err();
+        assert!(matches!(result, HookError::Panicked(_)));
+    }
+}


### PR DESCRIPTION
Write a `Task` actor whose sole responsibility is to run a tokio task and maintain a 1:1 lifecycle mapping. That is, if the tokio task dies, the actor dies, and if the actor is killed, the task is automatically killed. The motivation for this is in use in supervision and links, where we want failure to propagate to a link peer or to cause the task to be restarted by a supervisor.

Currently the most obvious usecases are runner futures used by the dataplane and netstack that just sit in a loop: if those ever die, the netstack and dataplane actors should die because they're nonfunctional. And if the actors die, those loops should shut down automatically. That's exactly what links are for, and `Task` being an actor provides natural support for that.