### PR TITLE
runtime: write `Registry`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
 name = "bounded-integer"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4925,6 +4935,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
+
+[[package]]
 name = "smoltcp"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6229,6 +6249,7 @@ dependencies = [
  "proptest",
  "rand 0.10.1",
  "smallvec",
+ "smol_str",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/ts_runtime/Cargo.toml
+++ b/ts_runtime/Cargo.toml
@@ -38,6 +38,7 @@ tokio.workspace = true
 tokio-stream = { version = "0.1", default-features = false, features = ["time"] }
 tracing.workspace = true
 smallvec.workspace = true
+smol_str = "0.3"
 
 [dev-dependencies]
 chrono.workspace = true

--- a/ts_runtime/src/control_runner.rs
+++ b/ts_runtime/src/control_runner.rs
@@ -83,6 +83,7 @@ impl kameo::Actor for ControlRunner {
             .await;
 
         slf.attach_stream(stream.boxed(), (), ());
+        params.env.register(None, &slf).await?;
 
         Ok(Self {
             client,

--- a/ts_runtime/src/dataplane.rs
+++ b/ts_runtime/src/dataplane.rs
@@ -83,6 +83,7 @@ impl kameo::Actor for DataplaneActor {
         });
 
         tracing::trace!("dataplane running");
+        env.register(None, &slf).await?;
 
         Ok(Self { dataplane, task })
     }

--- a/ts_runtime/src/derp_latency.rs
+++ b/ts_runtime/src/derp_latency.rs
@@ -23,6 +23,7 @@ impl kameo::Actor for DerpLatencyMeasurer {
 
     async fn on_start(env: Env, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
         env.subscribe::<Arc<ts_control::StateUpdate>>(&slf).await?;
+        env.register(None, &slf).await?;
 
         tracing::trace!("derp latency measurer running");
 

--- a/ts_runtime/src/env.rs
+++ b/ts_runtime/src/env.rs
@@ -1,18 +1,30 @@
+use core::any::Any;
 use std::sync::Arc;
 
 use kameo::{
-    actor::{ActorRef, Spawn},
-    message::Message,
+    Reply,
+    actor::{ActorRef, Spawn, WeakActorRef},
+    error::SendError,
+    message::{Context, Message},
+    reply::ForwardedReply,
 };
 use kameo_actors::scheduler::Scheduler;
+use smol_str::SmolStr;
 use tokio::sync::watch;
 
-use crate::{Error, error::ResultExt, retained_bus::RetainedBus};
+use crate::{
+    Error, ErrorKind,
+    error::ResultExt,
+    registry,
+    registry::{Forward, Registry},
+    retained_bus::RetainedBus,
+};
 
 #[derive(Clone)]
 pub struct Env {
     pub bus: ActorRef<RetainedBus>,
     pub scheduler: ActorRef<Scheduler>,
+    pub registry: ActorRef<Registry>,
 
     pub keys: Arc<ts_keys::NodeState>,
 
@@ -32,6 +44,7 @@ impl Env {
         Self {
             bus: RetainedBus::spawn_default(),
             scheduler: Scheduler::spawn_default(),
+            registry: Registry::spawn_default(),
             keys: Arc::new(keys),
             shutdown,
         }
@@ -72,4 +85,166 @@ impl Env {
 
         Ok(())
     }
+
+    /// Register an actor in the registry under the specified `name`. If `None`, the actor is
+    /// registered as the canonical actor of type `A`.
+    ///
+    /// If the return value is `Ok(Some(_))`, this registration replaced an existing registration
+    /// for the same name.
+    pub async fn register<A>(
+        &self,
+        name: Option<SmolStr>,
+        slf: &ActorRef<A>,
+    ) -> Result<Option<WeakActorRef<A>>, Error>
+    where
+        A: kameo::Actor,
+    {
+        self.registry
+            .ask(registry::Register::new(name, slf))
+            .await
+            .with_actor_info(&self.registry)
+    }
+
+    /// Look up an actor in the registry.
+    pub async fn lookup_opt<A>(
+        &self,
+        name: Option<SmolStr>,
+    ) -> Result<Option<WeakActorRef<A>>, Error>
+    where
+        A: kameo::Actor + Any,
+    {
+        let aref = self
+            .registry
+            .ask(registry::Lookup::<A>::new(name))
+            .await
+            .with_actor_info(&self.registry)?;
+
+        Ok(aref)
+    }
+
+    /// Look up an actor in the registry.
+    ///
+    /// Reports an error if the actor is in the registry but dead.
+    pub async fn lookup<A>(&self, name: Option<SmolStr>) -> Result<ActorRef<A>, Error>
+    where
+        A: kameo::Actor + Any,
+    {
+        let aref = self.lookup_opt::<A>(name).await?;
+        self.resolve_aref(aref)
+    }
+
+    /// Send an ask to an actor in the registry.
+    ///
+    /// # Parameters
+    ///
+    /// - `name`: the name of the actor to send the message to. If `None`, uses the canonical actor.
+    /// - `msg`: the message to send.
+    /// - `wait`: whether to wait for the actor to be registered if it's not present in the
+    ///   registry.
+    pub async fn ask<A, M>(
+        &self,
+        name: Option<SmolStr>,
+        mut msg: M,
+        wait: bool,
+    ) -> Result<<A::Reply as kameo::Reply>::Ok, Error>
+    where
+        A: Message<M> + Any,
+        M: Send + 'static,
+    {
+        let mk_forward = |msg| Forward::<A, _>::new(name.clone(), msg);
+
+        // If we aren't waiting, this just looks like `return self.registry.ask(forward).await?`
+        //
+        // If we are, the idea is to prefer to use `registry::Forward` to do both the lookup and
+        // forward steps inside the registry (atomically from the rest of the system's perspective).
+        // We could do them here, but there could be a race in between (we wouldn't know if the
+        // ActorRef for a given name is still alive and owning the name by the time we call it). If
+        // the forward fails, we use a lookup to determine if there has been activity on the name,
+        // but we throw away the result and just retry the forward for the previously discussed
+        // reasons.
+        loop {
+            let result = self.registry.ask(mk_forward(msg)).await;
+
+            match result {
+                Ok(x) => return Ok(x),
+                Err(e) => match e.unwrap_err() {
+                    SendError::ActorNotRunning(m) if wait => {
+                        msg = m;
+                    }
+                    e => {
+                        return Err(e).with_actor_info(&self.registry);
+                    }
+                },
+            }
+
+            tracing::trace!("in ask: actor not available, wait until register");
+            self.registry
+                .ask(registry::Lookup::<A>::new(name.clone()).wait(true))
+                .await
+                .with_actor_info(&self.registry)?;
+        }
+    }
+
+    /// Send a tell to an actor in the registry.
+    ///
+    /// The result provides no feedback about whether the actor was running or not.
+    pub async fn tell<A, M>(&self, name: Option<SmolStr>, msg: M) -> Result<(), Error>
+    where
+        A: Message<M> + Any,
+        M: Send + 'static,
+    {
+        self.registry
+            .tell(Forward::<A, _>::new(name, msg))
+            .await
+            .with_actor_info(&self.registry)
+    }
+
+    /// Forward a message to an actor through the registry.
+    pub async fn forward<A, M>(
+        &self,
+        ctx: &mut Context<impl kameo::Actor, impl Reply>,
+        name: Option<SmolStr>,
+        msg: M,
+    ) -> RegForwarded<A, M>
+    where
+        A: Message<M> + Any,
+        M: Send + 'static,
+    {
+        ctx.forward(&self.registry, Forward::<A, M>::new(name, msg))
+            .await
+    }
+
+    /// Wait for a specific actor of type `A` to appear in the registry.
+    pub async fn wait<A>(&self, name: Option<SmolStr>) -> Result<(), Error>
+    where
+        A: kameo::Actor,
+    {
+        self.registry
+            .ask(registry::Lookup::<A>::new(name).wait(true))
+            .await?;
+
+        Ok(())
+    }
+
+    fn resolve_aref<A>(&self, aref: Option<WeakActorRef<A>>) -> Result<ActorRef<A>, Error>
+    where
+        A: kameo::Actor,
+    {
+        let aref = aref.ok_or_else(|| Error {
+            kind: ErrorKind::ActorGone,
+            message_ty: Some("Lookup"),
+            target_actor: Some((&self.registry).into()),
+        })?;
+
+        let aref = aref.upgrade().ok_or_else(|| Error {
+            kind: ErrorKind::ActorGone,
+            message_ty: None,
+            target_actor: Some((&aref).into()),
+        })?;
+
+        Ok(aref)
+    }
 }
+
+pub type RegForwarded<A, M> =
+    ForwardedReply<Forward<A, M>, registry::RegistryForward<M, <A as Message<M>>::Reply>>;

--- a/ts_runtime/src/lib.rs
+++ b/ts_runtime/src/lib.rs
@@ -123,10 +123,9 @@ impl Runtime {
         let (netstack_id, netstack_up, netstack_down) =
             dataplane.ask(dataplane::NewOverlayTransport).await?;
 
-        let multiderp = Multiderp::spawn((env.clone(), dataplane.clone()));
+        Multiderp::spawn((env.clone(), dataplane.clone()));
 
-        let rt_upd =
-            route_updater::RouteUpdater::spawn((multiderp.clone(), env.clone(), netstack_id));
+        let rt_upd = route_updater::RouteUpdater::spawn((env.clone(), netstack_id));
         let pf_upd = packetfilter::PacketfilterUpdater::spawn(env.clone());
         let src_upd = src_filter::SourceFilterUpdater::spawn(env.clone());
         let stunner = stunner::Stunner::spawn(env.clone());

--- a/ts_runtime/src/lib.rs
+++ b/ts_runtime/src/lib.rs
@@ -28,6 +28,7 @@ mod netmon;
 mod netstack_actor;
 mod packetfilter;
 pub mod peer_tracker;
+mod registry;
 mod retained_bus;
 mod route_updater;
 mod src_filter;
@@ -35,6 +36,7 @@ mod stunner;
 
 pub(crate) use env::Env;
 pub use error::{Error, ErrorKind};
+pub use registry::Registry;
 
 use crate::peer_tracker::PeerTracker;
 

--- a/ts_runtime/src/netmon.rs
+++ b/ts_runtime/src/netmon.rs
@@ -11,6 +11,7 @@ use kameo::{
     actor::ActorRef,
     message::{Context, Message, StreamMessage},
 };
+use smol_str::ToSmolStr;
 use ts_netmon::{Event, Family, InterfaceId, Netmon};
 
 use crate::env::Env;
@@ -134,6 +135,10 @@ impl Actor for NetmonActor {
             (),
             (),
         );
+
+        env.register(Some(mon.ty().as_ref().to_smolstr()), &slf)
+            .await
+            .unwrap();
 
         Ok(Self {
             env,

--- a/ts_runtime/src/netstack_actor.rs
+++ b/ts_runtime/src/netstack_actor.rs
@@ -73,6 +73,8 @@ impl kameo::Actor for NetstackActor {
             tracing::warn!("netstack uplink shut down!");
         });
 
+        env.register(None, &slf).await?;
+
         Ok(Self {
             _joinset: joinset,
             channel,

--- a/ts_runtime/src/packetfilter.rs
+++ b/ts_runtime/src/packetfilter.rs
@@ -24,6 +24,7 @@ impl kameo::Actor for PacketfilterUpdater {
 
     async fn on_start(env: Self::Args, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
         env.subscribe::<Arc<ts_control::StateUpdate>>(&slf).await?;
+        env.register(None, &slf).await?;
 
         Ok(Self {
             env,

--- a/ts_runtime/src/peer_tracker/mod.rs
+++ b/ts_runtime/src/peer_tracker/mod.rs
@@ -41,6 +41,7 @@ impl kameo::Actor for PeerTracker {
 
     async fn on_start(env: Self::Args, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
         env.subscribe::<Arc<ts_control::StateUpdate>>(&slf).await?;
+        env.register(None, &slf).await?;
 
         Ok(Self {
             peer_db: PeerDb::default(),

--- a/ts_runtime/src/registry.rs
+++ b/ts_runtime/src/registry.rs
@@ -1,0 +1,373 @@
+use core::{
+    any::{Any, TypeId, type_name},
+    marker::PhantomData,
+};
+use std::collections::HashMap;
+
+use kameo::{
+    Reply,
+    actor::{ActorRef, WeakActorRef},
+    error::{BoxSendError, Infallible, SendError},
+    message::{Context, Message},
+    reply::{BoxReplySender, DelegatedReply, ForwardedReply, ReplyError},
+};
+use smol_str::SmolStr;
+
+/// Name for a canonical actor instance.
+const CANONICAL: SmolStr = SmolStr::new_static("__canonical__");
+
+/// Complete identifier for an actor registration: the actor type and the user-provided name string.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct Id {
+    actor_ty: TypeId,
+    name: SmolStr,
+}
+
+impl Id {
+    fn new<A>(name: Option<SmolStr>) -> Self
+    where
+        A: Any,
+    {
+        match name {
+            Some(name) => Self::named::<A>(name),
+            None => Self::canonical::<A>(),
+        }
+    }
+
+    const fn canonical<A>() -> Self
+    where
+        A: Any,
+    {
+        Self {
+            actor_ty: TypeId::of::<A>(),
+            name: CANONICAL,
+        }
+    }
+
+    const fn named<A>(name: SmolStr) -> Self
+    where
+        A: Any,
+    {
+        Self {
+            actor_ty: TypeId::of::<A>(),
+            name,
+        }
+    }
+}
+
+/// [`WeakActorRef`] with erased actor type.
+pub type ErasedWeakRef = Box<dyn Any + Send>;
+
+/// An actor registry which itself runs as an actor and provides naming service for the tuple
+/// `(actor_type, name)`.
+///
+/// # Names
+///
+/// When you communicate with this registry, you always explicitly name the type of actor you're
+/// talking about as well as the user-provided string name. This is an affordance for type-safety;
+/// kameo doesn't support fully type-erased actor references or message handlers. As a consequence,
+/// names are permitted to overlap between actors of different types, as there can't be a collision
+/// between them.
+///
+/// The conventional structure of names in this registry includes the idea of a "canonical" actor
+/// which is unique. For actors expected to run as singletons or to have a single special instance,
+/// the `new` function on any of the message types addresses this canonical instance. The canonical
+/// name isn't privileged in any other way (e.g. the registry doesn't prevent you from spawning
+/// named actors if there's a canonical one), it's just a conventional, easily-addressed name for a
+/// special actor if you have one.
+///
+/// # Liveness
+///
+/// This registry does not keep actors alive; all refs are held weakly.
+///
+/// # Comparison to [`kameo::registry`]
+///
+/// We're not using the singleton [`kameo::registry::ACTOR_REGISTRY`] because it's at global scope,
+/// but we need naming services to be scoped to each instance of a tailscale runtime. Rather than
+/// dealing with namespace prefixes, we just run a per-runtime registry.
+///
+/// We don't use [`kameo::registry::ActorRegistry`] for the per-runtime registry because it doesn't
+/// have any built-in synchronization, is hard to customize, and requires manual downcasting on the
+/// part of the user, despite the fact that the contained actor refs are only usable if you know
+/// what kind of messages they can handle (i.e. you essentially must know the actor type a priori).
+#[derive(Default)]
+pub struct Registry {
+    actors: HashMap<Id, ErasedWeakRef>,
+    pending_lookups: HashMap<Id, Vec<BoxReplySender>>,
+}
+
+impl kameo::Actor for Registry {
+    type Args = ();
+    type Error = Infallible;
+
+    async fn on_start(_args: Self::Args, _actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(Self::default())
+    }
+}
+
+/// Request to register an actor with a given name.
+///
+/// The registry replies with the [`WeakActorRef`] of an actor that was already registered in this
+/// name if there was one.
+pub struct Register<A>
+where
+    A: kameo::Actor,
+{
+    id: Id,
+    aref: WeakActorRef<A>,
+}
+
+impl<A> Register<A>
+where
+    A: kameo::Actor + Any,
+{
+    /// Construct a register request for the actor of type `A` with the specified `name`, if given,
+    /// or the canonical actor if not.
+    pub fn new(name: Option<SmolStr>, aref: &ActorRef<A>) -> Self {
+        Self {
+            id: Id::new::<A>(name),
+            aref: aref.downgrade(),
+        }
+    }
+}
+
+impl<A> Message<Register<A>> for Registry
+where
+    A: kameo::Actor + Any,
+{
+    type Reply = Option<WeakActorRef<A>>;
+
+    async fn handle(
+        &mut self,
+        msg: Register<A>,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Option<WeakActorRef<A>> {
+        if let Some(pending) = self.pending_lookups.remove(&msg.id) {
+            for sender in pending {
+                drop(sender.send(Ok(Box::new(Some(msg.aref.clone())))));
+            }
+        }
+
+        let previous = self.actors.insert(msg.id, Box::new(msg.aref))?;
+
+        *previous.downcast().unwrap()
+    }
+}
+
+/// Request to unregister an actor for a given name.
+///
+/// The registry replies with the [`WeakActorRef`] of the unregistered actor if there was one.
+pub struct Unregister<A>(Id, PhantomData<A>);
+
+impl<A> Unregister<A>
+where
+    A: Any,
+{
+    /// Unregister an actor of type `A` if it exists in the registry. If `name` is `None`, the
+    /// canonical actor is unregistered.
+    pub fn new(name: Option<SmolStr>) -> Self {
+        Self(Id::new::<A>(name), PhantomData)
+    }
+}
+
+impl<A> Message<Unregister<A>> for Registry
+where
+    A: kameo::Actor,
+{
+    type Reply = Option<WeakActorRef<A>>;
+
+    async fn handle(
+        &mut self,
+        msg: Unregister<A>,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Option<WeakActorRef<A>> {
+        let previous = self.actors.remove(&msg.0)?;
+        *previous.downcast().unwrap()
+    }
+}
+
+pub struct Lookup<A> {
+    id: Id,
+    wait: bool,
+    _phantom: PhantomData<A>,
+}
+
+impl<A> Lookup<A>
+where
+    A: Any,
+{
+    /// Look up the actor with the given `name`, or the canonical actor if `name` is `None`.
+    pub fn new(name: Option<SmolStr>) -> Self {
+        Self {
+            id: Id::new::<A>(name),
+            wait: false,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Wait until an actor is registered with the given name.
+    pub const fn wait(mut self, wait: bool) -> Self {
+        self.wait = wait;
+        self
+    }
+}
+
+impl<A> Message<Lookup<A>> for Registry
+where
+    A: kameo::Actor,
+{
+    type Reply = DelegatedReply<Option<WeakActorRef<A>>>;
+
+    async fn handle(
+        &mut self,
+        msg: Lookup<A>,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let (deleg, sender) = ctx.reply_sender();
+
+        if let Some(sender) = sender {
+            let aref = self
+                .actors
+                .get(&msg.id)
+                .map(|x| x.downcast_ref::<WeakActorRef<A>>().unwrap())
+                .cloned();
+
+            match (&aref, msg.wait) {
+                (Some(_), _) | (_, false) => {
+                    sender.send(aref);
+                }
+                (None, true) => {
+                    self.pending_lookups
+                        .entry(msg.id)
+                        .or_default()
+                        .push(sender.boxed());
+                }
+            }
+        };
+
+        deleg
+    }
+}
+
+/// Request to forward a message of type `M` to an actor of type `A` under a particular registered
+/// name.
+pub struct Forward<A, M> {
+    id: Id,
+    message: M,
+    _phantom: PhantomData<A>,
+}
+
+impl<A, M> Forward<A, M>
+where
+    A: Any,
+{
+    /// Construct a new [`Forward`] for the message `M`.
+    pub fn new(name: Option<SmolStr>, m: M) -> Self {
+        Self {
+            id: Id::new::<A>(name),
+            message: m,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// Wrapper around [`ForwardedReply`] that handles forwards into the registry.
+///
+/// This is needed because [`ForwardedReply`] doesn't let you construct a [`SendError`] variant
+/// directly.
+pub enum RegistryForward<M, R>
+where
+    M: Send + 'static,
+    R: Reply,
+{
+    /// The message was successfully forwarded or failed to be forwarded
+    Forwarded(ForwardedReply<M, R>),
+    ActorDead(M),
+    NotFound(M),
+}
+
+impl<M, R> Reply for RegistryForward<M, R>
+where
+    M: Send + 'static,
+    R: Reply,
+{
+    type Ok = R::Ok;
+    type Error = SendError<M, R::Error>;
+    type Value = Result<Self::Ok, Self::Error>;
+
+    fn to_result(self) -> Result<Self::Ok, Self::Error> {
+        match self {
+            Self::Forwarded(res) => res.to_result(),
+            Self::NotFound(m) => Err(SendError::ActorNotRunning(m)),
+            Self::ActorDead(m) => Err(SendError::ActorNotRunning(m)),
+        }
+        .inspect_err(|e| {
+            tracing::trace!(error = ?e, "forward error");
+        })
+    }
+
+    fn into_any_err(self) -> Option<Box<dyn ReplyError>> {
+        match self {
+            Self::Forwarded(res) => res.into_any_err(),
+            Self::ActorDead(m) => {
+                Some(Box::new(SendError::<M, R::Error>::ActorNotRunning(m)) as Box<dyn ReplyError>)
+            }
+            Self::NotFound(m) => {
+                Some(Box::new(SendError::<M, R::Error>::ActorNotRunning(m)) as Box<dyn ReplyError>)
+            }
+        }
+    }
+
+    fn into_value(self) -> Self::Value {
+        self.to_result()
+    }
+
+    /// If the forwarded reply succeeded, then we can safely assume
+    /// the `Box<dyn Any>` we have here is the ok value of the inner `R`.
+    fn downcast_ok(ok: Box<dyn Any>) -> Self::Ok {
+        *ok.downcast().unwrap()
+    }
+
+    /// The error is either from the inner `R`, or our outer `SendError`.
+    /// We'll try both.
+    fn downcast_err<N: 'static>(err: BoxSendError) -> SendError<N, Self::Error> {
+        err.try_downcast::<N, R::Error>()
+            .map(|err| err.map_err(SendError::HandlerError))
+            .unwrap_or_else(|err| {
+                err.downcast::<M, SendError<M, R::Error>>().map_msg(|_| {
+                    unreachable!(
+                        "forwarded reply is only an error if it failed to forward the message"
+                    )
+                })
+            })
+    }
+}
+
+impl<A, M> Message<Forward<A, M>> for Registry
+where
+    A: Message<M>,
+    M: Send + 'static,
+{
+    type Reply = RegistryForward<M, A::Reply>;
+
+    #[tracing::instrument(skip_all, fields(msgty = type_name::<M>(), actor = type_name::<A>(), name = %msg.id.name))]
+    async fn handle(
+        &mut self,
+        msg: Forward<A, M>,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let Some(aref) = self.actors.get(&msg.id) else {
+            tracing::trace!("actor not found");
+            return RegistryForward::NotFound(msg.message);
+        };
+
+        let Some(aref) = aref.downcast_ref::<WeakActorRef<A>>().unwrap().upgrade() else {
+            tracing::trace!("actor dead");
+            return RegistryForward::ActorDead(msg.message);
+        };
+
+        let result = ctx.try_forward(&aref, msg.message);
+
+        RegistryForward::Forwarded(result)
+    }
+}

--- a/ts_runtime/src/route_updater.rs
+++ b/ts_runtime/src/route_updater.rs
@@ -30,6 +30,8 @@ impl kameo::Actor for RouteUpdater {
         env.subscribe::<Arc<ts_control::StateUpdate>>(&actor_ref)
             .await?;
 
+        env.register(None, &slf).await?;
+
         Ok(Self {
             multiderp,
             default_overlay_transport: default_transport,

--- a/ts_runtime/src/route_updater.rs
+++ b/ts_runtime/src/route_updater.rs
@@ -13,27 +13,24 @@ use ts_transport::{OverlayTransportId, PeerId, UnderlayTransportId};
 use crate::{Error, env::Env, multiderp, multiderp::Multiderp, peer_tracker::PeerState};
 
 pub struct RouteUpdater {
-    multiderp: ActorRef<Multiderp>,
     default_overlay_transport: OverlayTransportId,
     env: Env,
 }
 
 impl kameo::Actor for RouteUpdater {
-    type Args = (ActorRef<Multiderp>, Env, OverlayTransportId);
+    type Args = (Env, OverlayTransportId);
     type Error = Error;
 
     async fn on_start(
-        (multiderp, env, default_transport): Self::Args,
-        actor_ref: ActorRef<Self>,
+        (env, default_transport): Self::Args,
+        slf: ActorRef<Self>,
     ) -> Result<Self, Self::Error> {
-        env.subscribe::<Arc<PeerState>>(&actor_ref).await?;
-        env.subscribe::<Arc<ts_control::StateUpdate>>(&actor_ref)
-            .await?;
+        env.subscribe::<Arc<PeerState>>(&slf).await?;
+        env.subscribe::<Arc<ts_control::StateUpdate>>(&slf).await?;
 
         env.register(None, &slf).await?;
 
         Ok(Self {
-            multiderp,
             default_overlay_transport: default_transport,
             env,
         })
@@ -84,8 +81,8 @@ impl Message<Arc<PeerState>> for RouteUpdater {
             tracing::trace!(parent: &span, "ask multiderp for transport id");
 
             match self
-                .multiderp
-                .ask(multiderp::TransportIdForRegion { id: region })
+                .env
+                .ask::<Multiderp, _>(None, multiderp::TransportIdForRegion { id: region }, true)
                 .await
             {
                 Ok(Some(transport_id)) => {

--- a/ts_runtime/src/src_filter.rs
+++ b/ts_runtime/src/src_filter.rs
@@ -19,6 +19,7 @@ impl kameo::Actor for SourceFilterUpdater {
 
     async fn on_start(env: Self::Args, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
         env.subscribe::<Arc<PeerState>>(&slf).await?;
+        env.register(None, &slf).await?;
 
         Ok(Self { env })
     }

--- a/ts_runtime/src/stunner.rs
+++ b/ts_runtime/src/stunner.rs
@@ -79,6 +79,8 @@ impl kameo::Actor for Stunner {
             )
             .await?;
 
+        env.register(None, &slf).await?;
+
         Ok(Self {
             env,
             servers: vec![],


### PR DESCRIPTION
Stacked on #253.

Write a `Registry` actor in roughly the Erlang model allowing actors to be registered and looked up by name. The `Registry` can also handle forwarding messages for registered actors, which can be useful for message-ordering purposes (the lookup and send are atomic from the perspective of the forwarding actor). 

Notably, each name is registered in the scope of a single actor type. This is a consequence of kameo's design trying to enforce strong message typing: the `ActorRef` type is a pid augmented with the actor type `A`, meaning that a collection of `ActorRef`s simply can't be held generically as `ActorRef`s (which is the only type you can send a message to because the `A` can be used to prove that `A` can handle the message you're trying to send it). To erase the actor type, you need to hold `Box<dyn Any>` and downcast later. But it's not possible to recover the actor type `A` from a generic incoming message (which you might want to forward): the sender must specify the type of the actor they're trying to communicate with. Hence, names overlapping between actors doesn't make sense and `Registry` separates them into what are essentially namespaces by `TypeId::of::<A>()`.

This is in the interest of supervision; as in Erlang, when an actor process dies and a supervisor restarts the process, its old pid (`ActorRef`) doesn't address it anymore. So you functionally need a naming service to resolve the semantic, symbolic name ("the control plane actor") to the actual pid (`ActorRef`) it currently has at the time you're trying to send a message.

## kameo's built-in registry

Kameo has a built-in actor registry which provides `ActorRef::register(name)`. We don't use this for a few reasons:

- The default instance providing `ActorRef::register` is global, which would break the ability to run more than one runtime in the same process without adding namespacing logic, which would require the runtimes to be aware of each other somehow (probably through more global state). I wanted to avoid that.
- You can make your own instance with `kameo::Registry::new`, but the implementation is  just a wrapper around a hashmap. It doesn't run as an actor. That's not ideal for observability or message-ordering &mdash; you'd need to stick it behind a mutex to run it like this, which is what the global one does. This also makes it difficult to wait for another actor to register itself, which this implementation provides
- It puts all actor types in the same namespace but kind of requires you to downcast twice. This felt awkward/unnecessary