### PR TITLE
kvstore: a bag of changes to owners, singletons, and indexes

### DIFF
--- a/ts_kv_store/src/index.rs
+++ b/ts_kv_store/src/index.rs
@@ -462,7 +462,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableRoTransactionalIndex<'guard, 'txn, D> {
 
 #[cfg(test)]
 mod test {
-    use crate::{KvErrorExt, tables};
+    use crate::{KvErrorExt, store};
 
     #[derive(Clone, Debug, PartialEq)]
     pub struct Row {
@@ -475,7 +475,7 @@ mod test {
         }
     }
 
-    tables!(Users(u32 => Row; OWNER; index(name: String)));
+    store!(tables: { Users(u32 => Row; OWNER; index(name: String)) });
 
     const OWNER: &str = "owner";
     const OTHER: &str = "other";
@@ -908,7 +908,7 @@ mod test {
 
 #[cfg(test)]
 mod test_two_indexes {
-    use crate::{KvErrorExt, tables};
+    use crate::{KvErrorExt, store};
 
     #[derive(Clone, Debug, PartialEq)]
     pub struct Person {
@@ -923,7 +923,7 @@ mod test_two_indexes {
         }
     }
 
-    tables!(People(u32 => Person; OWNER; index(email: String); index(username: Vec<u8>)));
+    store!(tables: { People(u32 => Person; OWNER; index(email: String); index(username: Vec<u8>)) });
 
     const OWNER: &str = "owner";
 
@@ -1215,7 +1215,7 @@ mod test_two_indexes {
 
 #[cfg(test)]
 mod test_transactional_index {
-    use crate::{KvErrorExt, tables};
+    use crate::{KvErrorExt, store};
 
     #[derive(Clone, Debug, PartialEq)]
     pub struct Row {
@@ -1230,7 +1230,7 @@ mod test_transactional_index {
         }
     }
 
-    tables!(Users(u32 => Row; OWNER; index(name: String)));
+    store!(tables: { Users(u32 => Row; OWNER; index(name: String)) });
 
     const OWNER: &str = "owner";
     #[cfg(debug_assertions)]
@@ -1668,7 +1668,7 @@ mod test_transactional_index {
 
 #[cfg(test)]
 mod test_poison {
-    use crate::{Error, KvErrorExt, tables};
+    use crate::{Error, KvErrorExt, store};
 
     #[derive(Clone, Debug, PartialEq)]
     pub struct Row {
@@ -1683,9 +1683,11 @@ mod test_poison {
         }
     }
 
-    tables!(
-        Users(u32 => Row; OWNER; index(name: String); index(email: String)),
-        AssertingUsers(u32 => Row; OWNER; index(name: String; assert_unique))
+    store!(
+        tables: {
+            Users(u32 => Row; OWNER; index(name: String); index(email: String)),
+            AssertingUsers(u32 => Row; OWNER; index(name: String; assert_unique)),
+        }
     );
 
     const OWNER: &str = "owner";

--- a/ts_kv_store/src/index.rs
+++ b/ts_kv_store/src/index.rs
@@ -50,17 +50,6 @@ impl<D: IndexDesc> IndexedOpsMut<D::Storage> for &KvTableIndex<'_, D> {
 }
 
 impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
-    /// Initialize the base table by setting its owner (indexes don't have an owner).
-    ///
-    /// Calling this function is optional, a table can be used without initialization in which case,
-    /// its owner is set to the owner specified in the first write.
-    ///
-    /// Returns an error (containing the current owner of the table) if the table has already been
-    /// initialized. In this case, the table will be in a consistent state and can be used as normal.
-    pub fn init(&self) -> Result<()> {
-        <&Self as IndexedOpsMut<_>>::init(self, self.owner)
-    }
-
     /// The number of key/value pairs in the base table.
     pub fn len(&self) -> usize {
         <&Self as IndexedOps<_>>::len(self)
@@ -76,7 +65,7 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
         <&Self as IndexedOps<_>>::check_consistent(self)
     }
 
-    /// Clear the base table by removing all its KVs, but preserving ownership.
+    /// Clear the base table by removing all its KVs.
     pub fn clear(&self)
     where
         IndexValue<D>: Eq + Hash,
@@ -110,8 +99,6 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     }
 
     /// Insert a value into the table using the base table's key.
-    ///
-    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn insert(&self, key: BaseKey<D>, value: BaseValue<D>)
     where
         <<D as IndexDesc>::BaseTable as TableDesc>::Key: Clone,
@@ -135,8 +122,6 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     }
 
     /// Remove a row from the table.
-    ///
-    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn remove<Q>(&self, key: &Q)
     where
         D::Key: Borrow<Q>,
@@ -230,17 +215,6 @@ impl<'guard, 'txn, D: IndexDesc> IndexedOpsMut<D::Storage>
 }
 
 impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
-    /// Initialize the base table by setting its owner (indexes don't have an owner).
-    ///
-    /// Calling this function is optional, a table can be used without initialization in which case,
-    /// its owner is set to the owner specified in the first write.
-    ///
-    /// Returns an error (containing the current owner of the table) if the table has already been
-    /// initialized. In this case, the table will be in a consistent state and can be used as normal.
-    pub fn init(&mut self) -> Result<()> {
-        <&mut Self as IndexedOpsMut<_>>::init(self, self.txn.owner)
-    }
-
     /// The number of key/value pairs in the base table.
     pub fn len(&self) -> usize {
         <&Self as IndexedOps<_>>::len(self)
@@ -255,7 +229,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
         <&Self as IndexedOps<_>>::check_consistent(self)
     }
 
-    /// Clear the base table by removing all its KVs, but preserving ownership.
+    /// Clear the base table by removing all its KVs.
     pub fn clear(&mut self)
     where
         IndexValue<D>: Eq + Hash,
@@ -289,8 +263,6 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
     }
 
     /// Insert a value into the table using the base table's key.
-    ///
-    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn insert(&mut self, key: BaseKey<D>, value: BaseValue<D>)
     where
         BaseKey<D>: Clone,
@@ -318,8 +290,6 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
     }
 
     /// Remove a row from the table.
-    ///
-    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn remove<Q>(&mut self, key: &Q)
     where
         D::Key: Borrow<Q>,
@@ -464,7 +434,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableRoTransactionalIndex<'guard, 'txn, D> {
 
 #[cfg(test)]
 mod test {
-    use crate::{AccessErrorExt, Error, tables};
+    use crate::{AccessErrorExt, tables};
 
     #[derive(Clone, Debug, PartialEq)]
     pub struct Row {
@@ -477,46 +447,10 @@ mod test {
         }
     }
 
-    tables!(Users(u32 => Row; index(name: String)));
+    tables!(Users(u32 => Row; OWNER; index(name: String)));
 
     const OWNER: &str = "owner";
     const OTHER: &str = "other";
-
-    #[test]
-    fn index_init_succeeds_on_fresh_table() {
-        let store = KvStore::new();
-        assert!(store.table_by::<index::Users::name>(OWNER).init().is_ok());
-    }
-
-    #[test]
-    fn index_init_second_call_returns_err() {
-        let store = KvStore::new();
-        store.table_by::<index::Users::name>(OWNER).init().unwrap();
-        let err = store
-            .table_by::<index::Users::name>(OWNER)
-            .init()
-            .unwrap_err();
-        assert!(matches!(err, Error::AlreadyInit(o) if o == OWNER));
-    }
-
-    #[test]
-    fn index_init_with_different_owner_returns_err() {
-        let store = KvStore::new();
-        store.table_by::<index::Users::name>(OWNER).init().unwrap();
-        let err = store
-            .table_by::<index::Users::name>(OTHER)
-            .init()
-            .unwrap_err();
-        assert!(matches!(err, Error::AlreadyInit(o) if o == OWNER));
-    }
-
-    #[test]
-    fn index_init_and_base_init_share_owner() {
-        let store = KvStore::new();
-        store.table_by::<index::Users::name>(OWNER).init().unwrap();
-        let err = store.table::<Users>(OWNER).init().unwrap_err();
-        assert!(matches!(err, Error::AlreadyInit(o) if o == OWNER));
-    }
 
     #[test]
     fn index_len_is_zero_on_fresh_store() {
@@ -924,7 +858,6 @@ mod test {
     #[should_panic(expected = "Ownership violation")]
     fn index_insert_wrong_owner_panics() {
         let store = KvStore::new();
-        store.table_by::<index::Users::name>(OWNER).init().unwrap();
         store
             .table_by::<index::Users::name>(OTHER)
             .insert(1, row("Alice"));
@@ -935,7 +868,6 @@ mod test {
     #[should_panic(expected = "Ownership violation")]
     fn index_clear_wrong_owner_panics() {
         let store = KvStore::new();
-        store.table_by::<index::Users::name>(OWNER).init().unwrap();
         store.table_by::<index::Users::name>(OTHER).clear();
     }
 }
@@ -957,7 +889,7 @@ mod test_two_indexes {
         }
     }
 
-    tables!(People(u32 => Person; index(email: String); index(username: Vec<u8>)));
+    tables!(People(u32 => Person; OWNER; index(email: String); index(username: Vec<u8>)));
 
     const OWNER: &str = "owner";
 
@@ -1264,7 +1196,7 @@ mod test_transactional_index {
         }
     }
 
-    tables!(Users(u32 => Row; index(name: String)));
+    tables!(Users(u32 => Row; OWNER; index(name: String)));
 
     const OWNER: &str = "owner";
     #[cfg(debug_assertions)]
@@ -1544,7 +1476,6 @@ mod test_transactional_index {
     #[should_panic(expected = "Ownership violation")]
     fn txn_index_insert_wrong_owner_panics() {
         let store = KvStore::new();
-        store.table::<Users>(OWNER).init().unwrap();
         let mut txn = store.begin_transaction(OTHER);
         txn.table_by::<index::Users::name>().insert(1, row("Alice"));
     }
@@ -1554,7 +1485,6 @@ mod test_transactional_index {
     #[should_panic(expected = "Ownership violation")]
     fn txn_index_clear_wrong_owner_panics() {
         let store = KvStore::new();
-        store.table::<Users>(OWNER).init().unwrap();
         let mut txn = store.begin_transaction(OTHER);
         txn.table_by::<index::Users::name>().clear();
     }
@@ -1564,7 +1494,6 @@ mod test_transactional_index {
     #[should_panic(expected = "Ownership violation")]
     fn txn_index_for_each_mut_wrong_owner_panics() {
         let store = KvStore::new();
-        store.table::<Users>(OWNER).init().unwrap();
         let mut txn = store.begin_transaction(OTHER);
         txn.table_by::<index::Users::name>().for_each_mut(|_, _| {});
     }
@@ -1700,8 +1629,8 @@ mod test_poison {
     }
 
     tables!(
-        Users(u32 => Row; index(name: String); index(email: String)),
-        AssertingUsers(u32 => Row; index(name: String; assert_unique))
+        Users(u32 => Row; OWNER; index(name: String); index(email: String)),
+        AssertingUsers(u32 => Row; OWNER; index(name: String; assert_unique))
     );
 
     const OWNER: &str = "owner";

--- a/ts_kv_store/src/index.rs
+++ b/ts_kv_store/src/index.rs
@@ -888,8 +888,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(debug_assertions)]
-    #[should_panic(expected = "Ownership violation")]
+    #[cfg_attr(debug_assertions, should_panic(expected = "Ownership violation"))]
     fn index_insert_wrong_owner_panics() {
         let store = KvStore::new();
         store
@@ -898,8 +897,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(debug_assertions)]
-    #[should_panic(expected = "Ownership violation")]
+    #[cfg_attr(debug_assertions, should_panic(expected = "Ownership violation"))]
     fn index_clear_wrong_owner_panics() {
         let store = KvStore::new();
         store.table_by::<index::Users::name>(OTHER).clear();
@@ -1233,7 +1231,6 @@ mod test_transactional_index {
     store!(tables: { Users(u32 => Row; OWNER; index(name: String)) });
 
     const OWNER: &str = "owner";
-    #[cfg(debug_assertions)]
     const OTHER: &str = "other";
 
     #[test]
@@ -1527,8 +1524,7 @@ mod test_transactional_index {
     }
 
     #[test]
-    #[cfg(debug_assertions)]
-    #[should_panic(expected = "Ownership violation")]
+    #[cfg_attr(debug_assertions, should_panic(expected = "Ownership violation"))]
     fn txn_index_insert_wrong_owner_panics() {
         let store = KvStore::new();
         let mut txn = store.begin_transaction(OTHER);
@@ -1536,8 +1532,7 @@ mod test_transactional_index {
     }
 
     #[test]
-    #[cfg(debug_assertions)]
-    #[should_panic(expected = "Ownership violation")]
+    #[cfg_attr(debug_assertions, should_panic(expected = "Ownership violation"))]
     fn txn_index_clear_wrong_owner_panics() {
         let store = KvStore::new();
         let mut txn = store.begin_transaction(OTHER);
@@ -1545,8 +1540,7 @@ mod test_transactional_index {
     }
 
     #[test]
-    #[cfg(debug_assertions)]
-    #[should_panic(expected = "Ownership violation")]
+    #[cfg_attr(debug_assertions, should_panic(expected = "Ownership violation"))]
     fn txn_index_for_each_mut_wrong_owner_panics() {
         let store = KvStore::new();
         let mut txn = store.begin_transaction(OTHER);

--- a/ts_kv_store/src/index.rs
+++ b/ts_kv_store/src/index.rs
@@ -69,8 +69,9 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     /// Get a row of the table from the store by cloning the value.
     ///
     /// Returns `Error::NotPresent` if there is no value for the specified key.
-    pub fn get<Q>(&self, key: &Q) -> Result<BaseValue<D>>
+    pub fn get<Q>(&self, key: &Q) -> Result<(BaseKey<D>, BaseValue<D>)>
     where
+        BaseKey<D>: Clone,
         BaseValue<D>: Clone,
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -82,7 +83,7 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `Error::NotPresent` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> Result<T>
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseKey<D>, &BaseValue<D>) -> T) -> Result<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -119,7 +120,11 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     /// Get mutable access to a row of the table in the store in the store.
     ///
     /// Returns `Error::NotPresent` (and does not call `f`) if there is no value for the specified key.
-    pub fn with_mut<Q, T>(&self, key: &Q, f: impl FnOnce(&mut BaseValue<D>) -> T) -> Result<T>
+    pub fn with_mut<Q, T>(
+        &self,
+        key: &Q,
+        f: impl FnOnce(&BaseKey<D>, &mut BaseValue<D>) -> T,
+    ) -> Result<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -149,7 +154,7 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     }
 
     /// Iterate all the keys in the index and value in the base table.
-    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &BaseValue<D>)>
+    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &BaseKey<D>, &BaseValue<D>)>
     where
         D: 'store,
         Base<D>: 'store,
@@ -169,7 +174,7 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     }
 
     /// Iterate all the values in the base table.
-    pub fn values(&self) -> impl Iterator<Item = &BaseValue<D>>
+    pub fn values(&self) -> impl Iterator<Item = (&BaseKey<D>, &BaseValue<D>)>
     where
         D: 'store,
         Base<D>: 'store,
@@ -179,7 +184,7 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     }
 
     /// Iterate all the key/value pairs in a table. Values are mutable.
-    pub fn for_each_mut(&self, f: impl FnMut(&D::Key, &mut BaseValue<D>))
+    pub fn for_each_mut(&self, f: impl FnMut(&BaseKey<D>, &mut BaseValue<D>))
     where
         IndexValue<D>: Eq + Hash + Clone,
         BaseValue<D>: Clone,
@@ -261,8 +266,9 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
     /// Get a row of the table from the store by cloning the value.
     ///
     /// Returns `Error::NotPresent` if there is no value for the specified key.
-    pub fn get<Q>(&self, key: &Q) -> Result<BaseValue<D>>
+    pub fn get<Q>(&self, key: &Q) -> Result<(BaseKey<D>, BaseValue<D>)>
     where
+        BaseKey<D>: Clone,
         BaseValue<D>: Clone,
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -274,7 +280,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `Error::NotPresent` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> Result<T>
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseKey<D>, &BaseValue<D>) -> T) -> Result<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -295,7 +301,11 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
     /// Get mutable access to a row of the table in the store in the store.
     ///
     /// Returns `Error::NotPresent` (and does not call `f`) if there is no value for the specified key.
-    pub fn with_mut<Q, T>(&mut self, key: &Q, f: impl FnOnce(&mut BaseValue<D>) -> T) -> Result<T>
+    pub fn with_mut<Q, T>(
+        &mut self,
+        key: &Q,
+        f: impl FnOnce(&BaseKey<D>, &mut BaseValue<D>) -> T,
+    ) -> Result<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -317,7 +327,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
     }
 
     /// Iterate all the keys in the index and value in the base table.
-    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &BaseValue<D>)>
+    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &BaseKey<D>, &BaseValue<D>)>
     where
         D: 'guard,
         Base<D>: 'guard,
@@ -336,7 +346,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
     }
 
     /// Iterate all the values in the base table.
-    pub fn values(&self) -> impl Iterator<Item = &BaseValue<D>>
+    pub fn values(&self) -> impl Iterator<Item = (&BaseKey<D>, &BaseValue<D>)>
     where
         D: 'guard,
         Base<D>: 'guard,
@@ -346,7 +356,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
     }
 
     /// Iterate all the key/value pairs in a table. Values are mutable.
-    pub fn for_each_mut(&mut self, f: impl FnMut(&D::Key, &mut BaseValue<D>))
+    pub fn for_each_mut(&mut self, f: impl FnMut(&BaseKey<D>, &mut BaseValue<D>))
     where
         IndexValue<D>: Eq + Hash + Clone,
         BaseValue<D>: Clone,
@@ -400,8 +410,9 @@ impl<'guard, 'txn, D: IndexDesc> KvTableRoTransactionalIndex<'guard, 'txn, D> {
     /// Get a row of the table from the store by cloning the value.
     ///
     /// Returns `Error::NotPresent` if there is no value for the specified key.
-    pub fn get<Q>(&self, key: &Q) -> Result<BaseValue<D>>
+    pub fn get<Q>(&self, key: &Q) -> Result<(BaseKey<D>, BaseValue<D>)>
     where
+        BaseKey<D>: Clone,
         BaseValue<D>: Clone,
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -413,7 +424,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableRoTransactionalIndex<'guard, 'txn, D> {
     /// Get immutable access to a row of the table in the store by reference.
     ///
     /// Returns `Error::NotPresent` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> Result<T>
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseKey<D>, &BaseValue<D>) -> T) -> Result<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -423,7 +434,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableRoTransactionalIndex<'guard, 'txn, D> {
     }
 
     /// Iterate all the keys in the index and value in the base table.
-    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &BaseValue<D>)>
+    pub fn iter(&self) -> impl Iterator<Item = (&D::Key, &BaseKey<D>, &BaseValue<D>)>
     where
         D: 'guard,
         IndexValue<D>: Eq + Hash,
@@ -440,7 +451,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableRoTransactionalIndex<'guard, 'txn, D> {
     }
 
     /// Iterate all the values in the base table.
-    pub fn values(&self) -> impl Iterator<Item = &BaseValue<D>>
+    pub fn values(&self) -> impl Iterator<Item = (&BaseKey<D>, &BaseValue<D>)>
     where
         D: 'guard,
         IndexValue<D>: Eq + Hash,
@@ -516,7 +527,7 @@ mod test {
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         let table = store.table_by::<index::Users::name>(OWNER);
         let value = table.get("Alice").unwrap();
-        assert_eq!(value, row("Alice"));
+        assert_eq!(value, (1, row("Alice")));
     }
 
     #[test]
@@ -529,7 +540,7 @@ mod test {
         let table = store.table_by::<index::Users::name>(OWNER);
 
         let value = table.get("Alice").unwrap();
-        assert_eq!(value, row("Alice"));
+        assert_eq!(value, (1, row("Alice")));
     }
 
     #[test]
