### PR TITLE
runtime/error: provide `From<Infallible>`

### DIFF
--- a/ts_runtime/src/error.rs
+++ b/ts_runtime/src/error.rs
@@ -3,7 +3,7 @@ use core::fmt::{Formatter, Write};
 use kameo::{
     Actor,
     actor::{ActorRef, WeakActorRef},
-    error::{HookError, SendError},
+    error::{HookError, Infallible, SendError},
 };
 
 pub(crate) trait ResultExt {
@@ -105,6 +105,12 @@ impl<E> From<HookError<E>> for Error {
                 message_ty: Some("ActorStartOrStop"),
             },
         }
+    }
+}
+
+impl From<Infallible> for Error {
+    fn from(_: Infallible) -> Self {
+        unreachable!()
     }
 }
 


### PR DESCRIPTION
Kameo provides its own `Infallible` instance, and it's not uncommon for actors to use this as their `Actor::Error` type if they don't produce errors. Providing this instance permits us to use question mark in cases like `Actor::spawn(...)?`.