### PR TITLE
runtime/control: supervise derp latency measurer

### DIFF
--- a/ts_runtime/src/control_runner.rs
+++ b/ts_runtime/src/control_runner.rs
@@ -78,7 +78,9 @@ impl kameo::Actor for ControlRunner {
         .await?;
 
         params.env.subscribe::<DerpLatencyMeasurement>(&slf).await?;
-        DerpLatencyMeasurer::spawn_link(&slf, params.env.clone()).await;
+        DerpLatencyMeasurer::supervise(&slf, params.env.clone())
+            .spawn()
+            .await;
 
         slf.attach_stream(stream.boxed(), (), ());
 


### PR DESCRIPTION
Stacked on #253. (Can't use the stacked PRs feature more than once for the same base -- apparently it took github this long to build beta support for stacked PRs but no one considered the fact that commit dependencies are a DAG in the general case.)

Tiny independent change: move the derp latency measurer to be supervised by the control actor so it's automatically restarted if it dies. This is the only use of spawn_link (I think? that isn't being otherwise refactored anyway), which is why it's in this tiny PR