@@ -538,7 +549,7 @@ mod test {
         let mut called = false;
         let result = store
             .table_by::<index::Users::name>(OWNER)
-            .with("Alice", |_| {
+            .with("Alice", |_, _| {
                 called = true;
             });
         assert!(result.is_none());
@@ -551,7 +562,10 @@ mod test {
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         let len = store
             .table_by::<index::Users::name>(OWNER)
-            .with("Alice", |v| v.name.len());
+            .with("Alice", |k, v| {
+                assert_eq!(*k, 1);
+                v.name.len()
+            });
         assert_eq!(len.unwrap_opt(), Some(5));
     }
 
@@ -616,7 +630,7 @@ mod test {
         let store = KvStore::new();
         let result = store
             .table_by::<index::Users::name>(OWNER)
-            .with_mut("Alice", |v| v.name.len());
+            .with_mut("Alice", |_, v| v.name.len());
         assert!(result.is_none());
     }
 
@@ -626,7 +640,10 @@ mod test {
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         store
             .table_by::<index::Users::name>(OWNER)
-            .with_mut("Alice", |v| v.name.push_str(" Smith"))
+            .with_mut("Alice", |k, v| {
+                assert_eq!(*k, 1);
+                v.name.push_str(" Smith")
+            })
             .unwrap();
         let value = store.table::<Users>(OWNER).get(&1).unwrap();
         assert_eq!(value.name, "Alice Smith");
@@ -638,7 +655,7 @@ mod test {
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         store
             .table_by::<index::Users::name>(OWNER)
-            .with_mut("Alice", |v| {
+            .with_mut("Alice", |_, v| {
                 v.name = "Charlie".to_owned();
             })
             .unwrap();
@@ -652,7 +669,7 @@ mod test {
             .table_by::<index::Users::name>(OWNER)
             .get("Charlie")
             .unwrap();
-        assert_eq!(value.name, "Charlie");
+        assert_eq!(value, (1, row("Charlie")));
     }
 
     #[test]
@@ -702,9 +719,9 @@ mod test {
         let items: Vec<_> = store
             .table_by::<index::Users::name>(OWNER)
             .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
+            .map(|(k, bk, v)| (k.clone(), *bk, v.clone()))
             .collect();
-        assert_eq!(items, vec![("Alice".to_owned(), row("Alice"))]);
+        assert_eq!(items, vec![("Alice".to_owned(), 1, row("Alice"))]);
     }
 
     #[test]
@@ -715,14 +732,14 @@ mod test {
         let mut items: Vec<_> = store
             .table_by::<index::Users::name>(OWNER)
             .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
+            .map(|(k, bk, v)| (k.clone(), *bk, v.clone()))
             .collect();
-        items.sort_by_key(|(k, _)| k.clone());
+        items.sort_by_key(|(k, ..)| k.clone());
         assert_eq!(
             items,
             vec![
-                ("Alice".to_owned(), row("Alice")),
-                ("Bob".to_owned(), row("Bob")),
+                ("Alice".to_owned(), 1, row("Alice")),
+                ("Bob".to_owned(), 2, row("Bob")),
             ]
         );
     }
@@ -763,8 +780,8 @@ mod test {
         store.table::<Users>(OWNER).insert(2, row("Bob"));
         let table = store.table_by::<index::Users::name>(OWNER);
         let mut values: Vec<_> = table.values().collect();
-        values.sort_by_key(|r| r.name.clone());
-        assert_eq!(values, vec![&row("Alice"), &row("Bob")]);
+        values.sort_by_key(|(_, r)| r.name.clone());
+        assert_eq!(values, vec![(&1, &row("Alice")), (&2, &row("Bob"))]);
     }
 
     #[test]
@@ -784,8 +801,8 @@ mod test {
         let mut items: Vec<_> = Vec::new();
         index
             .iter()
-            .for_each(|(k, v)| items.push((k.clone(), v.clone())));
-        assert_eq!(items, vec![("Alice".to_owned(), row("Alice"))]);
+            .for_each(|(k, bk, v)| items.push((k.clone(), *bk, v.clone())));
+        assert_eq!(items, vec![("Alice".to_owned(), 1, row("Alice"))]);
     }
 
     #[test]
@@ -797,13 +814,13 @@ mod test {
         let mut items: Vec<_> = Vec::new();
         index
             .iter()
-            .for_each(|(k, v)| items.push((k.clone(), v.clone())));
-        items.sort_by_key(|(k, _)| k.clone());
+            .for_each(|(k, bk, v)| items.push((k.clone(), *bk, v.clone())));
+        items.sort_by_key(|(k, ..)| k.clone());
         assert_eq!(
             items,
             vec![
-                ("Alice".to_owned(), row("Alice")),
-                ("Bob".to_owned(), row("Bob")),
+                ("Alice".to_owned(), 1, row("Alice")),
+                ("Bob".to_owned(), 2, row("Bob")),
             ]
         );
     }
@@ -844,7 +861,7 @@ mod test {
                 .table_by::<index::Users::name>(OWNER)
                 .get("Charlie")
                 .unwrap(),
-            row("Charlie"),
+            (1, row("Charlie")),
         );
     }
 
@@ -866,7 +883,7 @@ mod test {
                 .table_by::<index::Users::name>(OWNER)
                 .get("Charlie")
                 .unwrap(),
-            row("Charlie")
+            (1, row("Charlie"))
         );
     }
 
@@ -941,14 +958,14 @@ mod test_two_indexes {
                 .table_by::<index::People::email>(OWNER)
                 .get("a@example.com")
                 .unwrap(),
-            person("a@example.com", b"alice")
+            (1, person("a@example.com", b"alice"))
         );
         assert_eq!(
             store
                 .table_by::<index::People::username>(OWNER)
                 .get(b"alice".as_slice())
                 .unwrap(),
-            person("a@example.com", b"alice")
+            (1, person("a@example.com", b"alice"))
         );
     }
 
@@ -963,14 +980,14 @@ mod test_two_indexes {
                 .table_by::<index::People::email>(OWNER)
                 .get("a@example.com")
                 .unwrap(),
-            person("a@example.com", b"alice")
+            (1, person("a@example.com", b"alice"))
         );
         assert_eq!(
             store
                 .table_by::<index::People::username>(OWNER)
                 .get(b"alice".as_slice())
                 .unwrap(),
-            person("a@example.com", b"alice")
+            (1, person("a@example.com", b"alice"))
         );
     }
 
@@ -989,14 +1006,14 @@ mod test_two_indexes {
                 .table_by::<index::People::email>(OWNER)
                 .get("a@example.com")
                 .unwrap(),
-            person("a@example.com", b"alice")
+            (1, person("a@example.com", b"alice"))
         );
         assert_eq!(
             store
                 .table_by::<index::People::username>(OWNER)
                 .get(b"bob".as_slice())
                 .unwrap(),
-            person("b@example.com", b"bob")
+            (2, person("b@example.com", b"bob"))
         );
     }
 
@@ -1233,7 +1250,7 @@ mod test_transactional_index {
         txn.table_by::<index::Users::name>().insert(1, row("Alice"));
         assert_eq!(
             txn.table_by::<index::Users::name>().get("Alice").unwrap(),
-            row("Alice")
+            (1, row("Alice"))
         );
         txn.commit().unwrap();
         assert_eq!(
@@ -1241,7 +1258,7 @@ mod test_transactional_index {
                 .table_by::<index::Users::name>(OWNER)
                 .get("Alice")
                 .unwrap(),
-            row("Alice")
+            (1, row("Alice"))
         );
 
         let mut txn = store.begin_transaction(OWNER);
@@ -1270,7 +1287,10 @@ mod test_transactional_index {
         txn.table_by::<index::Users::name>().insert(1, row("Alice"));
         assert_eq!(
             txn.table_by::<index::Users::name>()
-                .with("Alice", |v| v.name.len())
+                .with("Alice", |k, v| {
+                    assert_eq!(*k, 1);
+                    v.name.len()
+                })
                 .unwrap(),
             5
         );
@@ -1282,15 +1302,18 @@ mod test_transactional_index {
         let mut txn = store.begin_transaction(OWNER);
         txn.table_by::<index::Users::name>().insert(1, row("Alice"));
         txn.table_by::<index::Users::name>()
-            .with_mut("Alice", |v| v.name = "Bob".to_owned())
+            .with_mut("Alice", |_, v| v.name = "Bob".to_owned())
             .unwrap();
         assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
         assert_eq!(
             txn.table_by::<index::Users::name>().get("Bob").unwrap(),
-            Row {
-                name: "Bob".to_owned(),
-                age: 0
-            }
+            (
+                1,
+                Row {
+                    name: "Bob".to_owned(),
+                    age: 0
+                }
+            )
         );
     }
 
@@ -1300,14 +1323,17 @@ mod test_transactional_index {
         let mut txn = store.begin_transaction(OWNER);
         txn.table_by::<index::Users::name>().insert(1, row("Alice"));
         txn.table_by::<index::Users::name>()
-            .with_mut("Alice", |v| v.age = 42)
+            .with_mut("Alice", |_, v| v.age = 42)
             .unwrap();
         assert_eq!(
             txn.table_by::<index::Users::name>().get("Alice").unwrap(),
-            Row {
-                name: "Alice".to_owned(),
-                age: 42
-            }
+            (
+                1,
+                Row {
+                    name: "Alice".to_owned(),
+                    age: 42
+                }
+            )
         );
     }
 
@@ -1352,10 +1378,13 @@ mod test_transactional_index {
         assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
         assert_eq!(
             txn.table_by::<index::Users::name>().get("Charlie").unwrap(),
-            Row {
-                name: "Charlie".to_owned(),
-                age: 0
-            }
+            (
+                1,
+                Row {
+                    name: "Charlie".to_owned(),
+                    age: 0
+                }
+            )
         );
     }
 
@@ -1366,7 +1395,7 @@ mod test_transactional_index {
         txn.table::<Users>().insert(1, row("Alice"));
         assert_eq!(
             txn.table_by::<index::Users::name>().get("Alice").unwrap(),
-            row("Alice")
+            (1, row("Alice"))
         );
     }
 
@@ -1380,10 +1409,13 @@ mod test_transactional_index {
         assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
         assert_eq!(
             txn.table_by::<index::Users::name>().get("Bob").unwrap(),
-            Row {
-                name: "Bob".to_owned(),
-                age: 0
-            }
+            (
+                1,
+                Row {
+                    name: "Bob".to_owned(),
+                    age: 0
+                }
+            )
         );
     }
 
@@ -1417,10 +1449,13 @@ mod test_transactional_index {
         assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
         assert_eq!(
             txn.table_by::<index::Users::name>().get("Charlie").unwrap(),
-            Row {
-                name: "Charlie".to_owned(),
-                age: 0
-            }
+            (
+                1,
+                Row {
+                    name: "Charlie".to_owned(),
+                    age: 0
+                }
+            )
         );
     }
 
@@ -1438,7 +1473,7 @@ mod test_transactional_index {
         let txn = store.begin_ro_transaction(OWNER);
         assert_eq!(
             txn.table_by::<index::Users::name>().get("Alice").unwrap(),
-            row("Alice")
+            (1, row("Alice"))
         );
     }
 
@@ -1449,7 +1484,10 @@ mod test_transactional_index {
         let txn = store.begin_ro_transaction(OWNER);
         assert_eq!(
             txn.table_by::<index::Users::name>()
-                .with("Alice", |v| v.name.len())
+                .with("Alice", |k, v| {
+                    assert_eq!(*k, 1);
+                    v.name.len()
+                })
                 .unwrap(),
             5
         );
@@ -1468,8 +1506,8 @@ mod test_transactional_index {
         assert_eq!(
             rows,
             vec![
-                (&"Alice".to_owned(), &row("Alice")),
-                (&"Bob".to_owned(), &row("Bob"))
+                (&"Alice".to_owned(), &1, &row("Alice")),
+                (&"Bob".to_owned(), &2, &row("Bob"))
             ]
         );
     }
@@ -1483,7 +1521,7 @@ mod test_transactional_index {
         let mut names: Vec<String> = Vec::new();
         txn.table_by::<index::Users::name>()
             .iter()
-            .for_each(|(k, _)| names.push(k.clone()));
+            .for_each(|(k, ..)| names.push(k.clone()));
         names.sort();
         assert_eq!(names, vec!["Alice".to_owned(), "Bob".to_owned()]);
     }
@@ -1538,7 +1576,7 @@ mod test_transactional_index {
         {
             let mut txn = store.begin_transaction(OWNER);
             txn.table_by::<index::Users::name>()
-                .with_mut("Alice", |v| v.name = "Bob".to_owned())
+                .with_mut("Alice", |_, v| v.name = "Bob".to_owned())
                 .unwrap();
         }
         assert_eq!(
@@ -1546,7 +1584,7 @@ mod test_transactional_index {
                 .table_by::<index::Users::name>(OWNER)
                 .get("Alice")
                 .unwrap(),
-            row("Alice")
+            (1, row("Alice"))
         );
         assert!(
             store
@@ -1570,7 +1608,7 @@ mod test_transactional_index {
                 .table_by::<index::Users::name>(OWNER)
                 .get("Alice")
                 .unwrap(),
-            row("Alice")
+            (1, row("Alice"))
         );
         assert_eq!(store.table::<Users>(OWNER).get(&1), Some(row("Alice")));
     }
@@ -1589,14 +1627,14 @@ mod test_transactional_index {
                 .table_by::<index::Users::name>(OWNER)
                 .get("Alice")
                 .unwrap(),
-            row("Alice")
+            (1, row("Alice"))
         );
         assert_eq!(
             store
                 .table_by::<index::Users::name>(OWNER)
                 .get("Bob")
                 .unwrap(),
-            row("Bob")
+            (2, row("Bob"))
         );
     }
 
@@ -1614,14 +1652,14 @@ mod test_transactional_index {
                 .table_by::<index::Users::name>(OWNER)
                 .get("Alice")
                 .unwrap(),
-            row("Alice")
+            (1, row("Alice"))
         );
         assert_eq!(
             store
                 .table_by::<index::Users::name>(OWNER)
                 .get("Bob")
                 .unwrap(),
-            row("Bob")
+            (2, row("Bob"))
         );
         assert_eq!(store.table::<Users>(OWNER).get(&1), Some(row("Alice")));
         assert_eq!(store.table::<Users>(OWNER).get(&2), Some(row("Bob")));
@@ -1669,10 +1707,10 @@ mod test_poison {
         assert!(matches!(result, Err(Error::NonUniqueIndexKey(_))));
 
         // The `panic`s ensure that the closure is not called.
-        let result = index_name.with("Alice", |_| panic!());
+        let result = index_name.with("Alice", |_, _| panic!());
         assert!(matches!(result, Err(Error::NonUniqueIndexKey(_))));
 
-        let result = index_name.with_mut("Alice", |_| panic!());
+        let result = index_name.with_mut("Alice", |_, _| panic!());
         assert!(matches!(result, Err(Error::NonUniqueIndexKey(_))));
     }
 
@@ -1743,11 +1781,11 @@ mod test_poison {
         assert!(email_index.check_consistent().is_ok());
         assert_eq!(
             email_index.get("alice1@x.com").unwrap(),
-            row("Alice", "alice1@x.com")
+            (1, row("Alice", "alice1@x.com"))
         );
         assert_eq!(
             email_index.get("alice2@x.com").unwrap(),
-            row("Alice", "alice2@x.com")
+            (2, row("Alice", "alice2@x.com"))
         );
     }
 
@@ -1855,8 +1893,11 @@ mod test_poison {
             index.check_consistent().is_ok(),
             "index should not be poisoned after the colliding txn was rolled back"
         );
-        assert_eq!(index.get("Alice").unwrap(), row("Alice", "alice1@x.com"));
-        assert_eq!(index.get("Bob").unwrap(), row("Bob", "bob@x.com"));
+        assert_eq!(
+            index.get("Alice").unwrap(),
+            (1, row("Alice", "alice1@x.com"))
+        );
+        assert_eq!(index.get("Bob").unwrap(), (3, row("Bob", "bob@x.com")));
     }
 
     #[test]
@@ -1873,7 +1914,7 @@ mod test_poison {
                 .table_by::<index::AssertingUsers::name>(OWNER)
                 .get("Alice")
                 .unwrap(),
-            row("Alice", "alice1@x.com")
+            (1, row("Alice", "alice1@x.com"))
         );
     }
 
@@ -1907,7 +1948,10 @@ mod test_poison {
         // The failed insert rolled back: the index is consistent and only the original row remains.
         let index = store.table_by::<index::Users::name>(OWNER);
         assert!(index.check_consistent().is_ok());
-        assert_eq!(index.get("Alice").unwrap(), row("Alice", "alice1@x.com"));
+        assert_eq!(
+            index.get("Alice").unwrap(),
+            (1, row("Alice", "alice1@x.com"))
+        );
         assert_eq!(
             store.table::<Users>(OWNER).get(&1),
             Some(row("Alice", "alice1@x.com"))
@@ -1929,10 +1973,13 @@ mod test_poison {
         }));
         assert!(result.is_err(), "duplicate raw insert should panic");
 
-        // The panicked mini-transaction rolled back, leaving the store consistent.
+        // The panicked insert has been rolled back, leaving the store consistent.
         let index = store.table_by::<index::Users::name>(OWNER);
         assert!(index.check_consistent().is_ok());
-        assert_eq!(index.get("Alice").unwrap(), row("Alice", "alice1@x.com"));
+        assert_eq!(
+            index.get("Alice").unwrap(),
+            (1, row("Alice", "alice1@x.com"))
+        );
         assert_eq!(store.table::<Users>(OWNER).get(&2), None);
     }
 
@@ -1943,7 +1990,6 @@ mod test_poison {
             .table_by::<index::Users::name>(OWNER)
             .insert(1, row("Alice", "alice1@x.com"));
 
-        // The raw index path is now atomic too: a duplicate is an error, not a silent poison.
         assert!(matches!(
             store
                 .table_by::<index::Users::name>(OWNER)
@@ -1953,7 +1999,10 @@ mod test_poison {
 
         let index = store.table_by::<index::Users::name>(OWNER);
         assert!(index.check_consistent().is_ok());
-        assert_eq!(index.get("Alice").unwrap(), row("Alice", "alice1@x.com"));
+        assert_eq!(
+            index.get("Alice").unwrap(),
+            (1, row("Alice", "alice1@x.com"))
+        );
     }
 
     #[test]
@@ -1981,8 +2030,11 @@ mod test_poison {
         );
         let index = store.table_by::<index::Users::name>(OWNER);
         assert!(index.check_consistent().is_ok());
-        assert_eq!(index.get("Bob").unwrap(), row("Bob", "bob@x.com"));
-        assert_eq!(index.get("Alice").unwrap(), row("Alice", "alice1@x.com"));
+        assert_eq!(index.get("Bob").unwrap(), (2, row("Bob", "bob@x.com")));
+        assert_eq!(
+            index.get("Alice").unwrap(),
+            (1, row("Alice", "alice1@x.com"))
+        );
     }
 
     #[test]
@@ -2007,7 +2059,10 @@ mod test_poison {
         );
         let index = store.table_by::<index::Users::name>(OWNER);
         assert!(index.check_consistent().is_ok());
-        assert_eq!(index.get("Alice").unwrap(), row("Alice", "alice1@x.com"));
+        assert_eq!(
+            index.get("Alice").unwrap(),
+            (1, row("Alice", "alice1@x.com"))
+        );
         assert!(index.get("Zelda").is_none());
     }
 }

--- a/ts_kv_store/src/index.rs
+++ b/ts_kv_store/src/index.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::{
-    AccessResult, KvStore, Owner, Result, RoTransaction, Transaction,
+    KvStore, Owner, Result, RoTransaction, Transaction,
     operations::{Base, BaseKey, BaseValue, IndexValue, IndexedOps, IndexedOpsMut, Ops, OpsMut},
     schema::{IndexDesc, TableDesc},
     storage::Storage,
@@ -34,18 +34,7 @@ impl<'idx, D: IndexDesc> Ops<D::Storage> for &'idx KvTableIndex<'_, D> {
     }
 }
 
-impl<'idx, D: IndexDesc> OpsMut<D::Storage> for &'idx KvTableIndex<'_, D> {
-    type WriteLock = std::sync::RwLockWriteGuard<'idx, Storage<D::Storage>>;
-
-    fn write_lock(self) -> Self::WriteLock {
-        self.store.get_write_lock()
-    }
-}
-
 impl<D: IndexDesc> IndexedOps<D::Storage> for &KvTableIndex<'_, D> {
-    type IndexDesc = D;
-}
-impl<D: IndexDesc> IndexedOpsMut<D::Storage> for &KvTableIndex<'_, D> {
     type IndexDesc = D;
 }
 
@@ -70,13 +59,17 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     where
         IndexValue<D>: Eq + Hash,
     {
-        <&Self as IndexedOpsMut<_>>::clear(self, self.owner)
+        let mut txn = self.store.begin_transaction(self.owner);
+        let mut txn_table = KvTableTransactionalIndex::<D> { txn: &mut txn };
+        IndexedOpsMut::clear(&mut txn_table, self.owner);
+        // Should never panic since transaction should only fail on index inserts.
+        txn.commit().unwrap();
     }
 
     /// Get a row of the table from the store by cloning the value.
     ///
-    /// Returns `AccessError::NotPresent` if there is no value for the specified key.
-    pub fn get<Q>(&self, key: &Q) -> AccessResult<BaseValue<D>>
+    /// Returns `Error::NotPresent` if there is no value for the specified key.
+    pub fn get<Q>(&self, key: &Q) -> Result<BaseValue<D>>
     where
         BaseValue<D>: Clone,
         D::Key: Borrow<Q>,
@@ -88,8 +81,8 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
 
     /// Get immutable access to a row of the table in the store by reference.
     ///
-    /// Returns `AccessError::NotPresent` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> AccessResult<T>
+    /// Returns `Error::NotPresent` (and does not call `f`) if there is no value for the specified key.
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> Result<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -99,18 +92,34 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     }
 
     /// Insert a value into the table using the base table's key.
+    ///
+    /// Panics if the value is already indexed with the same index key.
     pub fn insert(&self, key: BaseKey<D>, value: BaseValue<D>)
     where
         <<D as IndexDesc>::BaseTable as TableDesc>::Key: Clone,
         IndexValue<D>: Eq + Hash,
     {
-        <&Self as IndexedOpsMut<_>>::insert(self, key, value, self.owner)
+        self.try_insert(key, value).unwrap();
+    }
+
+    /// Insert a value into the table using the base table's key.
+    ///
+    /// Returns an error if `insert` would panic.
+    pub fn try_insert(&self, key: BaseKey<D>, value: BaseValue<D>) -> Result<()>
+    where
+        <<D as IndexDesc>::BaseTable as TableDesc>::Key: Clone,
+        IndexValue<D>: Eq + Hash,
+    {
+        let mut txn = self.store.begin_transaction(self.owner);
+        let mut txn_table = KvTableTransactionalIndex::<D> { txn: &mut txn };
+        IndexedOpsMut::insert(&mut txn_table, key, value, self.owner);
+        txn.commit()
     }
 
     /// Get mutable access to a row of the table in the store in the store.
     ///
-    /// Returns `AccessError::NotPresent` (and does not call `f`) if there is no value for the specified key.
-    pub fn with_mut<Q, T>(&self, key: &Q, f: impl FnOnce(&mut BaseValue<D>) -> T) -> AccessResult<T>
+    /// Returns `Error::NotPresent` (and does not call `f`) if there is no value for the specified key.
+    pub fn with_mut<Q, T>(&self, key: &Q, f: impl FnOnce(&mut BaseValue<D>) -> T) -> Result<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -118,7 +127,11 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
         BaseValue<D>: Clone,
         IndexValue<D>: Eq + Hash,
     {
-        <&Self as IndexedOpsMut<_>>::with_mut(self, key, f, self.owner)
+        let mut txn = self.store.begin_transaction(self.owner);
+        let mut txn_table = KvTableTransactionalIndex::<D> { txn: &mut txn };
+        let result = IndexedOpsMut::with_mut(&mut txn_table, key, f, self.owner);
+        txn.commit()?;
+        result
     }
 
     /// Remove a row from the table.
@@ -128,7 +141,11 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
         Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
         IndexValue<D>: Eq + Hash + ToOwned<Owned = BaseKey<D>>,
     {
-        <&Self as IndexedOpsMut<_>>::remove(self, key, self.owner)
+        let mut txn = self.store.begin_transaction(self.owner);
+        let mut txn_table = KvTableTransactionalIndex::<D> { txn: &mut txn };
+        IndexedOpsMut::remove(&mut txn_table, key, self.owner);
+        // Should never panic since transaction should only fail on index inserts.
+        txn.commit().unwrap();
     }
 
     /// Iterate all the keys in the index and value in the base table.
@@ -167,7 +184,11 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
         IndexValue<D>: Eq + Hash + Clone,
         BaseValue<D>: Clone,
     {
-        <&Self as IndexedOpsMut<_>>::for_each_mut(self, f, self.owner)
+        let mut txn = self.store.begin_transaction(self.owner);
+        let mut txn_table = KvTableTransactionalIndex::<D> { txn: &mut txn };
+        IndexedOpsMut::for_each_mut(&mut txn_table, f, self.owner);
+        // Should never panic since transaction should only fail on index inserts.
+        txn.commit().unwrap();
     }
 }
 
@@ -239,8 +260,8 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
 
     /// Get a row of the table from the store by cloning the value.
     ///
-    /// Returns `AccessError::NotPresent` if there is no value for the specified key.
-    pub fn get<Q>(&self, key: &Q) -> AccessResult<BaseValue<D>>
+    /// Returns `Error::NotPresent` if there is no value for the specified key.
+    pub fn get<Q>(&self, key: &Q) -> Result<BaseValue<D>>
     where
         BaseValue<D>: Clone,
         D::Key: Borrow<Q>,
@@ -252,8 +273,8 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
 
     /// Get immutable access to a row of the table in the store by reference.
     ///
-    /// Returns `AccessError::NotPresent` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> AccessResult<T>
+    /// Returns `Error::NotPresent` (and does not call `f`) if there is no value for the specified key.
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> Result<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -273,12 +294,8 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
 
     /// Get mutable access to a row of the table in the store in the store.
     ///
-    /// Returns `AccessError::NotPresent` (and does not call `f`) if there is no value for the specified key.
-    pub fn with_mut<Q, T>(
-        &mut self,
-        key: &Q,
-        f: impl FnOnce(&mut BaseValue<D>) -> T,
-    ) -> AccessResult<T>
+    /// Returns `Error::NotPresent` (and does not call `f`) if there is no value for the specified key.
+    pub fn with_mut<Q, T>(&mut self, key: &Q, f: impl FnOnce(&mut BaseValue<D>) -> T) -> Result<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -382,8 +399,8 @@ impl<'guard, 'txn, D: IndexDesc> KvTableRoTransactionalIndex<'guard, 'txn, D> {
 
     /// Get a row of the table from the store by cloning the value.
     ///
-    /// Returns `AccessError::NotPresent` if there is no value for the specified key.
-    pub fn get<Q>(&self, key: &Q) -> AccessResult<BaseValue<D>>
+    /// Returns `Error::NotPresent` if there is no value for the specified key.
+    pub fn get<Q>(&self, key: &Q) -> Result<BaseValue<D>>
     where
         BaseValue<D>: Clone,
         D::Key: Borrow<Q>,
@@ -395,8 +412,8 @@ impl<'guard, 'txn, D: IndexDesc> KvTableRoTransactionalIndex<'guard, 'txn, D> {
 
     /// Get immutable access to a row of the table in the store by reference.
     ///
-    /// Returns `AccessError::NotPresent` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> AccessResult<T>
+    /// Returns `Error::NotPresent` (and does not call `f`) if there is no value for the specified key.
+    pub fn with<Q, T>(&self, key: &Q, f: impl FnOnce(&BaseValue<D>) -> T) -> Result<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -434,7 +451,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableRoTransactionalIndex<'guard, 'txn, D> {
 
 #[cfg(test)]
 mod test {
-    use crate::{AccessErrorExt, tables};
+    use crate::{KvErrorExt, tables};
 
     #[derive(Clone, Debug, PartialEq)]
     pub struct Row {
@@ -874,7 +891,7 @@ mod test {
 
 #[cfg(test)]
 mod test_two_indexes {
-    use crate::{AccessErrorExt, tables};
+    use crate::{KvErrorExt, tables};
 
     #[derive(Clone, Debug, PartialEq)]
     pub struct Person {
@@ -1181,7 +1198,7 @@ mod test_two_indexes {
 
 #[cfg(test)]
 mod test_transactional_index {
-    use crate::{AccessErrorExt, tables};
+    use crate::{KvErrorExt, tables};
 
     #[derive(Clone, Debug, PartialEq)]
     pub struct Row {
@@ -1613,7 +1630,7 @@ mod test_transactional_index {
 
 #[cfg(test)]
 mod test_poison {
-    use crate::{AccessError, AccessErrorExt, Error, tables};
+    use crate::{Error, KvErrorExt, tables};
 
     #[derive(Clone, Debug, PartialEq)]
     pub struct Row {
@@ -1638,28 +1655,25 @@ mod test_poison {
     #[test]
     fn ops_return_error_when_poisoned() {
         let store = KvStore::new();
-        store
-            .table::<Users>(OWNER)
-            .insert(1, row("Alice", "alice1@x.com"));
-        store
-            .table::<Users>(OWNER)
-            .insert(2, row("Alice", "alice2@x.com"));
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Users>().insert(1, row("Alice", "alice1@x.com"));
+        txn.table::<Users>().insert(2, row("Alice", "alice2@x.com"));
 
-        let index_name = store.table_by::<index::Users::name>(OWNER);
+        let mut index_name = txn.table_by::<index::Users::name>();
         assert_eq!(
             index_name.check_consistent(),
             Err(Error::NonUniqueIndexKey("Users by name"))
         );
 
         let result = index_name.get("Alice");
-        assert!(matches!(result, Err(AccessError::NonUniqueIndexKey(_))));
+        assert!(matches!(result, Err(Error::NonUniqueIndexKey(_))));
 
         // The `panic`s ensure that the closure is not called.
         let result = index_name.with("Alice", |_| panic!());
-        assert!(matches!(result, Err(AccessError::NonUniqueIndexKey(_))));
+        assert!(matches!(result, Err(Error::NonUniqueIndexKey(_))));
 
         let result = index_name.with_mut("Alice", |_| panic!());
-        assert!(matches!(result, Err(AccessError::NonUniqueIndexKey(_))));
+        assert!(matches!(result, Err(Error::NonUniqueIndexKey(_))));
     }
 
     #[test]
@@ -1679,7 +1693,8 @@ mod test_poison {
     #[test]
     fn poisoned_via_index_insert() {
         let store = KvStore::new();
-        let index = store.table_by::<index::Users::name>(OWNER);
+        let mut txn = store.begin_transaction(OWNER);
+        let mut index = txn.table_by::<index::Users::name>();
         index.insert(1, row("Alice", "alice1@x.com"));
         index.insert(2, row("Alice", "alice2@x.com"));
 
@@ -1689,27 +1704,24 @@ mod test_poison {
         ));
         assert!(matches!(
             index.get("Alice"),
-            Err(AccessError::NonUniqueIndexKey(_))
+            Err(Error::NonUniqueIndexKey(_))
         ));
     }
 
     #[test]
     fn base_table_unaffected_when_index_poisoned() {
         let store = KvStore::new();
-        store
-            .table::<Users>(OWNER)
-            .insert(1, row("Alice", "alice1@x.com"));
-        store
-            .table::<Users>(OWNER)
-            .insert(2, row("Alice", "alice2@x.com"));
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Users>().insert(1, row("Alice", "alice1@x.com"));
+        txn.table::<Users>().insert(2, row("Alice", "alice2@x.com"));
 
         // The `name` index is poisoned, but the base table can still be read by primary key.
         assert_eq!(
-            store.table::<Users>(OWNER).get(&1),
+            txn.table::<Users>().get(&1),
             Some(row("Alice", "alice1@x.com"))
         );
         assert_eq!(
-            store.table::<Users>(OWNER).get(&2),
+            txn.table::<Users>().get(&2),
             Some(row("Alice", "alice2@x.com"))
         );
     }
@@ -1717,22 +1729,17 @@ mod test_poison {
     #[test]
     fn sibling_index_not_poisoned() {
         let store = KvStore::new();
-        store
-            .table::<Users>(OWNER)
-            .insert(1, row("Alice", "alice1@x.com"));
-        store
-            .table::<Users>(OWNER)
-            .insert(2, row("Alice", "alice2@x.com"));
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Users>().insert(1, row("Alice", "alice1@x.com"));
+        txn.table::<Users>().insert(2, row("Alice", "alice2@x.com"));
 
         // `name` is poisoned (both "Alice")...
         assert!(matches!(
-            store
-                .table_by::<index::Users::name>(OWNER)
-                .check_consistent(),
+            txn.table_by::<index::Users::name>().check_consistent(),
             Err(Error::NonUniqueIndexKey(_))
         ));
         // ...but `email` has distinct keys and stays consistent.
-        let email_index = store.table_by::<index::Users::email>(OWNER);
+        let email_index = txn.table_by::<index::Users::email>();
         assert!(email_index.check_consistent().is_ok());
         assert_eq!(
             email_index.get("alice1@x.com").unwrap(),
@@ -1747,14 +1754,11 @@ mod test_poison {
     #[test]
     fn clear_unpoisons() {
         let store = KvStore::new();
-        store
-            .table::<Users>(OWNER)
-            .insert(1, row("Alice", "alice1@x.com"));
-        store
-            .table::<Users>(OWNER)
-            .insert(2, row("Alice", "alice2@x.com"));
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Users>().insert(1, row("Alice", "alice1@x.com"));
+        txn.table::<Users>().insert(2, row("Alice", "alice2@x.com"));
 
-        let index = store.table_by::<index::Users::name>(OWNER);
+        let mut index = txn.table_by::<index::Users::name>();
         assert!(index.check_consistent().is_err());
 
         index.clear();
@@ -1771,7 +1775,7 @@ mod test_poison {
 
         assert!(matches!(
             txn.table_by::<index::Users::name>().get("Alice"),
-            Err(AccessError::NonUniqueIndexKey(_))
+            Err(Error::NonUniqueIndexKey(_))
         ));
     }
 
@@ -1883,5 +1887,127 @@ mod test_poison {
         store
             .table::<AssertingUsers>(OWNER)
             .insert(2, row("Alice", "alice2@x.com"));
+    }
+
+    #[test]
+    fn raw_base_try_insert_duplicate_errors_and_rolls_back() {
+        let store = KvStore::new();
+        store
+            .table::<Users>(OWNER)
+            .insert(1, row("Alice", "alice1@x.com"));
+
+        // The duplicate "Alice" name-index key makes the insert fail.
+        assert!(matches!(
+            store
+                .table::<Users>(OWNER)
+                .try_insert(2, row("Alice", "alice2@x.com")),
+            Err(Error::NonUniqueIndexKey(_))
+        ));
+
+        // The failed insert rolled back: the index is consistent and only the original row remains.
+        let index = store.table_by::<index::Users::name>(OWNER);
+        assert!(index.check_consistent().is_ok());
+        assert_eq!(index.get("Alice").unwrap(), row("Alice", "alice1@x.com"));
+        assert_eq!(
+            store.table::<Users>(OWNER).get(&1),
+            Some(row("Alice", "alice1@x.com"))
+        );
+        assert_eq!(store.table::<Users>(OWNER).get(&2), None);
+    }
+
+    #[test]
+    fn raw_base_insert_duplicate_panics_and_rolls_back() {
+        let store = KvStore::new();
+        store
+            .table::<Users>(OWNER)
+            .insert(1, row("Alice", "alice1@x.com"));
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            store
+                .table::<Users>(OWNER)
+                .insert(2, row("Alice", "alice2@x.com"));
+        }));
+        assert!(result.is_err(), "duplicate raw insert should panic");
+
+        // The panicked mini-transaction rolled back, leaving the store consistent.
+        let index = store.table_by::<index::Users::name>(OWNER);
+        assert!(index.check_consistent().is_ok());
+        assert_eq!(index.get("Alice").unwrap(), row("Alice", "alice1@x.com"));
+        assert_eq!(store.table::<Users>(OWNER).get(&2), None);
+    }
+
+    #[test]
+    fn raw_index_try_insert_duplicate_errors_and_rolls_back() {
+        let store = KvStore::new();
+        store
+            .table_by::<index::Users::name>(OWNER)
+            .insert(1, row("Alice", "alice1@x.com"));
+
+        // The raw index path is now atomic too: a duplicate is an error, not a silent poison.
+        assert!(matches!(
+            store
+                .table_by::<index::Users::name>(OWNER)
+                .try_insert(2, row("Alice", "alice2@x.com")),
+            Err(Error::NonUniqueIndexKey(_))
+        ));
+
+        let index = store.table_by::<index::Users::name>(OWNER);
+        assert!(index.check_consistent().is_ok());
+        assert_eq!(index.get("Alice").unwrap(), row("Alice", "alice1@x.com"));
+    }
+
+    #[test]
+    fn raw_with_mut_collision_returns_error_and_rolls_back() {
+        let store = KvStore::new();
+        store
+            .table::<Users>(OWNER)
+            .insert(1, row("Alice", "alice1@x.com"));
+        store
+            .table::<Users>(OWNER)
+            .insert(2, row("Bob", "bob@x.com"));
+
+        // Renaming Bob to "Alice" collides on the `name` index, so the mini-transaction fails.
+        assert!(matches!(
+            store
+                .table::<Users>(OWNER)
+                .with_mut(&2, |r| r.name = "Alice".to_owned()),
+            Err(Error::NonUniqueIndexKey(_))
+        ));
+
+        // Rolled back: Bob is unchanged and the index is consistent.
+        assert_eq!(
+            store.table::<Users>(OWNER).get(&2),
+            Some(row("Bob", "bob@x.com"))
+        );
+        let index = store.table_by::<index::Users::name>(OWNER);
+        assert!(index.check_consistent().is_ok());
+        assert_eq!(index.get("Bob").unwrap(), row("Bob", "bob@x.com"));
+        assert_eq!(index.get("Alice").unwrap(), row("Alice", "alice1@x.com"));
+    }
+
+    #[test]
+    fn raw_with_mut_panic_rolls_back() {
+        let store = KvStore::new();
+        store
+            .table::<Users>(OWNER)
+            .insert(1, row("Alice", "alice1@x.com"));
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = store.table::<Users>(OWNER).with_mut(&1, |r| {
+                r.name = "Zelda".to_owned();
+                panic!("boom");
+            });
+        }));
+        assert!(result.is_err(), "panicking closure should propagate");
+
+        // The mutation (and its index update) rolled back; "Alice" is intact and queryable.
+        assert_eq!(
+            store.table::<Users>(OWNER).get(&1),
+            Some(row("Alice", "alice1@x.com"))
+        );
+        let index = store.table_by::<index::Users::name>(OWNER);
+        assert!(index.check_consistent().is_ok());
+        assert_eq!(index.get("Alice").unwrap(), row("Alice", "alice1@x.com"));
+        assert!(index.get("Zelda").is_none());
     }
 }

--- a/ts_kv_store/src/iter.rs
+++ b/ts_kv_store/src/iter.rs
@@ -144,14 +144,19 @@ impl<'guard, Guard: StorageGuard<D::Storage>, D: IndexDesc> Iterator
 where
     D::Value: Hash + Eq,
 {
-    type Item = (&'guard D::Key, &'guard <D::BaseTable as TableDesc>::Value);
+    type Item = (
+        &'guard D::Key,
+        &'guard <D::BaseTable as TableDesc>::Key,
+        &'guard <D::BaseTable as TableDesc>::Value,
+    );
 
     fn next(&mut self) -> Option<Self::Item> {
         // Iterate by delegating to the `HashMap` iterator.
         let (base, iter) = self.inner.as_mut().unwrap();
         let (k, bk) = iter.next()?;
+        let value = base.get(bk, self.guard.storage().txn_id())?;
 
-        Some((k, base.get(bk, self.guard.storage().txn_id())?))
+        Some((k, bk, value))
     }
 }
 
@@ -170,14 +175,18 @@ impl<'guard, Guard: StorageGuard<D::Storage>, D: IndexDesc> Iterator
 where
     D::Value: Hash + Eq,
 {
-    type Item = &'guard <D::BaseTable as TableDesc>::Value;
+    type Item = (
+        &'guard <D::BaseTable as TableDesc>::Key,
+        &'guard <D::BaseTable as TableDesc>::Value,
+    );
 
     fn next(&mut self) -> Option<Self::Item> {
         // Iterate by delegating to the `HashMap` iterator.
         let (base, iter) = self.inner.as_mut().unwrap();
         let (_, bk) = iter.next()?;
+        let value = base.get(bk, self.guard.storage().txn_id())?;
 
-        base.get(bk, self.guard.storage().txn_id())
+        Some((bk, value))
     }
 }
 

--- a/ts_kv_store/src/lib.rs
+++ b/ts_kv_store/src/lib.rs
@@ -5,10 +5,12 @@
 //! # Example:
 //!
 //! ```rust
-//! # use ts_kv_store::{Owner, singleton, tables};
+//! # use ts_kv_store::{Owner, store};
 //! # const OWNER: Owner = "owner";
-//! singleton!(foo(u64; OWNER));
-//! tables!(Nodes(u32 => String; OWNER));
+//! store!(
+//!     kvs: { foo(u64; OWNER) }
+//!     tables: { Nodes(u32 => String; OWNER) }
+//! );
 //!
 //! pub fn main() {
 //!     let store = KvStore::new();

--- a/ts_kv_store/src/lib.rs
+++ b/ts_kv_store/src/lib.rs
@@ -7,8 +7,8 @@
 //! ```rust
 //! # use ts_kv_store::{Owner, singleton, tables};
 //! # const OWNER: Owner = "owner";
-//! singleton!(foo(u64));
-//! tables!(Nodes(u32 => String));
+//! singleton!(foo(u64; OWNER));
+//! tables!(Nodes(u32 => String; OWNER));
 //!
 //! pub fn main() {
 //!     let store = KvStore::new();
@@ -69,7 +69,7 @@
 //!
 //! For example, consider a table `Base` which maps `u64` keys to `Foo` values where `Foo` has a
 //! field `bar: Url` (and `bar` is a unique identifier for a `Foo` in `Base`). The schema would look
-//! like `tables!(Base(u64 => Foo; index(bar: Url)));` which will create a `Base` table and an
+//! like `tables!(Base(u64 => Foo; OWNER; index(bar: Url)));` which will create a `Base` table and an
 //! `index::Base::bar` table. By using `store.table_by::<index::Base::bar>(...)` the `Base` table
 //! can be accessed as if it were a table mapping `Url`s to `Foo`s. The index is maintained whenever
 //! `Base` is modified (directly or via any index) by using the `bar` field of the values in `Base`.
@@ -248,9 +248,6 @@ pub type Owner = &'static str;
 /// An error from a [`KvStore`].
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
 pub enum Error {
-    /// A table was expected to not be initialized, but was by the specified `Owner`.
-    #[error("A table has already been initialized with owner `{0}`")]
-    AlreadyInit(Owner),
     /// An inconsistency caused a transaction to fail. It has not been committed and can be re-tried.
     #[error("Transaction Failed")]
     TransactionFailed,

--- a/ts_kv_store/src/lib.rs
+++ b/ts_kv_store/src/lib.rs
@@ -183,6 +183,11 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
         KvStore { storage }
     }
 
+    /// A convenience for operating on a KV store with a specified owner.
+    pub fn with_owner(&self, owner: Owner) -> StoreWithOwner<'_, TableStorage> {
+        StoreWithOwner { store: self, owner }
+    }
+
     /// Might (theoretically) panic, see the note on [`clear_lock_poison`].
     fn get_read_lock(&self) -> RwLockReadGuard<'_, storage::Storage<TableStorage>> {
         self.clear_lock_poison();
@@ -220,6 +225,15 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
             lock.clear_transaction();
         }
     }
+}
+
+/// A reference to a store for a specified owner.
+///
+/// A convenience wrapper to avoid specifying an owner on every operation.
+#[derive(Clone)]
+pub struct StoreWithOwner<'a, TableStorage: schema::GeneratedStorage> {
+    store: &'a KvStore<TableStorage>,
+    owner: Owner,
 }
 
 /// A token indicating ownership of a KV singleton or table. See crate docs for what ownership means

--- a/ts_kv_store/src/lib.rs
+++ b/ts_kv_store/src/lib.rs
@@ -107,10 +107,10 @@
 //! for documentation.
 //!
 //! The implementation of storage for tabular data is one HashMap per table, and otherwise
-//! straightforward. For singleton data, we use a single HashMap which maps `TypeId` to `(Owner, SinValue)`.
-//! Where the `TypeId` id the id of the type used to describe the singleton. Values can be
-//! stored in different ways (inline, via an `Arc`, etc.) each of which is a variant of `SinValue`.
-//! The store transparently converts keys and values to their declared types.
+//! straightforward. For singleton data, we store values (as a `SinValue`) in fields with the name
+//! of the singleton. Values can be stored in different ways (inline, via an `Arc`, etc.) each of
+//! which is a variant of `SinValue`. The store transparently converts keys and values to their
+//! declared types.
 //!
 //! The implementation of the storage operations (`get`, `insert`, etc.) is somewhat shared between
 //! the various types which support them (`KvStore`, the table types, the transaction types, index

--- a/ts_kv_store/src/lib.rs
+++ b/ts_kv_store/src/lib.rs
@@ -1,6 +1,6 @@
 //! # ts-kvstore
 //!
-//! An in-memory, async, concurrent, and strongly-typed KV store for the Rust Tailscale client.
+//! An in-memory, async, concurrent, ACID, and strongly-typed KV store for the Rust Tailscale client.
 //!
 //! # Example:
 //!
@@ -119,8 +119,9 @@
 //! Transactions have an internal id (`TxnId`). Since we use a global lock to ensure serializability,
 //! transactions are only used to ensure atomicity. There can only ever be one (mutating) transaction
 //! in progress at a time. The store tracks the most recently committed transaction id, and optionally
-//! a current transaction id. Raw (non-transactional) operations use the most recently committed
-//! transaction id as their 'transaction' id (but there is no separate commit step for these operations).
+//! a current transaction id. Raw (non-transactional) writes are 'mini-transactions' of just a single
+//! operation. That means even raw operations consisting of multiple sub-operations are atomic. Raw
+//! reads use the most recently committed transaction id as their 'transaction' id.
 //!
 //! The KV store uses a simplified version of MVCC to implement transactions. Only two versions are
 //! required for each key, one will be the currently committed version and one will either be empty,
@@ -221,26 +222,6 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     }
 }
 
-impl<'store, TableStorage: schema::GeneratedStorage> operations::Ops<TableStorage>
-    for &'store KvStore<TableStorage>
-{
-    type ReadLock = RwLockReadGuard<'store, storage::Storage<TableStorage>>;
-
-    fn read_lock(self) -> Self::ReadLock {
-        self.get_read_lock()
-    }
-}
-
-impl<'store, TableStorage: schema::GeneratedStorage> operations::OpsMut<TableStorage>
-    for &'store KvStore<TableStorage>
-{
-    type WriteLock = RwLockWriteGuard<'store, storage::Storage<TableStorage>>;
-
-    fn write_lock(self) -> Self::WriteLock {
-        self.get_write_lock()
-    }
-}
-
 /// A token indicating ownership of a KV singleton or table. See crate docs for what ownership means
 /// for a store.
 pub type Owner = &'static str;
@@ -248,6 +229,9 @@ pub type Owner = &'static str;
 /// An error from a [`KvStore`].
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
 pub enum Error {
+    /// The requested key is not present in the store.
+    #[error("Key not found")]
+    NotPresent,
     /// An inconsistency caused a transaction to fail. It has not been committed and can be re-tried.
     #[error("Transaction Failed")]
     TransactionFailed,
@@ -257,61 +241,46 @@ pub enum Error {
     NonUniqueIndexKey(&'static str),
 }
 
-/// An error occuring during accessing of the store.
-#[derive(thiserror::Error, Debug, Clone, PartialEq)]
-pub enum AccessError {
-    /// The requested key is not present in the store.
-    #[error("Key not found")]
-    NotPresent,
-    /// An index had multiple primary keys for a single index key. If returned when committing a
-    /// transaction, the transaction will not have been committed.
-    #[error("An attempt to store a non-unique index key in `{0}`")]
-    NonUniqueIndexKey(&'static str),
-}
-
 /// `Result` alias for a KvStore [`Error`].
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// `Result` alias for a KvStore [`AccessError`].
-pub type AccessResult<T> = std::result::Result<T, AccessError>;
-
-/// Helper trait for making it easier for [`AccessError`] and `Option` to interoperate.
+/// Helper trait for making it easier for [`Error`] and `Option` to interoperate.
 ///
-/// The key observation is that `Result<T, AccessError>` is logically equivalent to `Result<Option<T>, Error>`
-/// (well a 'subtype' of sorts). This trait allows treating `Result<T, AccessError>` a bit more like
-/// an `Option` in various ways so that using functions which return `Result<T, AccessError>` can be
+/// `Err(Error::NotPresent)` for `Result<T, Error>`has the same meaning as `None` for `Option<T>`
+/// for most map operations. This trait allows treating `Result<T, Error>` a bit more like
+/// an `Option` in various ways so that using functions which return `Result<T, Error>` can be
 /// more ergonomic. (Annoyingly we can't implement helpers directly on `Result` or make conversion
 /// via `From` work).
-pub trait AccessErrorExt<T> {
-    /// Convert a `Result<T, AccessError>` into `Result<Option<T>, Error>`.
+pub trait KvErrorExt<T> {
+    /// Convert a `Result<T, Error>` into `Result<Option<T>, Error>`.
     fn try_opt(self) -> Result<Option<T>>;
-    /// Convert a `Result<T, AccessError>` into `Option<T>`, panicking if the `AccessError` is anything
+    /// Convert a `Result<T, Error>` into `Option<T>`, panicking if the `Error` is anything
     /// other than `NotPresent`.
     fn unwrap_opt(self) -> Option<T>;
-    /// Convert a `&Result<T, AccessError>` into `&Option<T>`, panicking if the `AccessError` is anything
+    /// Convert a `&Result<T, Error>` into `Option<&T>`, panicking if the `Error` is anything
     /// other than `NotPresent`.
     fn unwrap_opt_ref(&self) -> Option<&T>;
     /// True if self is `Ok`, i.e., there was no error and the requested key was present.
     fn is_some(&self) -> bool;
-    /// True if self is `Err(AccessError::NotPresent)`, i.e., there was no error and the requested
+    /// True if self is `Err(Error::NotPresent)`, i.e., there was no other error and the requested
     /// key was not present.
     fn is_none(&self) -> bool;
 }
 
-impl<T> AccessErrorExt<T> for AccessResult<T> {
+impl<T> KvErrorExt<T> for Result<T> {
     fn try_opt(self) -> Result<Option<T>> {
         match self {
             Ok(t) => Ok(Some(t)),
-            Err(AccessError::NotPresent) => Ok(None),
-            Err(AccessError::NonUniqueIndexKey(t)) => Err(Error::NonUniqueIndexKey(t)),
+            Err(Error::NotPresent) => Ok(None),
+            Err(e) => Err(e),
         }
     }
 
     fn unwrap_opt(self) -> Option<T> {
         match self {
             Ok(t) => Some(t),
-            Err(AccessError::NotPresent) => None,
-            Err(e @ AccessError::NonUniqueIndexKey(_)) => {
+            Err(Error::NotPresent) => None,
+            Err(e) => {
                 panic!("Expected `Ok` or not present, found: {e}")
             }
         }
@@ -320,8 +289,8 @@ impl<T> AccessErrorExt<T> for AccessResult<T> {
     fn unwrap_opt_ref(&self) -> Option<&T> {
         match self {
             Ok(t) => Some(t),
-            Err(AccessError::NotPresent) => None,
-            Err(e @ AccessError::NonUniqueIndexKey(_)) => {
+            Err(Error::NotPresent) => None,
+            Err(e) => {
                 panic!("Expected `Ok` or not present, found: {e}")
             }
         }
@@ -332,6 +301,6 @@ impl<T> AccessErrorExt<T> for AccessResult<T> {
     }
 
     fn is_none(&self) -> bool {
-        matches!(self, Err(AccessError::NotPresent))
+        matches!(self, Err(Error::NotPresent))
     }
 }

--- a/ts_kv_store/src/operations.rs
+++ b/ts_kv_store/src/operations.rs
@@ -240,11 +240,17 @@ pub(crate) trait IndexedOps<TableStorage: schema::GeneratedStorage>:
         }
     }
 
-    fn get<Q>(self, key: &Q, _owner: Owner) -> Result<BaseValue<Self::IndexDesc>>
+    #[allow(clippy::type_complexity)]
+    fn get<Q>(
+        self,
+        key: &Q,
+        _owner: Owner,
+    ) -> Result<(BaseKey<Self::IndexDesc>, BaseValue<Self::IndexDesc>)>
     where
+        BaseKey<Self::IndexDesc>: Clone,
+        BaseValue<Self::IndexDesc>: Clone,
         IndexKey<Self::IndexDesc>: Borrow<Q>,
         IndexValue<Self::IndexDesc>: Hash + Eq,
-        BaseValue<Self::IndexDesc>: Clone,
         Q: ?Sized + Hash + Eq,
     {
         let storage = self.read_lock();
@@ -257,15 +263,17 @@ pub(crate) trait IndexedOps<TableStorage: schema::GeneratedStorage>:
             ));
         }
         let base_key = index.get(key, storage.txn_id()).ok_or(Error::NotPresent)?;
-        base.get(base_key, storage.txn_id())
+        let value = base
+            .get(base_key, storage.txn_id())
             .cloned()
-            .ok_or(Error::NotPresent)
+            .ok_or(Error::NotPresent)?;
+        Ok((base_key.clone(), value))
     }
 
     fn with<Q, T>(
         self,
         key: &Q,
-        f: impl FnOnce(&BaseValue<Self::IndexDesc>) -> T,
+        f: impl FnOnce(&BaseKey<Self::IndexDesc>, &BaseValue<Self::IndexDesc>) -> T,
         _owner: Owner,
     ) -> Result<T>
     where
@@ -287,15 +295,17 @@ pub(crate) trait IndexedOps<TableStorage: schema::GeneratedStorage>:
             .get(base_key, storage.txn_id())
             .ok_or(Error::NotPresent)?;
 
-        Ok(f(value))
+        Ok(f(base_key, value))
     }
 
+    #[allow(clippy::type_complexity)]
     fn iter<'guard>(
         self,
         _owner: Owner,
     ) -> impl Iterator<
         Item = (
             &'guard IndexKey<Self::IndexDesc>,
+            &'guard BaseKey<Self::IndexDesc>,
             &'guard BaseValue<Self::IndexDesc>,
         ),
     >
@@ -322,7 +332,12 @@ pub(crate) trait IndexedOps<TableStorage: schema::GeneratedStorage>:
     fn values<'guard>(
         self,
         _owner: Owner,
-    ) -> impl Iterator<Item = &'guard BaseValue<Self::IndexDesc>>
+    ) -> impl Iterator<
+        Item = (
+            &'guard BaseKey<Self::IndexDesc>,
+            &'guard BaseValue<Self::IndexDesc>,
+        ),
+    >
     where
         Self::ReadLock: 'guard,
         Self::IndexDesc: 'guard,
@@ -489,7 +504,7 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
     fn with_mut<Q, T>(
         self,
         key: &Q,
-        f: impl FnOnce(&mut BaseValue<Self::IndexDesc>) -> T,
+        f: impl FnOnce(&BaseKey<Self::IndexDesc>, &mut BaseValue<Self::IndexDesc>) -> T,
         owner: Owner,
     ) -> Result<T>
     where
@@ -514,7 +529,7 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
         base.assert_owner(owner);
 
         let base_key = index.get(key, txn_id).ok_or(Error::NotPresent)?;
-        base.with_mut(base_key, f, txn_id, max_committed_id)
+        base.with_mut(base_key, |v| f(base_key, v), txn_id, max_committed_id)
             .ok_or(Error::NotPresent)
     }
 
@@ -543,7 +558,7 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
 
     fn for_each_mut(
         self,
-        mut f: impl FnMut(&IndexKey<Self::IndexDesc>, &mut BaseValue<Self::IndexDesc>),
+        mut f: impl FnMut(&BaseKey<Self::IndexDesc>, &mut BaseValue<Self::IndexDesc>),
         owner: Owner,
     ) where
         IndexValue<Self::IndexDesc>: Hash + Eq,
@@ -560,11 +575,11 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
         );
         base.assert_owner(owner);
 
-        for (k, base_key) in index.iter(txn_id) {
+        for (_, base_key) in index.iter(txn_id) {
             base.with_mut(
                 base_key,
                 |value| {
-                    f(k, value);
+                    f(base_key, value);
                 },
                 txn_id,
                 max_committed_id,

--- a/ts_kv_store/src/operations.rs
+++ b/ts_kv_store/src/operations.rs
@@ -9,7 +9,6 @@
 #![allow(clippy::wrong_self_convention)]
 
 use std::{
-    any::TypeId,
     borrow::Borrow,
     hash::Hash,
     sync::{Arc, RwLockReadGuard, RwLockWriteGuard},
@@ -78,35 +77,35 @@ impl<'a, 'inner, TableStorage: schema::GeneratedStorage> StorageGuardMut<TableSt
 pub(crate) trait SingletonOps<TableStorage: schema::GeneratedStorage>:
     Ops<TableStorage>
 {
-    fn get<D: schema::Singleton>(self, _owner: Owner) -> Option<D::Value>
+    fn get<D: schema::Singleton<Storage = TableStorage>>(self, _owner: Owner) -> Option<D::Value>
     where
         D::Value: Clone,
     {
         let storage = self.read_lock();
         let storage = storage.storage();
-        let key = TypeId::of::<D>();
         let txn_id = storage.txn_id();
-        storage.get_singleton_value::<D>(key, txn_id).cloned()
+        storage.get_singleton_value::<D>(txn_id).cloned()
     }
 
-    fn get_arc<D: schema::ArcSingleton>(self, _owner: Owner) -> Option<Arc<D::Value>> {
+    fn get_arc<D: schema::ArcSingleton<Storage = TableStorage>>(
+        self,
+        _owner: Owner,
+    ) -> Option<Arc<D::Value>> {
         let storage = self.read_lock();
         let storage = storage.storage();
-        let key = TypeId::of::<D>();
         let txn_id = storage.txn_id();
-        storage.get_singleton_arc::<D>(key, txn_id)
+        storage.get_singleton_arc::<D>(txn_id)
     }
 
-    fn with<D: schema::Singleton, T>(
+    fn with<D: schema::Singleton<Storage = TableStorage>, T>(
         self,
         f: impl FnOnce(&D::Value) -> T,
         _owner: Owner,
     ) -> Option<T> {
         let storage = self.read_lock();
         let storage = storage.storage();
-        let key = TypeId::of::<D>();
         let txn_id = storage.txn_id();
-        let value = storage.get_singleton_value::<D>(key, txn_id)?;
+        let value = storage.get_singleton_value::<D>(txn_id)?;
         Some(f(value))
     }
 }
@@ -359,24 +358,26 @@ pub(crate) trait OpsMut<TableStorage: schema::GeneratedStorage>: Sized {
 pub(crate) trait SingletonOpsMut<TableStorage: schema::GeneratedStorage>:
     OpsMut<TableStorage>
 {
-    fn insert<D: schema::Singleton>(self, value: D::ArgValue, owner: Owner) {
+    fn insert<D: schema::Singleton<Storage = TableStorage>>(
+        self,
+        value: D::ArgValue,
+        owner: Owner,
+    ) {
         let mut storage = self.write_lock();
         let storage = storage.storage();
         assert_owner::<D>(owner);
-        let key = TypeId::of::<D>();
 
         let txn_id = storage.txn_id();
-        storage.insert_singleton::<D>(key, value, txn_id);
+        storage.insert_singleton::<D>(value, txn_id);
     }
 
-    fn remove<D: schema::Singleton>(self, owner: Owner) {
+    fn remove<D: schema::Singleton<Storage = TableStorage>>(self, owner: Owner) {
         let mut storage = self.write_lock();
         let storage = storage.storage();
-        let key = TypeId::of::<D>();
         assert_owner::<D>(owner);
 
         let txn_id = storage.txn_id();
-        storage.remove_singleton(key, txn_id);
+        storage.remove_singleton::<D>(txn_id);
     }
 }
 

--- a/ts_kv_store/src/operations.rs
+++ b/ts_kv_store/src/operations.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use crate::{
-    AccessError, AccessResult, IndexIterator, Owner, Result, TableIterator, iter,
+    Error, IndexIterator, Owner, Result, TableIterator, iter,
     schema::{self, IndexDesc, TableDesc},
     storage::Storage,
 };
@@ -240,7 +240,7 @@ pub(crate) trait IndexedOps<TableStorage: schema::GeneratedStorage>:
         }
     }
 
-    fn get<Q>(self, key: &Q, _owner: Owner) -> AccessResult<BaseValue<Self::IndexDesc>>
+    fn get<Q>(self, key: &Q, _owner: Owner) -> Result<BaseValue<Self::IndexDesc>>
     where
         IndexKey<Self::IndexDesc>: Borrow<Q>,
         IndexValue<Self::IndexDesc>: Hash + Eq,
@@ -252,16 +252,14 @@ pub(crate) trait IndexedOps<TableStorage: schema::GeneratedStorage>:
         let base = Base::<Self::IndexDesc>::get_table(&storage.tables);
         let index = <Self::IndexDesc as TableDesc>::get_table(&storage.tables);
         if index.is_poisoned(storage.txn_id()) {
-            return Err(AccessError::NonUniqueIndexKey(
+            return Err(Error::NonUniqueIndexKey(
                 <Self::IndexDesc as TableDesc>::NAME,
             ));
         }
-        let base_key = index
-            .get(key, storage.txn_id())
-            .ok_or(AccessError::NotPresent)?;
+        let base_key = index.get(key, storage.txn_id()).ok_or(Error::NotPresent)?;
         base.get(base_key, storage.txn_id())
             .cloned()
-            .ok_or(AccessError::NotPresent)
+            .ok_or(Error::NotPresent)
     }
 
     fn with<Q, T>(
@@ -269,7 +267,7 @@ pub(crate) trait IndexedOps<TableStorage: schema::GeneratedStorage>:
         key: &Q,
         f: impl FnOnce(&BaseValue<Self::IndexDesc>) -> T,
         _owner: Owner,
-    ) -> AccessResult<T>
+    ) -> Result<T>
     where
         IndexKey<Self::IndexDesc>: Borrow<Q>,
         IndexValue<Self::IndexDesc>: Hash + Eq,
@@ -280,16 +278,14 @@ pub(crate) trait IndexedOps<TableStorage: schema::GeneratedStorage>:
         let base = Base::<Self::IndexDesc>::get_table(&storage.tables);
         let index = <Self::IndexDesc>::get_table(&storage.tables);
         if index.is_poisoned(storage.txn_id()) {
-            return Err(AccessError::NonUniqueIndexKey(
+            return Err(Error::NonUniqueIndexKey(
                 <Self::IndexDesc as TableDesc>::NAME,
             ));
         }
-        let base_key = index
-            .get(key, storage.txn_id())
-            .ok_or(AccessError::NotPresent)?;
+        let base_key = index.get(key, storage.txn_id()).ok_or(Error::NotPresent)?;
         let value = base
             .get(base_key, storage.txn_id())
-            .ok_or(AccessError::NotPresent)?;
+            .ok_or(Error::NotPresent)?;
 
         Ok(f(value))
     }
@@ -403,7 +399,6 @@ pub(crate) trait TabularOpsMut<TableStorage: schema::GeneratedStorage>:
         table.insert(key, value, txn_id, max_committed_id);
     }
 
-    // TODO if `f` panics then the indexes will be left in an inconsistent state.
     fn with_mut<Q, T>(
         self,
         key: &Q,
@@ -439,7 +434,6 @@ pub(crate) trait TabularOpsMut<TableStorage: schema::GeneratedStorage>:
         table.remove(key, txn_id, max_committed_id);
     }
 
-    // TODO if `f` panics then the indexes will be left in an inconsistent state.
     fn for_each_mut(
         self,
         f: impl FnMut(&<Self::TableDesc as TableDesc>::Key, &mut <Self::TableDesc as TableDesc>::Value),
@@ -492,13 +486,12 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
         base.insert(key, value, txn_id, max_committed_id);
     }
 
-    // TODO if `f` panics then the indexes will be left in an inconsistent state.
     fn with_mut<Q, T>(
         self,
         key: &Q,
         f: impl FnOnce(&mut BaseValue<Self::IndexDesc>) -> T,
         owner: Owner,
-    ) -> AccessResult<T>
+    ) -> Result<T>
     where
         IndexKey<Self::IndexDesc>: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -514,15 +507,15 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
             &mut storage.tables,
         );
         if index.is_poisoned(txn_id) {
-            return Err(AccessError::NonUniqueIndexKey(
+            return Err(Error::NonUniqueIndexKey(
                 <Self::IndexDesc as TableDesc>::NAME,
             ));
         }
         base.assert_owner(owner);
 
-        let base_key = index.get(key, txn_id).ok_or(AccessError::NotPresent)?;
+        let base_key = index.get(key, txn_id).ok_or(Error::NotPresent)?;
         base.with_mut(base_key, f, txn_id, max_committed_id)
-            .ok_or(AccessError::NotPresent)
+            .ok_or(Error::NotPresent)
     }
 
     fn remove<Q>(self, key: &Q, owner: Owner)
@@ -539,7 +532,6 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
         let (base, index) = schema::get_two_tables_mut::<_, Base<Self::IndexDesc>, Self::IndexDesc>(
             &mut storage.tables,
         );
-        // First check ownership, then do the operation.
         base.assert_owner(owner);
 
         let Some(base_key) = index.get(key, txn_id) else {
@@ -549,7 +541,6 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
         index.remove(key, txn_id, max_committed_id);
     }
 
-    // TODO if `f` panics then the indexes will be left in an inconsistent state.
     fn for_each_mut(
         self,
         mut f: impl FnMut(&IndexKey<Self::IndexDesc>, &mut BaseValue<Self::IndexDesc>),

--- a/ts_kv_store/src/operations.rs
+++ b/ts_kv_store/src/operations.rs
@@ -351,18 +351,18 @@ pub(crate) trait SingletonOpsMut<TableStorage: schema::GeneratedStorage>:
     fn insert<D: schema::Singleton>(self, value: D::ArgValue, owner: Owner) {
         let mut storage = self.write_lock();
         let storage = storage.storage();
+        assert_owner::<D>(owner);
         let key = TypeId::of::<D>();
-        assert_owner(owner, key, storage);
 
         let txn_id = storage.txn_id();
-        storage.insert_singleton::<D>(key, owner, value, txn_id);
+        storage.insert_singleton::<D>(key, value, txn_id);
     }
 
     fn remove<D: schema::Singleton>(self, owner: Owner) {
         let mut storage = self.write_lock();
         let storage = storage.storage();
         let key = TypeId::of::<D>();
-        assert_owner(owner, key, storage);
+        assert_owner::<D>(owner);
 
         let txn_id = storage.txn_id();
         storage.remove_singleton(key, txn_id);
@@ -374,13 +374,6 @@ pub(crate) trait TabularOpsMut<TableStorage: schema::GeneratedStorage>:
 {
     type TableDesc: TableDesc<Storage = TableStorage>;
 
-    fn init(self, owner: Owner) -> Result<()> {
-        let mut storage = self.write_lock();
-
-        let table = Self::TableDesc::get_table_mut(&mut storage.storage().tables);
-        table.try_set_owner(owner)
-    }
-
     fn clear(self, owner: Owner) {
         let mut storage = self.write_lock();
         let storage = storage.storage();
@@ -388,7 +381,7 @@ pub(crate) trait TabularOpsMut<TableStorage: schema::GeneratedStorage>:
         let max_committed_id = storage.max_committed_id();
 
         let table = Self::TableDesc::get_table_mut(&mut storage.tables);
-        table.assert_or_set_owner(owner);
+        table.assert_owner(owner);
         table.clear(txn_id, max_committed_id);
     }
 
@@ -405,7 +398,7 @@ pub(crate) trait TabularOpsMut<TableStorage: schema::GeneratedStorage>:
         let txn_id = storage.txn_id();
         let max_committed_id = storage.max_committed_id();
         let table = Self::TableDesc::get_table_mut(&mut storage.tables);
-        table.assert_or_set_owner(owner);
+        table.assert_owner(owner);
 
         table.insert(key, value, txn_id, max_committed_id);
     }
@@ -470,13 +463,6 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
 {
     type IndexDesc: IndexDesc<Storage = TableStorage>;
 
-    fn init(self, owner: Owner) -> Result<()> {
-        let mut storage = self.write_lock();
-        let storage = storage.storage();
-        let base = Base::<Self::IndexDesc>::get_table_mut(&mut storage.tables);
-        base.try_set_owner(owner)
-    }
-
     fn clear(self, owner: Owner)
     where
         IndexValue<Self::IndexDesc>: Hash + Eq,
@@ -487,7 +473,7 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
         let max_committed_id = storage.max_committed_id();
 
         let base = Base::<Self::IndexDesc>::get_table_mut(&mut storage.tables);
-        base.assert_or_set_owner(owner);
+        base.assert_owner(owner);
         base.clear(txn_id, max_committed_id);
     }
 
@@ -501,7 +487,7 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
         let txn_id = storage.txn_id();
         let max_committed_id = storage.max_committed_id();
         let base = Base::<Self::IndexDesc>::get_table_mut(&mut storage.tables);
-        base.assert_or_set_owner(owner);
+        base.assert_owner(owner);
 
         base.insert(key, value, txn_id, max_committed_id);
     }
@@ -598,12 +584,12 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
 
 #[allow(unused_variables)]
 #[track_caller]
-fn assert_owner(owner: Owner, key: TypeId, storage: &Storage<impl schema::GeneratedStorage>) {
+fn assert_owner<D: schema::Singleton>(owner: Owner) {
     #[cfg(debug_assertions)]
-    if let Some(prev_owner) = storage.get_singleton_owner(key) {
-        assert_eq!(
-            prev_owner, owner,
-            "Ownership violation: expected {prev_owner}, found {owner}"
-        );
-    }
+    assert_eq!(
+        D::OWNER,
+        owner,
+        "Ownership violation: expected {}, found {owner}",
+        D::OWNER,
+    );
 }

--- a/ts_kv_store/src/raw.rs
+++ b/ts_kv_store/src/raw.rs
@@ -3,7 +3,7 @@
 use std::{borrow::Borrow, hash::Hash, sync::Arc};
 
 use crate::{
-    Error, KvStore, KvTableTransactional, Owner, Result,
+    Error, KvStore, KvTableTransactional, Owner, Result, StoreWithOwner,
     index::KvTableIndex,
     operations::{Ops, SingletonOps, SingletonOpsMut, TabularOps, TabularOpsMut},
     schema,
@@ -108,6 +108,73 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
         SingletonOpsMut::remove::<D>(&mut txn, owner);
         // Should never panic since transaction should only fail on index inserts.
         txn.commit().unwrap();
+    }
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage> StoreWithOwner<'a, TableStorage> {
+    /// Operate on tables of key/values in the store.
+    ///
+    /// # Example:
+    ///
+    /// ```rust,ignore
+    /// let value = store.table::<Foo>().get(key).unwrap();
+    /// ```
+    pub fn table<D: schema::TableDesc<Storage = TableStorage>>(&self) -> KvTable<'_, D> {
+        KvTable {
+            store: self.store,
+            owner: self.owner,
+        }
+    }
+
+    /// Access a table via an index.
+    ///
+    /// # Example:
+    ///
+    /// ```rust,ignore
+    /// let value = store.table_by::<index::Foo::bar>().get(key).unwrap();
+    /// ```
+    ///
+    /// Here `Foo` describes a tables and `bar` describes an index over `Foo` using the `bar` field
+    /// as foreign key.
+    pub fn table_by<D: schema::IndexDesc<Storage = TableStorage>>(&self) -> KvTableIndex<'_, D> {
+        KvTableIndex {
+            store: self.store,
+            owner: self.owner,
+        }
+    }
+
+    /// Get a single value from the store by cloning the value.
+    ///
+    /// Returns `None` if there is no value for the specified key.
+    pub fn get<D: schema::Singleton>(&self) -> Option<D::Value>
+    where
+        D::Value: Clone,
+    {
+        self.store.get::<D>(self.owner)
+    }
+
+    /// Get a single value from the store by cloning an `Arc`.
+    ///
+    /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
+    pub fn get_arc<D: schema::ArcSingleton>(&self) -> Option<Arc<D::Value>> {
+        self.store.get_arc::<D>(self.owner)
+    }
+
+    /// Get immutable access to a value in the store by reference.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn with<D: schema::Singleton, T>(&self, f: impl FnOnce(&D::Value) -> T) -> Option<T> {
+        self.store.with::<D, T>(self.owner, f)
+    }
+
+    /// Insert a single value into the store.
+    pub fn insert<D: schema::Singleton>(&self, value: D::ArgValue) {
+        self.store.insert::<D>(self.owner, value)
+    }
+
+    /// Remove a single value from the store.
+    pub fn remove<D: schema::Singleton>(&self) {
+        self.store.remove::<D>(self.owner)
     }
 }
 

--- a/ts_kv_store/src/raw.rs
+++ b/ts_kv_store/src/raw.rs
@@ -69,7 +69,10 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     /// Get a single value from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<D: schema::Singleton>(&self, owner: Owner) -> Option<D::Value>
+    pub fn get<D: schema::Singleton<Storage = TableStorage>>(
+        &self,
+        owner: Owner,
+    ) -> Option<D::Value>
     where
         D::Value: Clone,
     {
@@ -79,14 +82,17 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     /// Get a single value from the store by cloning an `Arc`.
     ///
     /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
-    pub fn get_arc<D: schema::ArcSingleton>(&self, owner: Owner) -> Option<Arc<D::Value>> {
+    pub fn get_arc<D: schema::ArcSingleton<Storage = TableStorage>>(
+        &self,
+        owner: Owner,
+    ) -> Option<Arc<D::Value>> {
         <&Self as SingletonOps<_>>::get_arc::<D>(self, owner)
     }
 
     /// Get immutable access to a value in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<D: schema::Singleton, T>(
+    pub fn with<D: schema::Singleton<Storage = TableStorage>, T>(
         &self,
         owner: Owner,
         f: impl FnOnce(&D::Value) -> T,
@@ -95,7 +101,11 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     }
 
     /// Insert a single value into the store.
-    pub fn insert<D: schema::Singleton>(&self, owner: Owner, value: D::ArgValue) {
+    pub fn insert<D: schema::Singleton<Storage = TableStorage>>(
+        &self,
+        owner: Owner,
+        value: D::ArgValue,
+    ) {
         let mut txn = self.begin_transaction(owner);
         SingletonOpsMut::insert::<D>(&mut txn, value, owner);
         // Should never panic since transaction should only fail on index inserts.
@@ -103,7 +113,7 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     }
 
     /// Remove a single value from the store.
-    pub fn remove<D: schema::Singleton>(&self, owner: Owner) {
+    pub fn remove<D: schema::Singleton<Storage = TableStorage>>(&self, owner: Owner) {
         let mut txn = self.begin_transaction(owner);
         SingletonOpsMut::remove::<D>(&mut txn, owner);
         // Should never panic since transaction should only fail on index inserts.
@@ -146,7 +156,7 @@ impl<'a, TableStorage: schema::GeneratedStorage> StoreWithOwner<'a, TableStorage
     /// Get a single value from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<D: schema::Singleton>(&self) -> Option<D::Value>
+    pub fn get<D: schema::Singleton<Storage = TableStorage>>(&self) -> Option<D::Value>
     where
         D::Value: Clone,
     {
@@ -156,24 +166,29 @@ impl<'a, TableStorage: schema::GeneratedStorage> StoreWithOwner<'a, TableStorage
     /// Get a single value from the store by cloning an `Arc`.
     ///
     /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
-    pub fn get_arc<D: schema::ArcSingleton>(&self) -> Option<Arc<D::Value>> {
+    pub fn get_arc<D: schema::ArcSingleton<Storage = TableStorage>>(
+        &self,
+    ) -> Option<Arc<D::Value>> {
         self.store.get_arc::<D>(self.owner)
     }
 
     /// Get immutable access to a value in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<D: schema::Singleton, T>(&self, f: impl FnOnce(&D::Value) -> T) -> Option<T> {
+    pub fn with<D: schema::Singleton<Storage = TableStorage>, T>(
+        &self,
+        f: impl FnOnce(&D::Value) -> T,
+    ) -> Option<T> {
         self.store.with::<D, T>(self.owner, f)
     }
 
     /// Insert a single value into the store.
-    pub fn insert<D: schema::Singleton>(&self, value: D::ArgValue) {
+    pub fn insert<D: schema::Singleton<Storage = TableStorage>>(&self, value: D::ArgValue) {
         self.store.insert::<D>(self.owner, value)
     }
 
     /// Remove a single value from the store.
-    pub fn remove<D: schema::Singleton>(&self) {
+    pub fn remove<D: schema::Singleton<Storage = TableStorage>>(&self) {
         self.store.remove::<D>(self.owner)
     }
 }

--- a/ts_kv_store/src/raw.rs
+++ b/ts_kv_store/src/raw.rs
@@ -311,15 +311,21 @@ impl<D: schema::TableDesc> KvTable<'_, D> {
 
 #[cfg(test)]
 mod test {
-    use std::{any::Any, sync::Arc};
+    use std::sync::Arc;
 
-    use crate::{KvErrorExt, singleton, tables};
+    use crate::{KvErrorExt, store};
 
-    singleton!(Count(u64; OWNER));
-    singleton!(Shared(String as Arc; OWNER));
-    singleton!(Label(u64 as Ref; OWNER));
-
-    tables!(Items(&'static str => String; OWNER), Counters(u32 => u64; OWNER));
+    store!(
+        kvs: {
+            Count(u64; OWNER),
+            Shared(String as Arc; OWNER),
+            Label(u64 as Ref; OWNER),
+        }
+        tables: {
+            Items(&'static str => String; OWNER),
+            Counters(u32 => u64; OWNER),
+        }
+    );
 
     const OWNER: &str = "owner";
     const OTHER: &str = "other";

--- a/ts_kv_store/src/raw.rs
+++ b/ts_kv_store/src/raw.rs
@@ -3,7 +3,7 @@
 use std::{borrow::Borrow, hash::Hash, sync::Arc};
 
 use crate::{
-    KvStore, Owner, Result,
+    KvStore, Owner,
     index::KvTableIndex,
     operations::{Ops, OpsMut, SingletonOps, SingletonOpsMut, TabularOps, TabularOpsMut},
     schema,
@@ -101,16 +101,11 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     }
 
     /// Insert a single value into the store.
-    ///
-    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
-    // Question: do we need separate insert/update/upsert methods?
     pub fn insert<D: schema::Singleton>(&self, owner: Owner, value: D::ArgValue) {
         <&Self as SingletonOpsMut<_>>::insert::<D>(self, value, owner)
     }
 
     /// Remove a single value from the store.
-    ///
-    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn remove<D: schema::Singleton>(&self, owner: Owner) {
         <&Self as SingletonOpsMut<_>>::remove::<D>(self, owner)
     }
@@ -126,17 +121,6 @@ pub struct KvTable<'store, D: schema::TableDesc> {
 }
 
 impl<D: schema::TableDesc> KvTable<'_, D> {
-    /// Initialize a table by setting its owner.
-    ///
-    /// Calling this function is optional, a table can be used without initialization in which case,
-    /// its owner is set to the owner specified in the first write.
-    ///
-    /// Returns an error (containing the current owner of the table) if the table has already been
-    /// initialized. In this case, the table will be in a consistent state and can be used as normal.
-    pub fn init(&self) -> Result<()> {
-        <&Self as TabularOpsMut<_>>::init(self, self.owner)
-    }
-
     /// The number of key/value pairs in the table.
     pub fn len(&self) -> usize {
         <&Self as TabularOps<_>>::len(self)
@@ -147,7 +131,7 @@ impl<D: schema::TableDesc> KvTable<'_, D> {
         <&Self as TabularOps<_>>::is_empty(self)
     }
 
-    /// Clear a table by removing all its KVs, but preserve ownership.
+    /// Clear a table by removing all its KVs.
     pub fn clear(&self) {
         <&Self as TabularOpsMut<_>>::clear(self, self.owner)
     }
@@ -176,8 +160,6 @@ impl<D: schema::TableDesc> KvTable<'_, D> {
     }
 
     /// Insert a value into the table.
-    ///
-    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn insert(&self, key: D::Key, value: D::Value)
     where
         D::Key: Clone,
@@ -198,8 +180,6 @@ impl<D: schema::TableDesc> KvTable<'_, D> {
     }
 
     /// Remove a row from the table.
-    ///
-    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn remove<Q>(&self, key: &Q)
     where
         D::Key: Borrow<Q>,
@@ -236,13 +216,13 @@ impl<D: schema::TableDesc> KvTable<'_, D> {
 mod test {
     use std::{any::Any, sync::Arc};
 
-    use crate::{Error, singleton, tables};
+    use crate::{singleton, tables};
 
-    singleton!(Count(u64));
-    singleton!(Shared(String as Arc));
-    singleton!(Label(u64 as Ref));
+    singleton!(Count(u64; OWNER));
+    singleton!(Shared(String as Arc; OWNER));
+    singleton!(Label(u64 as Ref; OWNER));
 
-    tables!(Items(&'static str => String), Counters(u32 => u64));
+    tables!(Items(&'static str => String; OWNER), Counters(u32 => u64; OWNER));
 
     const OWNER: &str = "owner";
     const OTHER: &str = "other";
@@ -344,35 +324,6 @@ mod test {
     }
 
     #[test]
-    fn table_init_succeeds_on_fresh_table() {
-        let store = KvStore::new();
-        assert!(store.table::<Items>(OWNER).init().is_ok());
-    }
-
-    #[test]
-    fn table_init_second_call_returns_err() {
-        let store = KvStore::new();
-        store.table::<Items>(OWNER).init().unwrap();
-        let err = store.table::<Items>(OWNER).init().unwrap_err();
-        assert!(matches!(err, Error::AlreadyInit(o) if o == OWNER));
-    }
-
-    #[test]
-    fn table_init_with_different_owner_returns_err() {
-        let store = KvStore::new();
-        store.table::<Items>(OWNER).init().unwrap();
-        let err = store.table::<Items>(OTHER).init().unwrap_err();
-        assert!(matches!(err, Error::AlreadyInit(o) if o == OWNER));
-    }
-
-    #[test]
-    fn table_init_is_optional() {
-        let store = KvStore::new();
-        store.table::<Items>(OWNER).insert("k", "v".to_owned());
-        assert_eq!(store.table::<Items>(OWNER).get("k"), Some("v".to_owned()));
-    }
-
-    #[test]
     fn table_get_returns_none_when_absent() {
         let store = KvStore::new();
         assert!(store.table::<Items>(OWNER).get("missing").is_none());
@@ -413,7 +364,6 @@ mod test {
     #[test]
     fn table_mutate_returns_none_when_absent() {
         let store = KvStore::new();
-        store.table::<Items>(OWNER).init().unwrap();
         assert!(
             store
                 .table::<Items>(OWNER)
@@ -621,7 +571,6 @@ mod test {
     #[should_panic(expected = "Ownership violation")]
     fn table_insert_wrong_owner_panics() {
         let store = KvStore::new();
-        store.table::<Items>(OWNER).init().unwrap();
         store.table::<Items>(OTHER).insert("k", "v".to_owned());
     }
 
@@ -630,7 +579,6 @@ mod test {
     #[should_panic(expected = "Ownership violation")]
     fn table_mutate_wrong_owner_panics() {
         let store = KvStore::new();
-        store.table::<Items>(OWNER).init().unwrap();
         store.table::<Items>(OTHER).with_mut(&"k", |v| v.len());
     }
 
@@ -639,7 +587,6 @@ mod test {
     #[should_panic(expected = "Ownership violation")]
     fn table_remove_wrong_owner_panics() {
         let store = KvStore::new();
-        store.table::<Items>(OWNER).init().unwrap();
         store.table::<Items>(OTHER).remove(&"k");
     }
 
@@ -648,7 +595,6 @@ mod test {
     #[should_panic(expected = "Ownership violation")]
     fn table_clear_wrong_owner_panics() {
         let store = KvStore::new();
-        store.table::<Items>(OWNER).init().unwrap();
         store.table::<Items>(OTHER).clear();
     }
 

--- a/ts_kv_store/src/raw.rs
+++ b/ts_kv_store/src/raw.rs
@@ -3,18 +3,24 @@
 use std::{borrow::Borrow, hash::Hash, sync::Arc};
 
 use crate::{
-    KvStore, Owner,
+    Error, KvStore, KvTableTransactional, Owner, Result,
     index::KvTableIndex,
-    operations::{Ops, OpsMut, SingletonOps, SingletonOpsMut, TabularOps, TabularOpsMut},
+    operations::{Ops, SingletonOps, SingletonOpsMut, TabularOps, TabularOpsMut},
     schema,
     storage::Storage,
 };
 
-impl<TableStorage: schema::GeneratedStorage> SingletonOps<TableStorage> for &KvStore<TableStorage> {}
-impl<TableStorage: schema::GeneratedStorage> SingletonOpsMut<TableStorage>
-    for &KvStore<TableStorage>
+impl<'store, TableStorage: schema::GeneratedStorage> Ops<TableStorage>
+    for &'store KvStore<TableStorage>
 {
+    type ReadLock = std::sync::RwLockReadGuard<'store, Storage<TableStorage>>;
+
+    fn read_lock(self) -> Self::ReadLock {
+        self.get_read_lock()
+    }
 }
+
+impl<TableStorage: schema::GeneratedStorage> SingletonOps<TableStorage> for &KvStore<TableStorage> {}
 
 impl<'a, D: schema::TableDesc> Ops<D::Storage> for &'a KvTable<'_, D> {
     type ReadLock = std::sync::RwLockReadGuard<'a, Storage<D::Storage>>;
@@ -25,18 +31,6 @@ impl<'a, D: schema::TableDesc> Ops<D::Storage> for &'a KvTable<'_, D> {
 }
 
 impl<D: schema::TableDesc> TabularOps<D::Storage> for &KvTable<'_, D> {
-    type TableDesc = D;
-}
-
-impl<'a, D: schema::TableDesc> OpsMut<D::Storage> for &'a KvTable<'_, D> {
-    type WriteLock = std::sync::RwLockWriteGuard<'a, Storage<D::Storage>>;
-
-    fn write_lock(self) -> Self::WriteLock {
-        self.store.get_write_lock()
-    }
-}
-
-impl<D: schema::TableDesc> TabularOpsMut<D::Storage> for &KvTable<'_, D> {
     type TableDesc = D;
 }
 
@@ -102,12 +96,18 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
 
     /// Insert a single value into the store.
     pub fn insert<D: schema::Singleton>(&self, owner: Owner, value: D::ArgValue) {
-        <&Self as SingletonOpsMut<_>>::insert::<D>(self, value, owner)
+        let mut txn = self.begin_transaction(owner);
+        SingletonOpsMut::insert::<D>(&mut txn, value, owner);
+        // Should never panic since transaction should only fail on index inserts.
+        txn.commit().unwrap();
     }
 
     /// Remove a single value from the store.
     pub fn remove<D: schema::Singleton>(&self, owner: Owner) {
-        <&Self as SingletonOpsMut<_>>::remove::<D>(self, owner)
+        let mut txn = self.begin_transaction(owner);
+        SingletonOpsMut::remove::<D>(&mut txn, owner);
+        // Should never panic since transaction should only fail on index inserts.
+        txn.commit().unwrap();
     }
 }
 
@@ -133,7 +133,11 @@ impl<D: schema::TableDesc> KvTable<'_, D> {
 
     /// Clear a table by removing all its KVs.
     pub fn clear(&self) {
-        <&Self as TabularOpsMut<_>>::clear(self, self.owner)
+        let mut txn = self.store.begin_transaction(self.owner);
+        let mut txn_table = KvTableTransactional::<D> { txn: &mut txn };
+        TabularOpsMut::clear(&mut txn_table, self.owner);
+        // Should never panic since transaction should only fail on index inserts.
+        txn.commit().unwrap();
     }
 
     /// Get a row of the table from the store by cloning the value.
@@ -159,24 +163,43 @@ impl<D: schema::TableDesc> KvTable<'_, D> {
         <&Self as TabularOps<_>>::with(self, key, f, self.owner)
     }
 
-    /// Insert a value into the table.
+    /// Insert a `value` into the table.
+    ///
+    /// Panics if the value is already indexed with the same index key.
     pub fn insert(&self, key: D::Key, value: D::Value)
     where
         D::Key: Clone,
     {
-        <&Self as TabularOpsMut<_>>::insert(self, key, value, self.owner)
+        self.try_insert(key, value).unwrap();
+    }
+
+    /// Insert a `value` into the table.
+    ///
+    /// Returns an error if `insert` would panic.
+    pub fn try_insert(&self, key: D::Key, value: D::Value) -> Result<()>
+    where
+        D::Key: Clone,
+    {
+        let mut txn = self.store.begin_transaction(self.owner);
+        let mut txn_table = KvTableTransactional::<D> { txn: &mut txn };
+        TabularOpsMut::insert(&mut txn_table, key, value, self.owner);
+        txn.commit()
     }
 
     /// Get mutable access to a row of the table in the store in the store.
     ///
-    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with_mut<Q, T>(&self, key: &Q, f: impl FnOnce(&mut D::Value) -> T) -> Option<T>
+    /// Returns `Error::NotPresent` (and does not call `f`) if there is no value for the specified key.
+    pub fn with_mut<Q, T>(&self, key: &Q, f: impl FnOnce(&mut D::Value) -> T) -> Result<T>
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
         D::Value: Clone,
     {
-        <&Self as TabularOpsMut<_>>::with_mut(self, key, f, self.owner)
+        let mut txn = self.store.begin_transaction(self.owner);
+        let mut txn_table = KvTableTransactional::<D> { txn: &mut txn };
+        let result = TabularOpsMut::with_mut(&mut txn_table, key, f, self.owner);
+        txn.commit()?;
+        result.ok_or(Error::NotPresent)
     }
 
     /// Remove a row from the table.
@@ -185,7 +208,11 @@ impl<D: schema::TableDesc> KvTable<'_, D> {
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
     {
-        <&Self as TabularOpsMut<_>>::remove(self, key, self.owner)
+        let mut txn = self.store.begin_transaction(self.owner);
+        let mut txn_table = KvTableTransactional::<D> { txn: &mut txn };
+        TabularOpsMut::remove(&mut txn_table, key, self.owner);
+        // Should never panic since transaction should only fail on index inserts.
+        txn.commit().unwrap();
     }
 
     /// Iterate all the key/value pairs in a table.
@@ -208,7 +235,10 @@ impl<D: schema::TableDesc> KvTable<'_, D> {
     where
         D::Value: Clone,
     {
-        <&Self as TabularOpsMut<_>>::for_each_mut(self, f, self.owner)
+        let mut txn = self.store.begin_transaction(self.owner);
+        let mut txn_table = KvTableTransactional::<D> { txn: &mut txn };
+        TabularOpsMut::for_each_mut(&mut txn_table, f, self.owner);
+        txn.commit().unwrap();
     }
 }
 
@@ -216,7 +246,7 @@ impl<D: schema::TableDesc> KvTable<'_, D> {
 mod test {
     use std::{any::Any, sync::Arc};
 
-    use crate::{singleton, tables};
+    use crate::{KvErrorExt, singleton, tables};
 
     singleton!(Count(u64; OWNER));
     singleton!(Shared(String as Arc; OWNER));
@@ -376,7 +406,10 @@ mod test {
     fn table_mutate_modifies_value() {
         let store = KvStore::new();
         store.table::<Items>(OWNER).insert("k", "hello".to_owned());
-        store.table::<Items>(OWNER).with_mut(&"k", |v| v.push('!'));
+        store
+            .table::<Items>(OWNER)
+            .with_mut(&"k", |v| v.push('!'))
+            .unwrap();
         assert_eq!(
             store.table::<Items>(OWNER).get("k"),
             Some("hello!".to_owned())
@@ -478,10 +511,12 @@ mod test {
         let store = KvStore::new();
         let table = store.table::<Items>(OWNER);
         table.insert("k", "v1".to_owned());
-        table.with_mut(&"k", |v| {
-            v.clear();
-            v.push_str("v2");
-        });
+        table
+            .with_mut(&"k", |v| {
+                v.clear();
+                v.push_str("v2");
+            })
+            .unwrap();
         let items: Vec<_> = table.iter().collect();
         assert_eq!(items, vec![(&"k", &"v2".to_owned())]);
     }
@@ -579,7 +614,10 @@ mod test {
     #[should_panic(expected = "Ownership violation")]
     fn table_mutate_wrong_owner_panics() {
         let store = KvStore::new();
-        store.table::<Items>(OTHER).with_mut(&"k", |v| v.len());
+        store
+            .table::<Items>(OTHER)
+            .with_mut(&"k", |v| v.len())
+            .unwrap();
     }
 
     #[test]

--- a/ts_kv_store/src/raw.rs
+++ b/ts_kv_store/src/raw.rs
@@ -424,8 +424,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(debug_assertions)]
-    #[should_panic(expected = "Ownership violation")]
+    #[cfg_attr(debug_assertions, should_panic(expected = "Ownership violation"))]
     fn singleton_insert_wrong_owner_panics() {
         let store = KvStore::new();
         store.insert::<Count>(OWNER, 1);
@@ -433,8 +432,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(debug_assertions)]
-    #[should_panic(expected = "Ownership violation")]
+    #[cfg_attr(debug_assertions, should_panic(expected = "Ownership violation"))]
     fn singleton_remove_wrong_owner_panics() {
         let store = KvStore::new();
         store.insert::<Count>(OWNER, 1);
@@ -698,34 +696,29 @@ mod test {
     }
 
     #[test]
-    #[cfg(debug_assertions)]
-    #[should_panic(expected = "Ownership violation")]
+    #[cfg_attr(debug_assertions, should_panic(expected = "Ownership violation"))]
     fn table_mutate_wrong_owner_panics() {
         let store = KvStore::new();
         store
             .table::<Items>(OTHER)
             .with_mut(&"k", |v| v.len())
-            .unwrap();
+            .unwrap_err();
     }
 
     #[test]
-    #[cfg(debug_assertions)]
-    #[should_panic(expected = "Ownership violation")]
+    #[cfg_attr(debug_assertions, should_panic(expected = "Ownership violation"))]
     fn table_remove_wrong_owner_panics() {
         let store = KvStore::new();
         store.table::<Items>(OTHER).remove(&"k");
     }
 
     #[test]
-    #[cfg(debug_assertions)]
-    #[should_panic(expected = "Ownership violation")]
+    #[cfg_attr(debug_assertions, should_panic(expected = "Ownership violation"))]
     fn table_clear_wrong_owner_panics() {
         let store = KvStore::new();
         store.table::<Items>(OTHER).clear();
     }
 
-    // `remove` no longer returns the removed value: it is used in statement position and its only
-    // observable effect is that the row becomes absent.
     #[test]
     fn table_remove_used_in_statement_position() {
         let store = KvStore::new();

--- a/ts_kv_store/src/schema.rs
+++ b/ts_kv_store/src/schema.rs
@@ -191,185 +191,40 @@ pub trait GeneratedStorage: Default {
     fn gc_txn(&mut self, txn_id: TxnId);
 }
 
-/// Macro to declare a singleton key/value in the store.
+/// Declare the schema of a key/value store. Generates the store itself with the specified tables and
+/// singletons.
 ///
-/// Does not need to be used within or near the store declaration, but also is not linked to a specific
-/// store. Using a generated accessor on a store different to the store the key/value was stored in
-/// will have unpredictable results (panics, memory safety, etc.).
+/// The syntax is `store!((Name(KeyType => ValueType; owner; indexes?) | Name(ValueKind; owner)),*)`,
+///  where `Name` is an identifier to name the table or singleton (in which case it is also the key),
+/// `KeyType` and `ValueType` are types, `ValueKind` is `u64 | ValueType as (Box | Arc | Ref)`.
+/// `owner` is an expression which evaluates to an `Owner`. `Name` is used as a type argument to
+/// KvStore methods to identify the table or singletone.
 ///
-/// # Syntax:
+/// The storage kinds for singleton values are:
 ///
-/// - `singleton!(u64; owner)` to declare a value with type `u64` and inline storage.
-/// - `singleton!(ValueType as Box; owner)` to declare a value with type `Box<ValueType>`.
-/// - `singleton!(ValueType as Arc; owner)` to declare a value with type `Arc<ValueType>`.
-/// - `singleton!(ValueType as Ref; owner)` to declare a value with type `&'static ValueType`.
-///
-/// The storage class is separate to the value type since they have different representations in the
-/// store and slightly different APIs (e.g., whether mutable access is supported or access by cloning
-/// or copying a shared reference).
-///
-/// `owner` is an expression which evaluates to an `Owner` to specify the owner of the data.
-#[macro_export]
-macro_rules! singleton {
-    ($name:ident(u64; $owner:expr)) => {
-        $crate::singleton_types!($name(u64, u64, U64), $owner);
-
-        impl $crate::schema::MutSingleton for $name {
-            fn from_value_mut(value: &mut $crate::storage::SinValue) -> &mut Self::Value {
-                match value {
-                    $crate::match_helper_lhs!(U64, v) => $crate::match_helper_rhs_mut!(U64, v),
-                    _ => unreachable!(),
-                }
-            }
-        }
-    };
-    ($name:ident($value_ty:ty as Box; $owner:expr)) => {
-        $crate::singleton_types!($name($value_ty, $value_ty, Box), $owner);
-
-        impl $crate::schema::MutSingleton for $name {
-            fn from_value_mut(value: &mut $crate::storage::SinValue) -> &mut Self::Value {
-                match value {
-                    $crate::match_helper_lhs!(Box, v) => $crate::match_helper_rhs_mut!(Box, v),
-                    _ => unreachable!(),
-                }
-            }
-        }
-    };
-    ($name:ident($value_ty:ty as Arc; $owner:expr)) => {
-        $crate::singleton_types!($name($value_ty, std::sync::Arc<$value_ty>, Arc), $owner);
-
-        impl $crate::schema::ArcSingleton for $name {}
-    };
-    ($name:ident($value_ty:ty as Ref; $owner:expr)) => {
-        $crate::singleton_types!($name($value_ty, &'static $value_ty, Ref), $owner);
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! singleton_types {
-    ($name:ident($value_ty:ty, $arg_value_ty:ty, $variant:ident), $owner:expr) => {
-        /// Describes a singleton in the KV store.
-        #[allow(non_camel_case_types)]
-        pub struct $name;
-
-        impl $crate::schema::Singleton for $name {
-            const OWNER: $crate::Owner = $owner;
-            type Value = $value_ty;
-            type ArgValue = $arg_value_ty;
-
-            fn from_value(value: $crate::storage::SinValue) -> Self::ArgValue {
-                match value {
-                    $crate::match_helper_lhs!($variant, v) => {
-                        $crate::match_helper_rhs!($variant, v)
-                    }
-                    _ => unreachable!(),
-                }
-            }
-
-            fn from_value_ref(value: &$crate::storage::SinValue) -> &Self::Value {
-                match value {
-                    $crate::match_helper_lhs!($variant, v) => {
-                        $crate::match_helper_rhs_ref!($variant, v)
-                    }
-                    _ => unreachable!(),
-                }
-            }
-
-            fn to_value(value: Self::ArgValue) -> $crate::storage::SinValue {
-                $crate::init_helper!($variant, value)
-            }
-        }
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! init_helper {
-    (U64, $value:ident) => {
-        $crate::storage::SinValue::U64($value)
-    };
-    (Box, $value:ident) => {
-        $crate::storage::SinValue::Box(std::boxed::Box::new($value) as Box<dyn Any + Send + Sync>)
-    };
-    (Arc, $value:ident) => {
-        $crate::storage::SinValue::Arc($value.clone() as std::sync::Arc<dyn Any + Send + Sync>)
-    };
-    (Ref, $value:ident) => {
-        $crate::storage::SinValue::Ref($value as &'static (dyn std::any::Any + Send + Sync))
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! match_helper_lhs {
-    (U64, $value:ident) => {
-        $crate::storage::SinValue::U64($value)
-    };
-    ($variant:ident, $value:ident) => {
-        $crate::storage::SinValue::$variant($value)
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! match_helper_rhs {
-    (U64, $value:ident) => {
-        $value
-    };
-    (Box, $value:ident) => {
-        *$value.downcast().unwrap()
-    };
-    (Arc, $value:ident) => {
-        $value.downcast().unwrap()
-    };
-    (Ref, $value:ident) => {
-        $value.downcast_ref().unwrap()
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! match_helper_rhs_ref {
-    (U64, $value:ident) => {
-        $value
-    };
-    ($variant:ident, $value:ident) => {
-        $value.downcast_ref().unwrap()
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! match_helper_rhs_mut {
-    (U64, $value:ident) => {
-        $value
-    };
-    ($variant:ident, $value:ident) => {
-        $value.downcast_mut().unwrap()
-    };
-}
-
-/// Declare the tables in a key/value store. Generates the store itself with the specified tables.
-///
-/// The syntax is `tables!(Name(KeyType => ValueType; owner; indexes?),*)`, where `Name` is an
-/// identifier to name the table, `KeyType` and `ValueType` are types, and `owner` is an expression
-/// which evaluates to an `Owner`. `Name` is used as a type argument to KvStore methods to identify
-/// the table.
-///
-/// Use with an empty list of tables to generate a store for use only with singleton key/value pairs.
+/// - `u64` a `u64` stored inline.
+/// - `Box` a value with type `Box<ValueType>`.
+/// - `Arc` a value with type `Arc<ValueType>`.
+/// - `Ref` a value with type `&'static ValueType`.
 ///
 /// # Example:
 ///
 /// ```rust
-/// # use ts_kv_store::tables;
-/// # const NODES_OWNER: ts_kv_store::Owner = "foo";
-/// # const EDGES_OWNER: ts_kv_store::Owner = "bar";
+/// # use ts_kv_store::store;
+/// # const GRAPH_OWNER: ts_kv_store::Owner = "foo";
+/// # const NODES_OWNER: ts_kv_store::Owner = "bar";
+/// # const EDGES_OWNER: ts_kv_store::Owner = "baz";
 /// # pub struct Node;
+/// # pub struct Gid;
 /// # pub trait Edge {}
-/// tables!(
-///   Nodes(&'static str => Node; NODES_OWNER),
-///   Edges(u32 => Box<dyn Edge + Send + Sync>; EDGES_OWNER)
+/// store!(
+///   kvs: {
+///     GraphId(Gid as Arc; GRAPH_OWNER),
+///   }
+///   tables: {
+///     Nodes(&'static str => Node; NODES_OWNER),
+///     Edges(u32 => Box<dyn Edge + Send + Sync>; EDGES_OWNER),
+///   }
 /// );
 /// ```
 ///
@@ -380,17 +235,19 @@ macro_rules! match_helper_rhs_mut {
 /// specify multiple indexes for each table, separated with a semicolon. E.g.,
 ///
 /// ```rust
-/// # use ts_kv_store::tables;
+/// # use ts_kv_store::store;
 /// # const NODES_OWNER: ts_kv_store::Owner = "foo";
 /// # pub struct Node { a: u32, b: String };
-/// tables!(
-///   Nodes(
-///     &'static str => Node;
-///     NODES_OWNER;
-///     index(a: u32);
-///     index(b: String; assert_unique);
-///     index(c: String = |node: &Node| [format!("{}-{}", node.a, node.b)]);
-///   )
+/// store!(
+///   tables: {
+///     Nodes(
+///       &'static str => Node;
+///       NODES_OWNER;
+///       index(a: u32);
+///       index(b: String; assert_unique);
+///       index(c: String = |node: &Node| [format!("{}-{}", node.a, node.b)]);
+///     )
+///   }
 /// );
 /// ```
 ///
@@ -405,9 +262,19 @@ macro_rules! match_helper_rhs_mut {
 /// By adding `assert_unique` to an index declaration (after the index field, separated with a semicolon),
 /// attempting to store multiple rows with the same index key will cause a panic.
 #[macro_export]
-macro_rules! tables {
-    ($($name: ident ($key_ty: ty => $value_ty: ty; $owner: expr $(; index($field: ident: $field_ty: ty $(= $get_idx: expr)? $(; $unique:ident)?))* $(;)?)),*) => {
-        $(
+macro_rules! store {
+    (
+        $(kvs: { $($sname: ident $sbody: tt),* $(,)? })?
+        $(tables: { $(
+            $name: ident (
+                $key_ty: ty => $value_ty: ty;
+                $owner: expr
+                $(; index($field: ident: $field_ty: ty $(= $get_idx: expr)? $(; $unique:ident)?))* $(;)?
+            )
+        ),* $(,)? })?
+    ) => {
+        $($($crate::singleton!($sname $sbody );)*)?
+        $($(
             /// Describes a table in the KV store.
             #[derive(Default)]
             pub struct $name;
@@ -449,39 +316,43 @@ macro_rules! tables {
                     type BaseTable = $name;
                 }
             )*
-        )*
+        )*)?
 
         /// Macro-generated storage for all tabular data.
         #[derive(Default)]
         #[allow(non_snake_case)]
         pub struct TableStorage {
-            $($name: $crate::storage::Table<$name, index::$name::Indexes>),*
+            $($($name: $crate::storage::Table<$name, index::$name::Indexes>),*)?
         }
 
         impl $crate::schema::GeneratedStorage for TableStorage {
             fn commit_txn(&mut self, _txn_id: $crate::transactions::TxnId) -> $crate::Result<()> {
                 $(
-                    self.$name.check_txn_consistency(_txn_id)?;
-                    $(self.$name.indexes.$field.check_txn_consistency(_txn_id)?;)*
-                )*
-                $(
-                    self.$name.commit_txn(_txn_id);
-                    $(self.$name.indexes.$field.commit_txn(_txn_id);)*
-                )*
+                    $(
+                        self.$name.check_txn_consistency(_txn_id)?;
+                        $(self.$name.indexes.$field.check_txn_consistency(_txn_id)?;)*
+                    )*
+                    $(
+                        self.$name.commit_txn(_txn_id);
+                        $(self.$name.indexes.$field.commit_txn(_txn_id);)*
+                    )*
+                )?
 
                 Ok(())
             }
 
             fn gc_txn(&mut self, _txn_id: $crate::transactions::TxnId) {
                 $(
-                    self.$name.gc_txn(_txn_id);
-                    $(self.$name.indexes.$field.gc_txn(_txn_id);)*
-                )*
+                    $(
+                        self.$name.gc_txn(_txn_id);
+                        $(self.$name.indexes.$field.gc_txn(_txn_id);)*
+                    )*
+                )?
             }
         }
 
         pub mod index {
-            $(
+            $($(
                 #[allow(non_snake_case)]
                 pub mod $name {
                     $(
@@ -496,10 +367,10 @@ macro_rules! tables {
                         )*
                     }
                 }
-            )*
+            )*)?
         }
 
-        $(
+        $($(
             impl index::$name::Indexes {
                 $(
                     fn $field(val: &$value_ty) -> impl IntoIterator<Item = $field_ty> {
@@ -525,7 +396,7 @@ macro_rules! tables {
                     })*
                 }
             }
-        )*
+        )*)?
 
         /// A key-value store.
         ///
@@ -617,6 +488,152 @@ macro_rules! on_insert_each {
     };
 }
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! singleton {
+    ($name:ident(u64; $owner:expr)) => {
+        $crate::singleton_types!($name(u64, u64, U64), $owner);
+
+        impl $crate::schema::MutSingleton for $name {
+            fn from_value_mut(value: &mut $crate::storage::SinValue) -> &mut Self::Value {
+                match value {
+                    $crate::match_helper_lhs!(U64, v) => $crate::match_helper_rhs_mut!(U64, v),
+                    _ => unreachable!(),
+                }
+            }
+        }
+    };
+    ($name:ident($value_ty:ty as Box; $owner:expr)) => {
+        $crate::singleton_types!($name($value_ty, $value_ty, Box), $owner);
+
+        impl $crate::schema::MutSingleton for $name {
+            fn from_value_mut(value: &mut $crate::storage::SinValue) -> &mut Self::Value {
+                match value {
+                    $crate::match_helper_lhs!(Box, v) => $crate::match_helper_rhs_mut!(Box, v),
+                    _ => unreachable!(),
+                }
+            }
+        }
+    };
+    ($name:ident($value_ty:ty as Arc; $owner:expr)) => {
+        $crate::singleton_types!($name($value_ty, std::sync::Arc<$value_ty>, Arc), $owner);
+
+        impl $crate::schema::ArcSingleton for $name {}
+    };
+    ($name:ident($value_ty:ty as Ref; $owner:expr)) => {
+        $crate::singleton_types!($name($value_ty, &'static $value_ty, Ref), $owner);
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! singleton_types {
+    ($name:ident($value_ty:ty, $arg_value_ty:ty, $variant:ident), $owner:expr) => {
+        /// Describes a singleton in the KV store.
+        #[allow(non_camel_case_types)]
+        pub struct $name;
+
+        impl $crate::schema::Singleton for $name {
+            const OWNER: $crate::Owner = $owner;
+            type Value = $value_ty;
+            type ArgValue = $arg_value_ty;
+
+            fn from_value(value: $crate::storage::SinValue) -> Self::ArgValue {
+                match value {
+                    $crate::match_helper_lhs!($variant, v) => {
+                        $crate::match_helper_rhs!($variant, v)
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            fn from_value_ref(value: &$crate::storage::SinValue) -> &Self::Value {
+                match value {
+                    $crate::match_helper_lhs!($variant, v) => {
+                        $crate::match_helper_rhs_ref!($variant, v)
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            fn to_value(value: Self::ArgValue) -> $crate::storage::SinValue {
+                $crate::init_helper!($variant, value)
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! init_helper {
+    (U64, $value:ident) => {
+        $crate::storage::SinValue::U64($value)
+    };
+    (Box, $value:ident) => {
+        $crate::storage::SinValue::Box(
+            std::boxed::Box::new($value) as Box<dyn std::any::Any + Send + Sync>
+        )
+    };
+    (Arc, $value:ident) => {
+        $crate::storage::SinValue::Arc(
+            $value.clone() as std::sync::Arc<dyn std::any::Any + Send + Sync>
+        )
+    };
+    (Ref, $value:ident) => {
+        $crate::storage::SinValue::Ref($value as &'static (dyn std::any::Any + Send + Sync))
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! match_helper_lhs {
+    (U64, $value:ident) => {
+        $crate::storage::SinValue::U64($value)
+    };
+    ($variant:ident, $value:ident) => {
+        $crate::storage::SinValue::$variant($value)
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! match_helper_rhs {
+    (U64, $value:ident) => {
+        $value
+    };
+    (Box, $value:ident) => {
+        *$value.downcast().unwrap()
+    };
+    (Arc, $value:ident) => {
+        $value.downcast().unwrap()
+    };
+    (Ref, $value:ident) => {
+        $value.downcast_ref().unwrap()
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! match_helper_rhs_ref {
+    (U64, $value:ident) => {
+        $value
+    };
+    ($variant:ident, $value:ident) => {
+        $value.downcast_ref().unwrap()
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! match_helper_rhs_mut {
+    (U64, $value:ident) => {
+        $value
+    };
+    ($variant:ident, $value:ident) => {
+        $value.downcast_mut().unwrap()
+    };
+}
+
 #[cfg(test)]
 mod test {
     use std::sync::Arc;
@@ -625,17 +642,19 @@ mod test {
 
     #[test]
     fn single() {
-        singleton!(Foo(u64 as Box; "owner"));
-        singleton!(Bar(u64 as Arc; "owner"));
-        singleton!(Baz(u64 as Ref; "owner"));
-        singleton!(Qux(u64; "owner"));
+        store!(
+            kvs: {
+                Foo(u64 as Box; "owner"),
+                Bar(u64 as Arc; "owner"),
+                Baz(u64 as Ref; "owner"),
+                Qux(u64; "owner"),
+            }
+        );
 
         assert_eq!(&42, Foo::from_value_ref(&Foo::to_value(42)));
         assert_eq!(&42, Bar::from_value_ref(&Bar::to_value(Arc::new(42))));
         assert_eq!(&42, Baz::from_value_ref(&Baz::to_value(&42)));
         assert_eq!(&42, Qux::from_value_ref(&Qux::to_value(42)));
-
-        tables!();
 
         let store = KvStore::new();
         store.insert::<Foo>("owner", 42);
@@ -644,7 +663,7 @@ mod test {
 
     #[test]
     fn table() {
-        tables!(Foo(&'static str => String; "owner"), Bar(u32 => Vec<String>; "owner"));
+        store!(tables: { Foo(&'static str => String; "owner"), Bar(u32 => Vec<String>; "owner")});
 
         let store = KvStore::new();
 
@@ -668,9 +687,11 @@ mod test {
         pub struct BarT {
             a: String,
         }
-        tables!(
-            Foo(&'static str => String; "owner"; index(len: usize = |v: &String| [v.len()])),
-            Bar(u32 => BarT; "owner"; index(a: String; assert_unique))
+        store!(
+            tables: {
+                Foo(&'static str => String; "owner"; index(len: usize = |v: &String| [v.len()])),
+                Bar(u32 => BarT; "owner"; index(a: String; assert_unique)),
+            }
         );
 
         let store = KvStore::new();

--- a/ts_kv_store/src/schema.rs
+++ b/ts_kv_store/src/schema.rs
@@ -684,12 +684,12 @@ mod test {
             .table_by::<index::Bar::a>("owner")
             .get("hello")
             .unwrap();
-        assert_eq!(value.a, "hello");
+        assert_eq!(value.1.a, "hello");
 
         store
             .table::<Foo>("owner")
             .insert("foo", "hello".to_owned());
         let value = store.table_by::<index::Foo::len>("owner").get(&5).unwrap();
-        assert_eq!(value, "hello");
+        assert_eq!(value, ("foo", "hello".to_owned()));
     }
 }

--- a/ts_kv_store/src/schema.rs
+++ b/ts_kv_store/src/schema.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{
     Owner,
-    storage::{SinValue, Table},
+    storage::{SinValue, Table, VersionedValue},
     transactions::TxnId,
 };
 
@@ -25,6 +25,8 @@ pub trait Singleton: 'static {
     /// `Arc<Self::Value>`, for values stored by reference, this should be `&'static Self::Value`, and
     /// for other types, it should be the same as `Self::Value`.
     type ArgValue;
+    /// The storage for this singleton KV.
+    type Storage: GeneratedStorage;
 
     /// Unwrap a `SinValue` into a typed value.
     ///
@@ -36,6 +38,10 @@ pub trait Singleton: 'static {
     fn from_value_ref(value: &SinValue) -> &Self::Value;
     /// Wrap a typed value into a `SinValue`.
     fn to_value(value: Self::ArgValue) -> SinValue;
+    /// Get a reference to the field storing this singleton in `storage`.
+    fn field_ref(storage: &Self::Storage) -> &VersionedValue<SinValue>;
+    /// Get a mutable reference to the field storing this singleton in `storage`.
+    fn field_ref_mut(storage: &mut Self::Storage) -> &mut VersionedValue<SinValue>;
 }
 
 /// A singleton key/value which is store as an `Arc`.
@@ -194,8 +200,8 @@ pub trait GeneratedStorage: Default {
 /// Declare the schema of a key/value store. Generates the store itself with the specified tables and
 /// singletons.
 ///
-/// The syntax is `store!((Name(KeyType => ValueType; owner; indexes?) | Name(ValueKind; owner)),*)`,
-///  where `Name` is an identifier to name the table or singleton (in which case it is also the key),
+/// The syntax is `store!(kvs: { Name(ValueKind; owner),* } tables: { Name(KeyType => ValueType; owner; indexes?),* })`,
+/// where `Name` is an identifier to name the table or singleton (in which case it is also the key),
 /// `KeyType` and `ValueType` are types, `ValueKind` is `u64 | ValueType as (Box | Arc | Ref)`.
 /// `owner` is an expression which evaluates to an `Owner`. `Name` is used as a type argument to
 /// KvStore methods to identify the table or singletone.
@@ -273,7 +279,7 @@ macro_rules! store {
             )
         ),* $(,)? })?
     ) => {
-        $($($crate::singleton!($sname $sbody );)*)?
+        $($($crate::singleton!($sname $sbody, TableStorage);)*)?
         $($(
             /// Describes a table in the KV store.
             #[derive(Default)]
@@ -322,7 +328,8 @@ macro_rules! store {
         #[derive(Default)]
         #[allow(non_snake_case)]
         pub struct TableStorage {
-            $($($name: $crate::storage::Table<$name, index::$name::Indexes>),*)?
+            $($($name: $crate::storage::Table<$name, index::$name::Indexes>,)*)?
+            $($($sname: $crate::storage::VersionedValue<$crate::storage::SinValue>,)*)?
         }
 
         impl $crate::schema::GeneratedStorage for TableStorage {
@@ -346,6 +353,11 @@ macro_rules! store {
                     $(
                         self.$name.gc_txn(_txn_id);
                         $(self.$name.indexes.$field.gc_txn(_txn_id);)*
+                    )*
+                )?
+                $(
+                    $(
+                        self.$sname.gc_txn(_txn_id);
                     )*
                 )?
             }
@@ -491,8 +503,8 @@ macro_rules! on_insert_each {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! singleton {
-    ($name:ident(u64; $owner:expr)) => {
-        $crate::singleton_types!($name(u64, u64, U64), $owner);
+    ($name:ident(u64; $owner:expr), $storage:ident) => {
+        $crate::singleton_types!($name(u64, u64, U64), $owner, $storage);
 
         impl $crate::schema::MutSingleton for $name {
             fn from_value_mut(value: &mut $crate::storage::SinValue) -> &mut Self::Value {
@@ -503,8 +515,8 @@ macro_rules! singleton {
             }
         }
     };
-    ($name:ident($value_ty:ty as Box; $owner:expr)) => {
-        $crate::singleton_types!($name($value_ty, $value_ty, Box), $owner);
+    ($name:ident($value_ty:ty as Box; $owner:expr), $storage:ident) => {
+        $crate::singleton_types!($name($value_ty, $value_ty, Box), $owner, $storage);
 
         impl $crate::schema::MutSingleton for $name {
             fn from_value_mut(value: &mut $crate::storage::SinValue) -> &mut Self::Value {
@@ -515,20 +527,24 @@ macro_rules! singleton {
             }
         }
     };
-    ($name:ident($value_ty:ty as Arc; $owner:expr)) => {
-        $crate::singleton_types!($name($value_ty, std::sync::Arc<$value_ty>, Arc), $owner);
+    ($name:ident($value_ty:ty as Arc; $owner:expr), $storage:ident) => {
+        $crate::singleton_types!(
+            $name($value_ty, std::sync::Arc<$value_ty>, Arc),
+            $owner,
+            $storage
+        );
 
         impl $crate::schema::ArcSingleton for $name {}
     };
-    ($name:ident($value_ty:ty as Ref; $owner:expr)) => {
-        $crate::singleton_types!($name($value_ty, &'static $value_ty, Ref), $owner);
+    ($name:ident($value_ty:ty as Ref; $owner:expr), $storage:ident) => {
+        $crate::singleton_types!($name($value_ty, &'static $value_ty, Ref), $owner, $storage);
     };
 }
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! singleton_types {
-    ($name:ident($value_ty:ty, $arg_value_ty:ty, $variant:ident), $owner:expr) => {
+    ($name:ident($value_ty:ty, $arg_value_ty:ty, $variant:ident), $owner:expr, $storage:ident) => {
         /// Describes a singleton in the KV store.
         #[allow(non_camel_case_types)]
         pub struct $name;
@@ -537,6 +553,7 @@ macro_rules! singleton_types {
             const OWNER: $crate::Owner = $owner;
             type Value = $value_ty;
             type ArgValue = $arg_value_ty;
+            type Storage = $storage;
 
             fn from_value(value: $crate::storage::SinValue) -> Self::ArgValue {
                 match value {
@@ -558,6 +575,18 @@ macro_rules! singleton_types {
 
             fn to_value(value: Self::ArgValue) -> $crate::storage::SinValue {
                 $crate::init_helper!($variant, value)
+            }
+
+            fn field_ref(
+                storage: &Self::Storage,
+            ) -> &$crate::storage::VersionedValue<$crate::storage::SinValue> {
+                &storage.$name
+            }
+
+            fn field_ref_mut(
+                storage: &mut Self::Storage,
+            ) -> &mut $crate::storage::VersionedValue<$crate::storage::SinValue> {
+                &mut storage.$name
             }
         }
     };

--- a/ts_kv_store/src/schema.rs
+++ b/ts_kv_store/src/schema.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use crate::{
+    Owner,
     storage::{SinValue, Table},
     transactions::TxnId,
 };
@@ -15,6 +16,9 @@ use crate::{
 ///
 /// Prefer to use the macros in this module rather than this trait directly.
 pub trait Singleton: 'static {
+    /// The datum's owner.
+    const OWNER: Owner;
+
     /// The type of the value.
     type Value: Any + Send + Sync;
     /// The type used to initialize and access the value. For values stored as `Arc`s this should be
@@ -68,6 +72,9 @@ pub trait MutSingleton: Singleton {
 pub trait TableDesc: Sized + 'static {
     /// The name of the table.
     const NAME: &'static str;
+    /// The table's owner.
+    const OWNER: Owner;
+
     /// The type of the key.
     type Key: Hash + Eq + Clone;
     /// The type of the value.
@@ -192,18 +199,20 @@ pub trait GeneratedStorage: Default {
 ///
 /// # Syntax:
 ///
-/// - `singleton!(u64)` to declare a value with type `u64` and inline storage.
-/// - `singleton!(ValueType as Box)` to declare a value with type `Box<ValueType>`.
-/// - `singleton!(ValueType as Arc)` to declare a value with type `Arc<ValueType>`.
-/// - `singleton!(ValueType as Ref)` to declare a value with type `&'static ValueType`.
+/// - `singleton!(u64; owner)` to declare a value with type `u64` and inline storage.
+/// - `singleton!(ValueType as Box; owner)` to declare a value with type `Box<ValueType>`.
+/// - `singleton!(ValueType as Arc; owner)` to declare a value with type `Arc<ValueType>`.
+/// - `singleton!(ValueType as Ref; owner)` to declare a value with type `&'static ValueType`.
 ///
 /// The storage class is separate to the value type since they have different representations in the
 /// store and slightly different APIs (e.g., whether mutable access is supported or access by cloning
 /// or copying a shared reference).
+///
+/// `owner` is an expression which evaluates to an `Owner` to specify the owner of the data.
 #[macro_export]
 macro_rules! singleton {
-    ($name:ident(u64)) => {
-        $crate::singleton_types!($name(u64, u64, U64));
+    ($name:ident(u64; $owner:expr)) => {
+        $crate::singleton_types!($name(u64, u64, U64), $owner);
 
         impl $crate::schema::MutSingleton for $name {
             fn from_value_mut(value: &mut $crate::storage::SinValue) -> &mut Self::Value {
@@ -214,8 +223,8 @@ macro_rules! singleton {
             }
         }
     };
-    ($name:ident($value_ty:ty as Box)) => {
-        $crate::singleton_types!($name($value_ty, $value_ty, Box));
+    ($name:ident($value_ty:ty as Box; $owner:expr)) => {
+        $crate::singleton_types!($name($value_ty, $value_ty, Box), $owner);
 
         impl $crate::schema::MutSingleton for $name {
             fn from_value_mut(value: &mut $crate::storage::SinValue) -> &mut Self::Value {
@@ -226,25 +235,26 @@ macro_rules! singleton {
             }
         }
     };
-    ($name:ident($value_ty:ty as Arc)) => {
-        $crate::singleton_types!($name($value_ty, std::sync::Arc<$value_ty>, Arc));
+    ($name:ident($value_ty:ty as Arc; $owner:expr)) => {
+        $crate::singleton_types!($name($value_ty, std::sync::Arc<$value_ty>, Arc), $owner);
 
         impl $crate::schema::ArcSingleton for $name {}
     };
-    ($name:ident($value_ty:ty as Ref)) => {
-        $crate::singleton_types!($name($value_ty, &'static $value_ty, Ref));
+    ($name:ident($value_ty:ty as Ref; $owner:expr)) => {
+        $crate::singleton_types!($name($value_ty, &'static $value_ty, Ref), $owner);
     };
 }
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! singleton_types {
-    ($name:ident($value_ty:ty, $arg_value_ty:ty, $variant:ident)) => {
+    ($name:ident($value_ty:ty, $arg_value_ty:ty, $variant:ident), $owner:expr) => {
         /// Describes a singleton in the KV store.
         #[allow(non_camel_case_types)]
         pub struct $name;
 
         impl $crate::schema::Singleton for $name {
+            const OWNER: $crate::Owner = $owner;
             type Value = $value_ty;
             type ArgValue = $arg_value_ty;
 
@@ -342,34 +352,41 @@ macro_rules! match_helper_rhs_mut {
 
 /// Declare the tables in a key/value store. Generates the store itself with the specified tables.
 ///
-/// The syntax is `tables!(Name(KeyType, ValueType indexes?),*)`, where `Name` is an identifier to name
-/// the table, and `KeyType` and `ValueType` are types. `Name` is used as a type argument to
-/// KvStore methods to identify the table. Use with an empty list of tables to generate a store
-/// for use only with singleton key/value pairs.
+/// The syntax is `tables!(Name(KeyType => ValueType; owner; indexes?),*)`, where `Name` is an
+/// identifier to name the table, `KeyType` and `ValueType` are types, and `owner` is an expression
+/// which evaluates to an `Owner`. `Name` is used as a type argument to KvStore methods to identify
+/// the table.
+///
+/// Use with an empty list of tables to generate a store for use only with singleton key/value pairs.
 ///
 /// # Example:
 ///
 /// ```rust
 /// # use ts_kv_store::tables;
+/// # const NODES_OWNER: ts_kv_store::Owner = "foo";
+/// # const EDGES_OWNER: ts_kv_store::Owner = "bar";
 /// # pub struct Node;
 /// # pub trait Edge {}
 /// tables!(
-///   Nodes(&'static str => Node),
-///   Edges(u32 => Box<dyn Edge + Send + Sync>)
+///   Nodes(&'static str => Node; NODES_OWNER),
+///   Edges(u32 => Box<dyn Edge + Send + Sync>; EDGES_OWNER)
 /// );
 /// ```
+///
 /// # Indexes
 ///
-/// The syntax of an index is `index(field: Type)` where `field` is the name of a field in the value
-/// type of the base table and `Type` is the type of that field. You can specify multiple indexes
-/// for each table, separated with a semicolon. E.g.,
+/// The syntax of an index is `index(field: Type(; assert_unique)?)` where `field` is the name of
+/// a field in the value type of the base table and `Type` is the type of that field. You can
+/// specify multiple indexes for each table, separated with a semicolon. E.g.,
 ///
 /// ```rust
 /// # use ts_kv_store::tables;
+/// # const NODES_OWNER: ts_kv_store::Owner = "foo";
 /// # pub struct Node { a: u32, b: String };
 /// tables!(
 ///   Nodes(
 ///     &'static str => Node;
+///     NODES_OWNER;
 ///     index(a: u32);
 ///     index(b: String; assert_unique);
 ///     index(c: String = |node: &Node| [format!("{}-{}", node.a, node.b)]);
@@ -389,7 +406,7 @@ macro_rules! match_helper_rhs_mut {
 /// attempting to store multiple rows with the same index key will cause a panic.
 #[macro_export]
 macro_rules! tables {
-    ($($name: ident ($key_ty: ty => $value_ty: ty $(; index($field: ident: $field_ty: ty $(= $get_idx: expr)? $(; $unique:ident)?))* $(;)?)),*) => {
+    ($($name: ident ($key_ty: ty => $value_ty: ty; $owner: expr $(; index($field: ident: $field_ty: ty $(= $get_idx: expr)? $(; $unique:ident)?))* $(;)?)),*) => {
         $(
             /// Describes a table in the KV store.
             #[derive(Default)]
@@ -397,6 +414,7 @@ macro_rules! tables {
 
             impl $crate::schema::TableDesc for $name {
                 const NAME: &'static str = stringify!($name);
+                const OWNER: $crate::Owner = $owner;
                 type Key = $key_ty;
                 type Value = $value_ty;
                 type Storage = TableStorage;
@@ -413,6 +431,7 @@ macro_rules! tables {
             $(
                 impl $crate::schema::TableDesc for index::$name::$field where $field_ty: Clone {
                     const NAME: &'static str = stringify!($name by $field);
+                    const OWNER: $crate::Owner = $owner;
                     type Key = $field_ty;
                     type Value = $key_ty;
                     type Storage = TableStorage;
@@ -606,10 +625,10 @@ mod test {
 
     #[test]
     fn single() {
-        singleton!(Foo(u64 as Box));
-        singleton!(Bar(u64 as Arc));
-        singleton!(Baz(u64 as Ref));
-        singleton!(Qux(u64));
+        singleton!(Foo(u64 as Box; "owner"));
+        singleton!(Bar(u64 as Arc; "owner"));
+        singleton!(Baz(u64 as Ref; "owner"));
+        singleton!(Qux(u64; "owner"));
 
         assert_eq!(&42, Foo::from_value_ref(&Foo::to_value(42)));
         assert_eq!(&42, Bar::from_value_ref(&Bar::to_value(Arc::new(42))));
@@ -625,7 +644,7 @@ mod test {
 
     #[test]
     fn table() {
-        tables!(Foo(&'static str => String), Bar(u32 => Vec<String>));
+        tables!(Foo(&'static str => String; "owner"), Bar(u32 => Vec<String>; "owner"));
 
         let store = KvStore::new();
 
@@ -650,8 +669,8 @@ mod test {
             a: String,
         }
         tables!(
-            Foo(&'static str => String; index(len: usize = |v: &String| [v.len()])),
-            Bar(u32 => BarT; index(a: String; assert_unique))
+            Foo(&'static str => String; "owner"; index(len: usize = |v: &String| [v.len()])),
+            Bar(u32 => BarT; "owner"; index(a: String; assert_unique))
         );
 
         let store = KvStore::new();

--- a/ts_kv_store/src/storage.rs
+++ b/ts_kv_store/src/storage.rs
@@ -602,9 +602,11 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
 
     /// Check if this table's transaction state is consistent for commit.
     ///
-    /// Must be called before calling `commit_txn`. In theory, because of the global lock, this
-    /// should never happen. But if we were to allow transactions to be timed-out (or multiple
+    /// Must be called before calling `commit_txn`. In theory, because of the global lock, the transaction
+    /// should not conflict. But if we were to allow transactions to be timed-out (or multiple
     /// mutating transaction), or in the presence of unsafe code, then inconsistency could happen.
+    ///
+    /// This will error too if an index has been poisoned during the transaction.
     pub fn check_txn_consistency(&self, txn_id: TxnId) -> Result<()> {
         if let Some(modified) = &self.modified
             && modified.txn_id != txn_id
@@ -799,11 +801,7 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
     {
-        if txn_id == max_committed_id {
-            if let Some(value) = self.data.remove(key).and_then(|mut v| v.take(txn_id)) {
-                self.indexes.on_remove(&value, txn_id, max_committed_id);
-            }
-        } else if txn_id > max_committed_id {
+        if txn_id > max_committed_id {
             let dm_result = self.delete_mask.remove(key, txn_id, &self.data);
             if let Some(value) = dm_result
                 .as_ref()
@@ -813,19 +811,17 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
             }
         } else {
             unreachable!(
-                "current transaction id less than committed id: {txn_id:?} < {max_committed_id:?}"
+                "current transaction id less than committed id: {txn_id:?} <= {max_committed_id:?}"
             );
         }
     }
 
     pub fn clear(&mut self, txn_id: TxnId, max_committed_id: TxnId) {
-        if txn_id == max_committed_id {
-            self.data.clear();
-        } else if txn_id > max_committed_id {
+        if txn_id > max_committed_id {
             self.delete_mask.clear(txn_id);
         } else {
             unreachable!(
-                "current transaction id less than committed id: {txn_id:?} < {max_committed_id:?}"
+                "current transaction id less than committed id: {txn_id:?} <= {max_committed_id:?}"
             );
         }
 

--- a/ts_kv_store/src/storage.rs
+++ b/ts_kv_store/src/storage.rs
@@ -1,5 +1,5 @@
 use std::{
-    any::{Any, TypeId},
+    any::Any,
     borrow::Borrow,
     collections::{HashMap, HashSet},
     hash::Hash,
@@ -15,9 +15,6 @@ use crate::{
 /// Where we store the data.
 #[doc(hidden)]
 pub struct Storage<TableStorage: schema::GeneratedStorage> {
-    /// The key is the TypeId of the generated marker type for the KV data. See [`SinValue`] for
-    /// how values are represented in the store.
-    pub(crate) singletons: HashMap<TypeId, VersionedValue<SinValue>>,
     /// Storage for tabular data. The concrete type will be macro-generated, see the [`crate::schema`]
     /// module.
     pub(crate) tables: TableStorage,
@@ -25,13 +22,11 @@ pub struct Storage<TableStorage: schema::GeneratedStorage> {
     /// The id of the most-recently committed transaction.
     pub(crate) committed: TxnId,
     /// `None` if there is no transaction in progress. `Some` if there is a transaction in progress
-    /// or a transaction has been aborted without proper rollback. The `Vec` tracks the keys of
-    /// singleton key-values modified during this transaction. It may be an over-approximation, but
-    /// not an under-approximation. `pending_txn` must not be cleared until a transaction has been
-    /// fully committed or fully rolled-back.
+    /// or a transaction has been aborted without proper rollback. `pending_txn` must not be cleared
+    /// until a transaction has been fully committed or fully rolled-back.
     ///
     /// `self.tables` may only contain un-committed state if `pending_txn.is_some()`.
-    pending_txn: Option<(TxnId, Vec<TypeId>)>,
+    pending_txn: Option<TxnId>,
     /// Counter for creating new transaction ids.
     next_txn: TxnId,
 }
@@ -41,7 +36,6 @@ impl<TableStorage: schema::GeneratedStorage> Storage<TableStorage> {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Storage {
-            singletons: HashMap::new(),
             tables: TableStorage::default(),
             committed: TxnId::FIRST,
             pending_txn: None,
@@ -59,71 +53,48 @@ impl<TableStorage: schema::GeneratedStorage> Storage<TableStorage> {
     }
 
     pub(crate) fn current_txn(&self) -> Option<TxnId> {
-        self.pending_txn.as_ref().map(|(id, _)| *id)
+        self.pending_txn
     }
 
     pub(crate) fn max_committed_id(&self) -> TxnId {
         self.committed
     }
 
-    fn record_mutation(&mut self, key: TypeId, txn_id: TxnId) {
-        if self.committed != txn_id
-            && let Some((id, modified)) = &mut self.pending_txn
-        {
-            assert_eq!(*id, txn_id);
-            modified.push(key);
-        }
-    }
-
-    pub(crate) fn insert_singleton<D: schema::Singleton>(
+    pub(crate) fn insert_singleton<D: schema::Singleton<Storage = TableStorage>>(
         &mut self,
-        key: TypeId,
         value: D::ArgValue,
         txn_id: TxnId,
     ) {
-        self.record_mutation(key, txn_id);
-        match self.singletons.get_mut(&key) {
-            Some(v) => {
-                v.set(D::to_value(value), txn_id);
-            }
-            None => {
-                self.singletons
-                    .insert(key, VersionedValue::new(D::to_value(value), txn_id));
-            }
-        }
+        D::field_ref_mut(&mut self.tables).set(D::to_value(value), txn_id);
     }
 
-    pub(crate) fn remove_singleton(&mut self, key: TypeId, txn_id: TxnId) {
-        self.record_mutation(key, txn_id);
-        if let Some(value) = self.singletons.get_mut(&key) {
-            value.set(SinValue::None, txn_id);
-        }
+    pub(crate) fn remove_singleton<D: schema::Singleton<Storage = TableStorage>>(
+        &mut self,
+        txn_id: TxnId,
+    ) {
+        D::field_ref_mut(&mut self.tables).set(SinValue::None, txn_id);
     }
 
     /// Retrieve a singleton value from the store using the given type-key.
-    pub(crate) fn get_singleton_value<D: schema::Singleton>(
+    pub(crate) fn get_singleton_value<D: schema::Singleton<Storage = TableStorage>>(
         &self,
-        key: TypeId,
         txn_id: TxnId,
     ) -> Option<&D::Value> {
-        let value = self.singletons.get(&key);
-        map_singleton_value(value, txn_id, |v| D::from_value_ref(v))
+        map_singleton_value(D::field_ref(&self.tables), txn_id, |v| D::from_value_ref(v))
     }
 
     /// Retrieve a singleton value from the store using the given type-key.
-    pub(crate) fn get_singleton_arc<D: schema::ArcSingleton>(
+    pub(crate) fn get_singleton_arc<D: schema::ArcSingleton<Storage = TableStorage>>(
         &self,
-        key: TypeId,
         txn_id: TxnId,
     ) -> Option<Arc<D::Value>> {
-        let value = self.singletons.get(&key);
-        map_singleton_value(value, txn_id, |v| D::from_value_arc(v))
+        map_singleton_value(D::field_ref(&self.tables), txn_id, |v| D::from_value_arc(v))
     }
 
     /// Begin a new transaction. Returns the transactions unique id.
     pub(crate) fn begin_transaction(&mut self) -> TxnId {
         let new_txn_id = self.next_txn;
-        self.pending_txn = Some((new_txn_id, Vec::new()));
+        self.pending_txn = Some(new_txn_id);
         self.next_txn = new_txn_id.next();
         new_txn_id
     }
@@ -132,7 +103,7 @@ impl<TableStorage: schema::GeneratedStorage> Storage<TableStorage> {
     /// current transaction does not match the `txn_id` (which should be impossible with only safe
     /// code).
     pub(crate) fn commit_transaction(&mut self, txn_id: TxnId) -> Result<()> {
-        let Some((pending_txn, _)) = self.pending_txn else {
+        let Some(pending_txn) = self.pending_txn else {
             return Err(Error::TransactionFailed);
         };
         if pending_txn != txn_id {
@@ -149,7 +120,7 @@ impl<TableStorage: schema::GeneratedStorage> Storage<TableStorage> {
     /// transaction, then nothing happens (the `txn_id` transaction must already have been committed
     /// or rolled back).
     pub(crate) fn rollback_transaction(&mut self, txn_id: TxnId) {
-        let Some((pending_txn, _)) = self.pending_txn else {
+        let Some(pending_txn) = self.pending_txn else {
             return;
         };
         if pending_txn != txn_id {
@@ -162,17 +133,7 @@ impl<TableStorage: schema::GeneratedStorage> Storage<TableStorage> {
     /// Garbage-collects the remnants of any in-progress transaction, leaving the store ready to begin
     /// another transaction or perform raw operations.
     pub(crate) fn clear_transaction(&mut self) {
-        if let Some((id, modified)) = &self.pending_txn {
-            for k in modified {
-                let Some(v) = self.singletons.get_mut(k) else {
-                    continue;
-                };
-                v.gc_txn(*id);
-
-                if v.is_empty() {
-                    self.singletons.remove(k);
-                }
-            }
+        if let Some(id) = &self.pending_txn {
             self.tables.gc_txn(*id);
             // Must do this last so it is only cleared if we've successfully GCed the store.
             self.pending_txn = None;
@@ -199,11 +160,11 @@ pub enum SinValue {
 }
 
 fn map_singleton_value<'a, T>(
-    value: Option<&'a VersionedValue<SinValue>>,
+    value: &'a VersionedValue<SinValue>,
     id: TxnId,
     f: impl FnOnce(&'a SinValue) -> T,
 ) -> Option<T> {
-    match value?.get(id)? {
+    match &value.get(id)? {
         SinValue::None => None,
         v => Some(f(v)),
     }
@@ -234,7 +195,7 @@ impl<T> VersionedValue<T> {
         }
     }
 
-    fn gc_txn(&mut self, txn_id: TxnId) {
+    pub fn gc_txn(&mut self, txn_id: TxnId) {
         if let Some((id, _)) = self.slot_a
             && id == txn_id
         {
@@ -1122,8 +1083,6 @@ mod txn_test {
     // (operating on `Storage` directly) do not use.
     #![allow(dead_code)]
 
-    use std::any::TypeId;
-
     use crate::{Error, storage::Storage, store};
 
     store!(kvs: { Count(u64; "owner") });
@@ -1155,18 +1114,15 @@ mod txn_test {
     fn clear_transaction_rolls_back_and_frees_singleton_entry() {
         let mut storage = Storage::<TableStorage>::new();
         let id = storage.begin_transaction();
-        let key = TypeId::of::<Count>();
-        storage.insert_singleton::<Count>(key, 42, id);
+        storage.insert_singleton::<Count>(42, id);
         // Visible to the in-progress transaction.
-        assert_eq!(storage.get_singleton_value::<Count>(key, id), Some(&42));
+        assert_eq!(storage.get_singleton_value::<Count>(id), Some(&42));
 
         // Simulate cleanup of an abandoned transaction.
         storage.clear_transaction();
 
         assert!(storage.current_txn().is_none());
         let now = storage.txn_id();
-        assert!(storage.get_singleton_value::<Count>(key, now).is_none());
-        // The emptied entry was freed, not left as a dead `VersionedValue`.
-        assert!(!storage.singletons.contains_key(&key));
+        assert!(storage.get_singleton_value::<Count>(now).is_none());
     }
 }

--- a/ts_kv_store/src/storage.rs
+++ b/ts_kv_store/src/storage.rs
@@ -17,7 +17,7 @@ use crate::{
 pub struct Storage<TableStorage: schema::GeneratedStorage> {
     /// The key is the TypeId of the generated marker type for the KV data. See [`SinValue`] for
     /// how values are represented in the store.
-    pub(crate) singletons: HashMap<TypeId, (Owner, VersionedValue<SinValue>)>,
+    pub(crate) singletons: HashMap<TypeId, VersionedValue<SinValue>>,
     /// Storage for tabular data. The concrete type will be macro-generated, see the [`crate::schema`]
     /// module.
     pub(crate) tables: TableStorage,
@@ -78,28 +78,24 @@ impl<TableStorage: schema::GeneratedStorage> Storage<TableStorage> {
     pub(crate) fn insert_singleton<D: schema::Singleton>(
         &mut self,
         key: TypeId,
-        owner: Owner,
         value: D::ArgValue,
         txn_id: TxnId,
     ) {
         self.record_mutation(key, txn_id);
         match self.singletons.get_mut(&key) {
-            Some((_, v)) => {
+            Some(v) => {
                 v.set(D::to_value(value), txn_id);
             }
             None => {
-                self.singletons.insert(
-                    key,
-                    (owner, VersionedValue::new(D::to_value(value), txn_id)),
-                );
+                self.singletons
+                    .insert(key, VersionedValue::new(D::to_value(value), txn_id));
             }
         }
     }
 
     pub(crate) fn remove_singleton(&mut self, key: TypeId, txn_id: TxnId) {
         self.record_mutation(key, txn_id);
-        if let Some((_, value)) = self.singletons.get_mut(&key) {
-            // TODO ownership is wrong, but we're getting rid of dynamic ownership
+        if let Some(value) = self.singletons.get_mut(&key) {
             value.set(SinValue::None, txn_id);
         }
     }
@@ -110,7 +106,7 @@ impl<TableStorage: schema::GeneratedStorage> Storage<TableStorage> {
         key: TypeId,
         txn_id: TxnId,
     ) -> Option<&D::Value> {
-        let value = self.singletons.get(&key).map(|(_, v)| v);
+        let value = self.singletons.get(&key);
         map_singleton_value(value, txn_id, |v| D::from_value_ref(v))
     }
 
@@ -120,14 +116,8 @@ impl<TableStorage: schema::GeneratedStorage> Storage<TableStorage> {
         key: TypeId,
         txn_id: TxnId,
     ) -> Option<Arc<D::Value>> {
-        let value = self.singletons.get(&key).map(|(_, v)| v);
+        let value = self.singletons.get(&key);
         map_singleton_value(value, txn_id, |v| D::from_value_arc(v))
-    }
-
-    /// Retrieve the owner of a singleton KV pair using the given type-key.
-    #[cfg(debug_assertions)]
-    pub(crate) fn get_singleton_owner(&self, key: TypeId) -> Option<Owner> {
-        self.singletons.get(&key).map(|(o, _)| *o)
     }
 
     /// Begin a new transaction. Returns the transactions unique id.
@@ -174,7 +164,7 @@ impl<TableStorage: schema::GeneratedStorage> Storage<TableStorage> {
     pub(crate) fn clear_transaction(&mut self) {
         if let Some((id, modified)) = &self.pending_txn {
             for k in modified {
-                let Some((_, v)) = self.singletons.get_mut(k) else {
+                let Some(v) = self.singletons.get_mut(k) else {
                     continue;
                 };
                 v.gc_txn(*id);
@@ -546,8 +536,6 @@ enum MaskInsertResult<K, V> {
 /// implementing `TableStorage` in [`Storage`].
 #[doc(hidden)]
 pub struct Table<D: schema::TableDesc, I> {
-    /// Owner of the table.
-    pub(crate) owner: Option<Owner>,
     /// KV data.
     data: HashMap<D::Key, VersionedValue<D::Value>>,
     /// A mask of deleted rows in the table. Should be checked before reading from `data`.
@@ -567,7 +555,6 @@ pub struct Table<D: schema::TableDesc, I> {
 impl<D: schema::TableDesc, I: Default> Default for Table<D, I> {
     fn default() -> Self {
         Self {
-            owner: None,
             data: HashMap::new(),
             delete_mask: DeleteMask::None,
             modified: None,
@@ -578,16 +565,6 @@ impl<D: schema::TableDesc, I: Default> Default for Table<D, I> {
 }
 
 impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
-    pub(crate) fn try_set_owner(&mut self, owner: Owner) -> Result<()> {
-        match &self.owner {
-            Some(owner) => Err(Error::AlreadyInit(owner)),
-            None => {
-                self.owner = Some(owner);
-                Ok(())
-            }
-        }
-    }
-
     pub fn set_poisoned(&mut self, txn_id: TxnId) {
         self.poisoned.set(true, txn_id);
     }
@@ -857,25 +834,13 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
         self.indexes.clear(txn_id, max_committed_id);
     }
 
-    pub(crate) fn assert_or_set_owner(&mut self, owner: Owner) {
-        match &self.owner {
-            Some(prev_owner) => debug_assert_eq!(
-                *prev_owner, owner,
-                "Ownership violation: expected {prev_owner}, found {owner}"
-            ),
-            None => {
-                self.owner = Some(owner);
-            }
-        }
-    }
-
     pub(crate) fn assert_owner(&mut self, owner: Owner) {
-        if let Some(prev_owner) = &self.owner {
-            debug_assert_eq!(
-                *prev_owner, owner,
-                "Ownership violation: expected {prev_owner}, found {owner}"
-            );
-        }
+        debug_assert_eq!(
+            D::OWNER,
+            owner,
+            "Ownership violation: expected {}, found {owner}",
+            D::OWNER,
+        );
     }
 }
 
@@ -1163,7 +1128,7 @@ mod txn_test {
 
     use crate::{Error, singleton, storage::Storage, tables};
 
-    singleton!(Count(u64));
+    singleton!(Count(u64; "owner"));
     tables!();
 
     #[test]
@@ -1194,7 +1159,7 @@ mod txn_test {
         let mut storage = Storage::<TableStorage>::new();
         let id = storage.begin_transaction();
         let key = TypeId::of::<Count>();
-        storage.insert_singleton::<Count>(key, "owner", 42, id);
+        storage.insert_singleton::<Count>(key, 42, id);
         // Visible to the in-progress transaction.
         assert_eq!(storage.get_singleton_value::<Count>(key, id), Some(&42));
 

--- a/ts_kv_store/src/storage.rs
+++ b/ts_kv_store/src/storage.rs
@@ -1124,10 +1124,9 @@ mod txn_test {
 
     use std::any::TypeId;
 
-    use crate::{Error, singleton, storage::Storage, tables};
+    use crate::{Error, storage::Storage, store};
 
-    singleton!(Count(u64; "owner"));
-    tables!();
+    store!(kvs: { Count(u64; "owner") });
 
     #[test]
     fn commit_with_mismatched_id_fails() {

--- a/ts_kv_store/src/storage.rs
+++ b/ts_kv_store/src/storage.rs
@@ -714,7 +714,6 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
             MaskStatus::Overwritten(v) => v,
         };
 
-        // TODO we could be more efficient and only update indexes if the foreign key changes
         self.indexes.on_remove(value, txn_id, max_committed_id);
         record_mutation(&mut self.modified, key, txn_id, max_committed_id);
         let result = f(value);
@@ -747,22 +746,25 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
     ) where
         D::Value: Clone,
     {
-        // TODO could be more efficient by only updating if value is changed
         match &mut self.delete_mask {
-            DeleteMask::None => Self::iter_data_mut(&mut self.data, txn_id).for_each(|(k, v)| {
-                self.indexes.on_remove(v, txn_id, max_committed_id);
-                record_mutation(&mut self.modified, k, txn_id, max_committed_id);
-                f(k, v);
-                self.indexes.on_insert(k, v, txn_id, max_committed_id);
-            }),
-            DeleteMask::All(_, pending) => pending.iter_mut().for_each(|(k, v)| {
-                if let Some(v) = v.get_mut(txn_id) {
-                    self.indexes.on_remove(v, txn_id, max_committed_id);
+            DeleteMask::None => {
+                self.indexes.clear(txn_id, max_committed_id);
+                Self::iter_data_mut(&mut self.data, txn_id).for_each(|(k, v)| {
                     record_mutation(&mut self.modified, k, txn_id, max_committed_id);
                     f(k, v);
                     self.indexes.on_insert(k, v, txn_id, max_committed_id);
-                }
-            }),
+                })
+            }
+            DeleteMask::All(_, pending) => {
+                self.indexes.clear(txn_id, max_committed_id);
+                pending.iter_mut().for_each(|(k, v)| {
+                    if let Some(v) = v.get_mut(txn_id) {
+                        record_mutation(&mut self.modified, k, txn_id, max_committed_id);
+                        f(k, v);
+                        self.indexes.on_insert(k, v, txn_id, max_committed_id);
+                    }
+                })
+            }
             DeleteMask::Some(_, removed) => {
                 Self::iter_data_mut(&mut self.data, txn_id).for_each(|(k, v)| {
                     if removed.contains(k) {

--- a/ts_kv_store/src/transactions.rs
+++ b/ts_kv_store/src/transactions.rs
@@ -237,16 +237,11 @@ impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableSt
     }
 
     /// Insert a single value into the store.
-    ///
-    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
-    // Question: do we need separate insert/update/upsert methods?
     pub fn insert<D: schema::Singleton>(&mut self, value: D::ArgValue) {
         <&mut Self as SingletonOpsMut<_>>::insert::<D>(self, value, self.owner)
     }
 
     /// Remove a single value from the store.
-    ///
-    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn remove<D: schema::Singleton>(&mut self) {
         <&mut Self as SingletonOpsMut<_>>::remove::<D>(self, self.owner)
     }
@@ -286,17 +281,6 @@ impl<'guard, D: TableDesc> TabularOpsMut<D::Storage> for &mut KvTableTransaction
 }
 
 impl<'guard, D: TableDesc> KvTableTransactional<'guard, '_, D> {
-    /// Initialize a table by setting its owner.
-    ///
-    /// Calling this function is optional, a table can be used without initialization in which case,
-    /// its owner is set to the owner specified in the first write.
-    ///
-    /// Returns an error (containing the current owner of the table) if the table has already been
-    /// initialized. In this case, the table will be in a consistent state and can be used as normal.
-    pub fn init(&mut self) -> Result<()> {
-        <&mut Self as TabularOpsMut<_>>::init(self, self.txn.owner)
-    }
-
     /// The number of key/value pairs in the table.
     pub fn len(&self) -> usize {
         <&Self as TabularOps<_>>::len(self)
@@ -307,7 +291,7 @@ impl<'guard, D: TableDesc> KvTableTransactional<'guard, '_, D> {
         <&Self as TabularOps<_>>::is_empty(self)
     }
 
-    /// Clear a table by removing all its KVs, but preserving ownership.
+    /// Clear a table by removing all its KVs.
     pub fn clear(&mut self) {
         <&mut Self as TabularOpsMut<_>>::clear(self, self.txn.owner)
     }
@@ -336,8 +320,6 @@ impl<'guard, D: TableDesc> KvTableTransactional<'guard, '_, D> {
     }
 
     /// Insert a value into the table.
-    ///
-    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn insert(&mut self, key: D::Key, value: D::Value)
     where
         D::Key: Clone,
@@ -358,8 +340,6 @@ impl<'guard, D: TableDesc> KvTableTransactional<'guard, '_, D> {
     }
 
     /// Remove a row from the table.
-    ///
-    /// Returns the previous value if there is one, or `None` if there is no value for the specified key.
     pub fn remove<Q>(&mut self, key: &Q)
     where
         D::Key: Borrow<Q>,
@@ -566,12 +546,12 @@ impl<'guard, D: TableDesc> KvTableRoTransactional<'guard, '_, D> {
 mod test {
     use std::{any::Any, sync::Arc};
 
-    use crate::{Error, singleton, tables};
+    use crate::{singleton, tables};
 
-    singleton!(Count(u64));
-    singleton!(Shared(String as Arc));
+    singleton!(Count(u64; OWNER));
+    singleton!(Shared(String as Arc; OWNER));
 
-    tables!(Items(&'static str => String), Counters(u32 => u64));
+    tables!(Items(&'static str => String; OWNER), Counters(u32 => u64; OWNER));
 
     const OWNER: &str = "owner";
     #[cfg(debug_assertions)]
@@ -771,24 +751,6 @@ mod test {
     }
 
     #[test]
-    fn txn_table_init_succeeds() {
-        let store = KvStore::new();
-        let mut txn = store.begin_transaction(OWNER);
-        let mut table = txn.table::<Items>();
-        assert!(table.init().is_ok());
-    }
-
-    #[test]
-    fn txn_table_init_second_call_err() {
-        let store = KvStore::new();
-        let mut txn = store.begin_transaction(OWNER);
-        let mut table = txn.table::<Items>();
-        table.init().unwrap();
-        let err = table.init().unwrap_err();
-        assert!(matches!(err, Error::AlreadyInit(o) if o == OWNER));
-    }
-
-    #[test]
     fn txn_table_get_returns_none_when_absent() {
         let store = KvStore::new();
         let mut txn = store.begin_transaction(OWNER);
@@ -832,7 +794,6 @@ mod test {
         let store = KvStore::new();
         let mut txn = store.begin_transaction(OWNER);
         let mut table = txn.table::<Items>();
-        table.init().unwrap();
         assert!(table.with_mut(&"missing", |v| v.len()).is_none());
     }
 
@@ -1002,7 +963,6 @@ mod test {
     #[should_panic(expected = "Ownership violation")]
     fn txn_table_insert_wrong_owner_panics() {
         let store = KvStore::new();
-        store.table::<Items>(OWNER).init().unwrap();
         let mut txn = store.begin_transaction(OTHER);
         txn.table::<Items>().insert("k", "v".to_owned());
     }
@@ -1012,7 +972,6 @@ mod test {
     #[should_panic(expected = "Ownership violation")]
     fn txn_table_mutate_wrong_owner_panics() {
         let store = KvStore::new();
-        store.table::<Items>(OWNER).init().unwrap();
         let mut txn = store.begin_transaction(OTHER);
         txn.table::<Items>()
             .with_mut(&"k", |v: &mut String| v.len());
@@ -1023,7 +982,6 @@ mod test {
     #[should_panic(expected = "Ownership violation")]
     fn txn_table_remove_wrong_owner_panics() {
         let store = KvStore::new();
-        store.table::<Items>(OWNER).init().unwrap();
         let mut txn = store.begin_transaction(OTHER);
         txn.table::<Items>().remove(&"k");
     }

--- a/ts_kv_store/src/transactions.rs
+++ b/ts_kv_store/src/transactions.rs
@@ -249,7 +249,7 @@ impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableSt
 
 /// Abstracts a table of key/values pairs in the store accessed as part of a transaction.
 pub struct KvTableTransactional<'guard, 'txn, D: TableDesc> {
-    txn: &'txn mut Transaction<'guard, D::Storage>,
+    pub(crate) txn: &'txn mut Transaction<'guard, D::Storage>,
 }
 
 impl<'guard, 'txn, 'table, D: TableDesc> Ops<D::Storage>

--- a/ts_kv_store/src/transactions.rs
+++ b/ts_kv_store/src/transactions.rs
@@ -114,8 +114,6 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
         // presumably don't want to wait and we'd only need to retry if someone else grabbed the
         // the lock before we could.
     }
-
-    // TODO single-table transactions?
 }
 
 /// A read/write transaction over a [`KvStore`].

--- a/ts_kv_store/src/transactions.rs
+++ b/ts_kv_store/src/transactions.rs
@@ -574,14 +574,14 @@ impl<'guard, D: TableDesc> KvTableRoTransactional<'guard, '_, D> {
 
 #[cfg(test)]
 mod test {
-    use std::{any::Any, sync::Arc};
+    use std::sync::Arc;
 
-    use crate::{singleton, tables};
+    use crate::{singleton, store};
 
     singleton!(Count(u64; OWNER));
     singleton!(Shared(String as Arc; OWNER));
 
-    tables!(Items(&'static str => String; OWNER), Counters(u32 => u64; OWNER));
+    store!(tables: { Items(&'static str => String; OWNER), Counters(u32 => u64; OWNER) });
 
     const OWNER: &str = "owner";
     #[cfg(debug_assertions)]

--- a/ts_kv_store/src/transactions.rs
+++ b/ts_kv_store/src/transactions.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use crate::{
-    KvStore, Owner, Result,
+    KvStore, Owner, Result, StoreWithOwner,
     index::{KvTableRoTransactionalIndex, KvTableTransactionalIndex},
     operations::{Ops, OpsMut, SingletonOps, SingletonOpsMut, TabularOps, TabularOpsMut},
     schema::{self, TableDesc},
@@ -113,6 +113,38 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
         // We only try once, rather than loop because if the user is calling `try_begin_...`, they
         // presumably don't want to wait and we'd only need to retry if someone else grabbed the
         // the lock before we could.
+    }
+}
+
+impl<'a, TableStorage: schema::GeneratedStorage> StoreWithOwner<'a, TableStorage> {
+    /// Start a transaction.
+    ///
+    /// Blocks until the store's global lock is available for write access.
+    pub fn begin_transaction(&self) -> Transaction<'_, TableStorage> {
+        self.store.begin_transaction(self.owner)
+    }
+
+    /// Start a transaction.
+    ///
+    /// Returns `None` if the store's global lock is unavailable for write access.
+    pub fn try_begin_transaction(&self) -> Option<Transaction<'_, TableStorage>> {
+        self.store.try_begin_transaction(self.owner)
+    }
+
+    /// Start a read-only transaction (i.e., only supports non-mutating access to the store, but
+    /// all reads are guaranteed to be atomic).
+    ///
+    /// Blocks until the store's global lock is available for read access.
+    pub fn begin_ro_transaction(&self) -> RoTransaction<'_, TableStorage> {
+        self.store.begin_ro_transaction(self.owner)
+    }
+
+    /// Start a read-only transaction (i.e., only supports non-mutating access to the store, but
+    /// all reads are guaranteed to be atomic).
+    ///
+    /// Returns `None` if the store's global lock is unavailable for read access.
+    pub fn try_begin_ro_transaction(&self) -> Option<RoTransaction<'_, TableStorage>> {
+        self.store.try_begin_ro_transaction(self.owner)
     }
 }
 

--- a/ts_kv_store/src/transactions.rs
+++ b/ts_kv_store/src/transactions.rs
@@ -245,7 +245,7 @@ impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableSt
     /// Get a single value from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<D: schema::Singleton>(&self) -> Option<D::Value>
+    pub fn get<D: schema::Singleton<Storage = TableStorage>>(&self) -> Option<D::Value>
     where
         D::Value: Clone,
     {
@@ -255,24 +255,29 @@ impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableSt
     /// Get a single value from the store by cloning an `Arc`.
     ///
     /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
-    pub fn get_arc<D: schema::ArcSingleton>(&self) -> Option<Arc<D::Value>> {
+    pub fn get_arc<D: schema::ArcSingleton<Storage = TableStorage>>(
+        &self,
+    ) -> Option<Arc<D::Value>> {
         <&Self as SingletonOps<_>>::get_arc::<D>(self, self.owner)
     }
 
     /// Get immutable access to a value in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<D: schema::Singleton, T>(&self, f: impl FnOnce(&D::Value) -> T) -> Option<T> {
+    pub fn with<D: schema::Singleton<Storage = TableStorage>, T>(
+        &self,
+        f: impl FnOnce(&D::Value) -> T,
+    ) -> Option<T> {
         <&Self as SingletonOps<_>>::with::<D, T>(self, f, self.owner)
     }
 
     /// Insert a single value into the store.
-    pub fn insert<D: schema::Singleton>(&mut self, value: D::ArgValue) {
+    pub fn insert<D: schema::Singleton<Storage = TableStorage>>(&mut self, value: D::ArgValue) {
         <&mut Self as SingletonOpsMut<_>>::insert::<D>(self, value, self.owner)
     }
 
     /// Remove a single value from the store.
-    pub fn remove<D: schema::Singleton>(&mut self) {
+    pub fn remove<D: schema::Singleton<Storage = TableStorage>>(&mut self) {
         <&mut Self as SingletonOpsMut<_>>::remove::<D>(self, self.owner)
     }
 }
@@ -486,7 +491,7 @@ impl<'guard, TableStorage: schema::GeneratedStorage> RoTransaction<'guard, Table
     /// Get a single value from the store by cloning the value.
     ///
     /// Returns `None` if there is no value for the specified key.
-    pub fn get<D: schema::Singleton>(&self) -> Option<D::Value>
+    pub fn get<D: schema::Singleton<Storage = TableStorage>>(&self) -> Option<D::Value>
     where
         D::Value: Clone,
     {
@@ -496,14 +501,19 @@ impl<'guard, TableStorage: schema::GeneratedStorage> RoTransaction<'guard, Table
     /// Get a single value from the store by cloning an `Arc`.
     ///
     /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
-    pub fn get_arc<D: schema::ArcSingleton>(&self) -> Option<Arc<D::Value>> {
+    pub fn get_arc<D: schema::ArcSingleton<Storage = TableStorage>>(
+        &self,
+    ) -> Option<Arc<D::Value>> {
         <&Self as SingletonOps<_>>::get_arc::<D>(self, self.owner)
     }
 
     /// Get immutable access to a value in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
-    pub fn with<D: schema::Singleton, T>(&self, f: impl FnOnce(&D::Value) -> T) -> Option<T> {
+    pub fn with<D: schema::Singleton<Storage = TableStorage>, T>(
+        &self,
+        f: impl FnOnce(&D::Value) -> T,
+    ) -> Option<T> {
         <&Self as SingletonOps<_>>::with::<D, T>(self, f, self.owner)
     }
 }
@@ -576,12 +586,12 @@ impl<'guard, D: TableDesc> KvTableRoTransactional<'guard, '_, D> {
 mod test {
     use std::sync::Arc;
 
-    use crate::{singleton, store};
+    use crate::store;
 
-    singleton!(Count(u64; OWNER));
-    singleton!(Shared(String as Arc; OWNER));
-
-    store!(tables: { Items(&'static str => String; OWNER), Counters(u32 => u64; OWNER) });
+    store!(
+        kvs: { Count(u64; OWNER), Shared(String as Arc; OWNER) }
+        tables: { Items(&'static str => String; OWNER), Counters(u32 => u64; OWNER) }
+    );
 
     const OWNER: &str = "owner";
     #[cfg(debug_assertions)]


### PR DESCRIPTION
Makes the following changes (each change in separate commits):

- owners are declared as part of the schema rather than set on first use
- mutating functions leave the store consistent if the user function panics
- an optimisation to clear a whole index if possible
- convenience function for specifying an owner just once rather than on every operation
- return the base key from index-driven operations (#227)
- store singletons as fields rather than in a map and tie them to a particular store, rather than being 'floating'

closes #227
cc #217

AI declaration: I used Claude for some very mechanical changes. I have reviewed those changes.