### PR TITLE
kvstore: iter_mut and for tables

### DIFF
--- a/ts_kv_store/src/index.rs
+++ b/ts_kv_store/src/index.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     KvStore, Owner, Result, RoTransaction, Transaction,
     operations::{Base, BaseKey, BaseValue, IndexValue, IndexedOps, IndexedOpsMut, Ops, OpsMut},
-    schema::{IndexDesc, TableDesc},
+    schema::IndexDesc,
     storage::Storage,
 };
 
@@ -97,7 +97,6 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     /// Panics if the value is already indexed with the same index key.
     pub fn insert(&self, key: BaseKey<D>, value: BaseValue<D>)
     where
-        <<D as IndexDesc>::BaseTable as TableDesc>::Key: Clone,
         IndexValue<D>: Eq + Hash,
     {
         self.try_insert(key, value).unwrap();
@@ -108,7 +107,6 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     /// Returns an error if `insert` would panic.
     pub fn try_insert(&self, key: BaseKey<D>, value: BaseValue<D>) -> Result<()>
     where
-        <<D as IndexDesc>::BaseTable as TableDesc>::Key: Clone,
         IndexValue<D>: Eq + Hash,
     {
         let mut txn = self.store.begin_transaction(self.owner);
@@ -183,17 +181,25 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
         <&Self as IndexedOps<_>>::values(self, self.owner)
     }
 
-    /// Iterate all the key/value pairs in a table. Values are mutable.
-    pub fn for_each_mut(&self, f: impl FnMut(&BaseKey<D>, &mut BaseValue<D>))
+    /// Iterate all the key/value pairs in a table.
+    ///
+    /// If you need a mutable iterator without access scoped by a closure, use `iter_mut` within a
+    /// transaction.
+    pub fn with_iter_mut<F, T>(&self, mut f: F) -> T
     where
+        F: for<'a> FnMut(
+            Box<dyn Iterator<Item = (&D::Key, &'a BaseKey<D>, &'a mut BaseValue<D>)> + 'a>,
+        ) -> T,
         IndexValue<D>: Eq + Hash + Clone,
         BaseValue<D>: Clone,
     {
         let mut txn = self.store.begin_transaction(self.owner);
         let mut txn_table = KvTableTransactionalIndex::<D> { txn: &mut txn };
-        IndexedOpsMut::for_each_mut(&mut txn_table, f, self.owner);
+        let iter = IndexedOpsMut::iter_mut(&mut txn_table, self.owner);
+        let result = f(Box::new(iter));
         // Should never panic since transaction should only fail on index inserts.
         txn.commit().unwrap();
+        result
     }
 }
 
@@ -355,13 +361,24 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
         <&Self as IndexedOps<_>>::values(self, self.txn.owner)
     }
 
-    /// Iterate all the key/value pairs in a table. Values are mutable.
-    pub fn for_each_mut(&mut self, f: impl FnMut(&BaseKey<D>, &mut BaseValue<D>))
+    /// Iterate all the key/value pairs in a table.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&D::Key, &BaseKey<D>, &mut BaseValue<D>)>
     where
         IndexValue<D>: Eq + Hash + Clone,
         BaseValue<D>: Clone,
     {
-        <&mut Self as IndexedOpsMut<_>>::for_each_mut(self, f, self.txn.owner)
+        let owner = self.txn.owner;
+        IndexedOpsMut::iter_mut(self, owner)
+    }
+
+    /// Iterate all the values in a table.
+    pub fn values_mut(&mut self) -> impl Iterator<Item = (&BaseKey<D>, &mut BaseValue<D>)>
+    where
+        IndexValue<D>: Eq + Hash + Clone,
+        BaseValue<D>: Clone,
+    {
+        let owner = self.txn.owner;
+        IndexedOpsMut::values_mut(self, owner)
     }
 }
 
@@ -826,30 +843,21 @@ mod test {
     }
 
     #[test]
-    fn index_for_each_mut_empty_calls_closure_zero_times() {
-        let store = KvStore::new();
-        let index = store.table_by::<index::Users::name>(OWNER);
-        let mut count = 0;
-        index.for_each_mut(|_, _| count += 1);
-        assert_eq!(count, 0);
-    }
-
-    #[test]
-    fn index_for_each_mut_modifies_base_values() {
+    fn index_with_iter_mut_modifies_base_values() {
         let store = KvStore::new();
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         let index = store.table_by::<index::Users::name>(OWNER);
-        index.for_each_mut(|_, v| v.name.push('!'));
+        index.with_iter_mut(|mut i| i.next().unwrap().2.name.push('!'));
         assert_eq!(store.table::<Users>(OWNER).get(&1), Some(row("Alice!")));
     }
 
     #[test]
-    fn table_for_each_mut_updates_index() {
+    fn table_with_iter_mut_updates_index() {
         let store = KvStore::new();
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         store
             .table::<Users>(OWNER)
-            .for_each_mut(|_, v| v.name = "Charlie".to_owned());
+            .with_iter_mut(|mut i| i.next().unwrap().1.name = "Charlie".to_owned());
         assert!(
             store
                 .table_by::<index::Users::name>(OWNER)
@@ -866,12 +874,12 @@ mod test {
     }
 
     #[test]
-    fn index_for_each_mut_updates_index() {
+    fn index_with_iter_mut_updates_index() {
         let store = KvStore::new();
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         store
             .table_by::<index::Users::name>(OWNER)
-            .for_each_mut(|_, v| v.name = "Charlie".to_owned());
+            .with_iter_mut(|mut i| i.next().unwrap().2.name = "Charlie".to_owned());
         assert!(
             store
                 .table_by::<index::Users::name>(OWNER)
@@ -885,6 +893,59 @@ mod test {
                 .unwrap(),
             (1, row("Charlie"))
         );
+    }
+
+    #[test]
+    fn index_with_iter_mut_empty_yields_none() {
+        let store = KvStore::new();
+        let index = store.table_by::<index::Users::name>(OWNER);
+        let count = index.with_iter_mut(|i| i.count());
+        assert_eq!(count, 0);
+    }
+
+    // Mutating every row through a multi-row index iterator must rebuild the index for all of
+    // them (the single-row tests can't catch aliasing or partial-rebuild bugs).
+    #[test]
+    fn index_with_iter_mut_updates_all_rows() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store.table::<Users>(OWNER).insert(2, row("Bob"));
+        store
+            .table_by::<index::Users::name>(OWNER)
+            .with_iter_mut(|i| {
+                for (_, _, v) in i {
+                    v.name.push('!');
+                }
+            });
+        let index = store.table_by::<index::Users::name>(OWNER);
+        assert!(index.get("Alice").is_none());
+        assert!(index.get("Bob").is_none());
+        assert_eq!(index.get("Alice!").unwrap(), (1, row("Alice!")));
+        assert_eq!(index.get("Bob!").unwrap(), (2, row("Bob!")));
+    }
+
+    // Visiting a row without mutating it still tears down and rebuilds its index entry (via
+    // `get_mut` -> `on_remove` then `rebuild_indexes_for_key` on drop), so a row left unchanged
+    // must remain correctly indexed alongside one that was changed.
+    #[test]
+    fn index_with_iter_mut_visited_unmodified_row_stays_indexed() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store.table::<Users>(OWNER).insert(2, row("Bob"));
+        store
+            .table_by::<index::Users::name>(OWNER)
+            .with_iter_mut(|i| {
+                for (_, base_key, v) in i {
+                    if *base_key == 1 {
+                        v.name = "Zara".to_owned();
+                    }
+                }
+            });
+        let index = store.table_by::<index::Users::name>(OWNER);
+        assert!(index.get("Alice").is_none());
+        assert_eq!(index.get("Zara").unwrap(), (1, row("Zara")));
+        // Bob was visited but not modified; its index entry must be intact.
+        assert_eq!(index.get("Bob").unwrap(), (2, row("Bob")));
     }
 
     #[test]
@@ -1137,12 +1198,13 @@ mod test_two_indexes {
     }
 
     #[test]
-    fn table_for_each_mut_updates_both_indexes() {
+    fn table_with_iter_mut_updates_both_indexes() {
         let store = KvStore::new();
         store
             .table::<People>(OWNER)
             .insert(1, person("a@example.com", b"alice"));
-        store.table::<People>(OWNER).for_each_mut(|_, v| {
+        store.table::<People>(OWNER).with_iter_mut(|mut i| {
+            let v = &mut i.next().unwrap().1;
             v.email = "b@example.com".to_owned();
             v.username = b"bob".to_vec();
         });
@@ -1173,16 +1235,18 @@ mod test_two_indexes {
     }
 
     #[test]
-    fn email_index_for_each_mut_updates_both_indexes() {
+    fn email_index_with_iter_mut_updates_both_indexes() {
         let store = KvStore::new();
         store
             .table::<People>(OWNER)
             .insert(1, person("a@example.com", b"alice"));
         store
             .table_by::<index::People::email>(OWNER)
-            .for_each_mut(|_, v| {
-                v.email = "b@example.com".to_owned();
-                v.username = b"bob".to_vec();
+            .with_iter_mut(|iter| {
+                iter.for_each(|(_, _, v)| {
+                    v.email = "b@example.com".to_owned();
+                    v.username = b"bob".to_vec();
+                });
             });
         assert!(
             store
@@ -1366,12 +1430,13 @@ mod test_transactional_index {
     }
 
     #[test]
-    fn txn_index_for_each_mut_updates_index_on_field_change() {
+    fn txn_index_iter_mut_updates_index_on_field_change() {
         let store = KvStore::new();
         let mut txn = store.begin_transaction(OWNER);
         txn.table_by::<index::Users::name>().insert(1, row("Alice"));
         txn.table_by::<index::Users::name>()
-            .for_each_mut(|_, v| v.name = "Charlie".to_owned());
+            .iter_mut()
+            .for_each(|(_, _, v)| v.name = "Charlie".to_owned());
         assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
         assert_eq!(
             txn.table_by::<index::Users::name>().get("Charlie").unwrap(),
@@ -1382,6 +1447,76 @@ mod test_transactional_index {
                     age: 0
                 }
             )
+        );
+    }
+
+    #[test]
+    fn txn_index_values_mut_updates_index_on_field_change() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table_by::<index::Users::name>().insert(1, row("Alice"));
+        txn.table_by::<index::Users::name>()
+            .values_mut()
+            .for_each(|(_, v)| v.name = "Charlie".to_owned());
+        assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
+        assert_eq!(
+            txn.table_by::<index::Users::name>().get("Charlie").unwrap(),
+            (
+                1,
+                Row {
+                    name: "Charlie".to_owned(),
+                    age: 0
+                }
+            )
+        );
+    }
+
+    // Multi-row transactional index mutation: every row must be re-indexed under its new key.
+    #[test]
+    fn txn_index_iter_mut_updates_multiple_rows() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table_by::<index::Users::name>().insert(1, row("Alice"));
+        txn.table_by::<index::Users::name>().insert(2, row("Bob"));
+        txn.table_by::<index::Users::name>()
+            .iter_mut()
+            .for_each(|(_, _, v)| v.name.push('!'));
+
+        assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
+        assert!(txn.table_by::<index::Users::name>().get("Bob").is_none());
+        assert_eq!(
+            txn.table_by::<index::Users::name>().get("Alice!").unwrap(),
+            (1, row("Alice!"))
+        );
+        assert_eq!(
+            txn.table_by::<index::Users::name>().get("Bob!").unwrap(),
+            (2, row("Bob!"))
+        );
+    }
+
+    // A row visited by the index iterator but left unmodified must remain correctly indexed.
+    #[test]
+    fn txn_index_iter_mut_visited_unmodified_row_stays_indexed() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table_by::<index::Users::name>().insert(1, row("Alice"));
+        txn.table_by::<index::Users::name>().insert(2, row("Bob"));
+        txn.table_by::<index::Users::name>()
+            .iter_mut()
+            .for_each(|(_, base_key, v)| {
+                if *base_key == 1 {
+                    v.name = "Zara".to_owned();
+                }
+            });
+
+        assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
+        assert_eq!(
+            txn.table_by::<index::Users::name>().get("Zara").unwrap(),
+            (1, row("Zara"))
+        );
+        assert_eq!(
+            txn.table_by::<index::Users::name>().get("Bob").unwrap(),
+            (2, row("Bob"))
         );
     }
 
@@ -1437,12 +1572,11 @@ mod test_transactional_index {
     }
 
     #[test]
-    fn txn_base_for_each_mut_updates_index_on_field_change() {
+    fn txn_base_iter_mut_updates_index_on_field_change() {
         let store = KvStore::new();
         let mut txn = store.begin_transaction(OWNER);
         txn.table::<Users>().insert(1, row("Alice"));
-        txn.table::<Users>()
-            .for_each_mut(|_, v| v.name = "Charlie".to_owned());
+        txn.table::<Users>().iter_mut().next().unwrap().1.name = "Charlie".to_owned();
         assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
         assert_eq!(
             txn.table_by::<index::Users::name>().get("Charlie").unwrap(),
@@ -1454,6 +1588,61 @@ mod test_transactional_index {
                 }
             )
         );
+    }
+
+    // Rows inserted after a `clear()` in the same transaction live in the delete
+    // mask's pending map, not in `data`. Iterating the base table mutably must still leave those
+    // rows correctly indexed.
+    #[test]
+    fn txn_base_iter_mut_after_clear_keeps_new_rows_indexed() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Users>().insert(1, row("Alice"));
+        txn.table::<Users>().clear();
+        txn.table::<Users>().insert(2, row("Bob"));
+        for (_, v) in txn.table::<Users>().iter_mut() {
+            v.name.push('!');
+        }
+        txn.commit().unwrap();
+
+        let index = store.table_by::<index::Users::name>(OWNER);
+        assert!(index.get("Alice").is_none());
+        assert!(index.get("Bob").is_none());
+        assert_eq!(index.get("Bob!").unwrap(), (2, row("Bob!")));
+    }
+
+    #[test]
+    fn txn_base_iter_mut_after_clear_unmodified_stays_indexed() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Users>().clear();
+        txn.table::<Users>().insert(2, row("Bob"));
+        for (_, _v) in txn.table::<Users>().iter_mut() {}
+        txn.commit().unwrap();
+
+        let index = store.table_by::<index::Users::name>(OWNER);
+        assert_eq!(index.get("Bob").unwrap(), (2, row("Bob")));
+    }
+
+    // Removing a key then iterating mutably: the removed row must not be re-indexed, and a surviving
+    // row mutated through the iterator must be re-indexed under its new key.
+    #[test]
+    fn txn_base_iter_mut_after_remove_keeps_index_consistent() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Users>().insert(1, row("Alice"));
+        txn.table::<Users>().insert(2, row("Bob"));
+        txn.table::<Users>().remove(&1);
+        for (_, v) in txn.table::<Users>().iter_mut() {
+            v.name.push('!');
+        }
+        txn.commit().unwrap();
+
+        let index = store.table_by::<index::Users::name>(OWNER);
+        assert!(index.get("Alice").is_none());
+        assert!(index.get("Alice!").is_none());
+        assert!(index.get("Bob").is_none());
+        assert_eq!(index.get("Bob!").unwrap(), (2, row("Bob!")));
     }
 
     #[test]
@@ -1541,10 +1730,11 @@ mod test_transactional_index {
 
     #[test]
     #[cfg_attr(debug_assertions, should_panic(expected = "Ownership violation"))]
-    fn txn_index_for_each_mut_wrong_owner_panics() {
+    fn txn_index_iter_mut_wrong_owner_panics() {
         let store = KvStore::new();
         let mut txn = store.begin_transaction(OTHER);
-        txn.table_by::<index::Users::name>().for_each_mut(|_, _| {});
+        let mut table = txn.table_by::<index::Users::name>();
+        let _iter = table.iter_mut();
     }
 
     #[test]

--- a/ts_kv_store/src/index.rs
+++ b/ts_kv_store/src/index.rs
@@ -188,15 +188,17 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
     pub fn with_iter_mut<F, T>(&self, mut f: F) -> T
     where
         F: for<'a> FnMut(
-            Box<dyn Iterator<Item = (&D::Key, &'a BaseKey<D>, &'a mut BaseValue<D>)> + 'a>,
+            &mut dyn Iterator<Item = (&D::Key, &'a BaseKey<D>, &'a mut BaseValue<D>)>,
         ) -> T,
         IndexValue<D>: Eq + Hash + Clone,
         BaseValue<D>: Clone,
     {
         let mut txn = self.store.begin_transaction(self.owner);
         let mut txn_table = KvTableTransactionalIndex::<D> { txn: &mut txn };
-        let iter = IndexedOpsMut::iter_mut(&mut txn_table, self.owner);
-        let result = f(Box::new(iter));
+        let result = {
+            let mut iter = IndexedOpsMut::iter_mut(&mut txn_table, self.owner);
+            f(&mut iter)
+        };
         // Should never panic since transaction should only fail on index inserts.
         txn.commit().unwrap();
         result
@@ -372,9 +374,8 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
     }
 
     /// Iterate all the values in a table.
-    pub fn values_mut(&mut self) -> impl Iterator<Item = (&BaseKey<D>, &mut BaseValue<D>)>
+    pub fn iter_base_mut(&mut self) -> impl Iterator<Item = (&BaseKey<D>, &mut BaseValue<D>)>
     where
-        IndexValue<D>: Eq + Hash + Clone,
         BaseValue<D>: Clone,
     {
         let owner = self.txn.owner;
@@ -847,7 +848,7 @@ mod test {
         let store = KvStore::new();
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         let index = store.table_by::<index::Users::name>(OWNER);
-        index.with_iter_mut(|mut i| i.next().unwrap().2.name.push('!'));
+        index.with_iter_mut(|i| i.next().unwrap().2.name.push('!'));
         assert_eq!(store.table::<Users>(OWNER).get(&1), Some(row("Alice!")));
     }
 
@@ -857,7 +858,7 @@ mod test {
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         store
             .table::<Users>(OWNER)
-            .with_iter_mut(|mut i| i.next().unwrap().1.name = "Charlie".to_owned());
+            .with_iter_mut(|i| i.next().unwrap().1.name = "Charlie".to_owned());
         assert!(
             store
                 .table_by::<index::Users::name>(OWNER)
@@ -879,7 +880,7 @@ mod test {
         store.table::<Users>(OWNER).insert(1, row("Alice"));
         store
             .table_by::<index::Users::name>(OWNER)
-            .with_iter_mut(|mut i| i.next().unwrap().2.name = "Charlie".to_owned());
+            .with_iter_mut(|i| i.next().unwrap().2.name = "Charlie".to_owned());
         assert!(
             store
                 .table_by::<index::Users::name>(OWNER)
@@ -1203,7 +1204,7 @@ mod test_two_indexes {
         store
             .table::<People>(OWNER)
             .insert(1, person("a@example.com", b"alice"));
-        store.table::<People>(OWNER).with_iter_mut(|mut i| {
+        store.table::<People>(OWNER).with_iter_mut(|i| {
             let v = &mut i.next().unwrap().1;
             v.email = "b@example.com".to_owned();
             v.username = b"bob".to_vec();
@@ -1456,7 +1457,7 @@ mod test_transactional_index {
         let mut txn = store.begin_transaction(OWNER);
         txn.table_by::<index::Users::name>().insert(1, row("Alice"));
         txn.table_by::<index::Users::name>()
-            .values_mut()
+            .iter_base_mut()
             .for_each(|(_, v)| v.name = "Charlie".to_owned());
         assert!(txn.table_by::<index::Users::name>().get("Alice").is_none());
         assert_eq!(

--- a/ts_kv_store/src/iter.rs
+++ b/ts_kv_store/src/iter.rs
@@ -1,11 +1,12 @@
 //! Iterate over a table
 
-use std::{hash::Hash, marker::PhantomData};
+use std::{collections::HashSet, hash::Hash, marker::PhantomData};
 
 use crate::{
-    operations::StorageGuard,
+    Owner,
+    operations::{StorageGuard, StorageGuardMut},
     schema::{IndexDesc, TableDesc},
-    storage::{Table, TableIterator as InnerIterator},
+    storage::{Table, TableIterator as InnerIterator, TableIteratorMut as InnerIteratorMut},
     transactions::TxnId,
 };
 
@@ -99,6 +100,94 @@ impl<'guard, Guard, D: TableDesc, Kind> Drop for TableIterator<'guard, Guard, D,
     }
 }
 
+/// An iterator giving mutable access to values.
+pub struct TableIteratorMut<'guard, Guard: StorageGuardMut<D::Storage> + 'guard, D: TableDesc, Kind>
+{
+    /// Guard on the KV store's storage (all of it).
+    guard: Guard,
+    /// An iterator over the `HashMap` representing the table.
+    ///
+    /// Invariants:
+    ///   - `inner.is_some()` once `new` has completed.
+    inner: Option<InnerIteratorMut<'guard, D, D::Indexes>>,
+    /// Tracks keys of yielded values for rebuilding indexes in `drop`.
+    modified: HashSet<D::Key>,
+    _kind: PhantomData<(D, Kind)>,
+}
+
+impl<'guard, Guard: StorageGuardMut<D::Storage> + 'guard, D: TableDesc, Kind>
+    TableIteratorMut<'guard, Guard, D, Kind>
+where
+    D::Value: Clone,
+{
+    /// Create an iterator over the table described by `D`.
+    pub(crate) fn new(guard: Guard, owner: Owner) -> Self
+    where
+        D: 'guard,
+    {
+        let mut result = TableIteratorMut {
+            guard,
+            inner: None,
+            modified: HashSet::new(),
+            _kind: PhantomData,
+        };
+        let txn_id = result.guard.storage().txn_id();
+        let max_transaction_id = result.guard.storage().max_committed_id();
+        result.inner = Some(inner_iter_mut::<D, Guard>(
+            &mut result.guard,
+            txn_id,
+            max_transaction_id,
+            owner,
+        ));
+        result
+    }
+
+    fn inner_next(&mut self) -> Option<(&'guard D::Key, &'guard mut D::Value)> {
+        let (k, v) = self.inner.as_mut().unwrap().next()?;
+        // The inner iterator has de-indexed this row; record the key for later re-indexing.
+        self.modified.insert(k.clone());
+        Some((k, v))
+    }
+}
+
+impl<'guard, Guard: StorageGuardMut<D::Storage>, D: TableDesc, Kind> Drop
+    for TableIteratorMut<'guard, Guard, D, Kind>
+{
+    fn drop(&mut self) {
+        let storage = self.guard.storage();
+        let txn_id = storage.txn_id();
+        let max_transaction_id = storage.max_committed_id();
+        let table = D::get_table_mut(&mut storage.tables);
+        for k in &self.modified {
+            table.rebuild_indexes_for_key(k, txn_id, max_transaction_id);
+        }
+    }
+}
+
+impl<'guard, Guard: StorageGuardMut<D::Storage>, D: TableDesc> Iterator
+    for TableIteratorMut<'guard, Guard, D, KeysAndValues>
+where
+    D::Value: Clone,
+{
+    type Item = (&'guard D::Key, &'guard mut D::Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner_next()
+    }
+}
+
+impl<'guard, Guard: StorageGuardMut<D::Storage>, D: TableDesc> Iterator
+    for TableIteratorMut<'guard, Guard, D, Values>
+where
+    D::Value: Clone,
+{
+    type Item = &'guard mut D::Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner_next().map(|(_, v)| v)
+    }
+}
+
 /// An iterator for an indexed table (described by the generic parameter `D`) in the KV
 /// store.
 pub struct IndexIterator<'guard, Guard, D: IndexDesc, Kind> {
@@ -151,7 +240,6 @@ where
     );
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Iterate by delegating to the `HashMap` iterator.
         let (base, iter) = self.inner.as_mut().unwrap();
         let (k, bk) = iter.next()?;
         let value = base.get(bk, self.guard.storage().txn_id())?;
@@ -164,7 +252,6 @@ impl<'guard, Guard, D: IndexDesc> Iterator for IndexIterator<'guard, Guard, D, K
     type Item = &'guard D::Key;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Iterate by delegating to the `HashMap` iterator.
         let (_, iter) = self.inner.as_mut().unwrap();
         iter.next().map(|(k, _)| k)
     }
@@ -181,7 +268,6 @@ where
     );
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Iterate by delegating to the `HashMap` iterator.
         let (base, iter) = self.inner.as_mut().unwrap();
         let (_, bk) = iter.next()?;
         let value = base.get(bk, self.guard.storage().txn_id())?;
@@ -197,7 +283,132 @@ impl<'guard, Guard, D: IndexDesc, Kind> Drop for IndexIterator<'guard, Guard, D,
     }
 }
 
-// Create an iterator over a table's data to use as a base for these iterators.
+/// An iterator for an indexed table (described by the generic parameter `D`) in the KV
+/// store. Gives mutable access to base table values.
+pub struct IndexIteratorMut<'guard, Guard: StorageGuardMut<D::Storage> + 'guard, D: IndexDesc, Kind>
+{
+    /// Guard on the KV store's storage (all of it).
+    guard: Guard,
+    /// An iterator over the `HashMap` representing the table.
+    ///
+    /// Invariants:
+    ///   - `inner.is_some()` once `new` has completed.
+    inner: Option<(&'guard mut Indexes<D>, InnerIterator<'guard, D>)>,
+    modified: HashSet<D::Value>,
+    _kind: PhantomData<Kind>,
+}
+
+impl<'guard, Guard: StorageGuardMut<D::Storage> + 'guard, D: IndexDesc, Kind>
+    IndexIteratorMut<'guard, Guard, D, Kind>
+where
+    <<D as IndexDesc>::BaseTable as TableDesc>::Value: Clone,
+{
+    /// Create an iterator over the table described by `D`.
+    pub(crate) fn new(guard: Guard, owner: Owner) -> Self
+    where
+        D: 'guard,
+    {
+        let mut result = IndexIteratorMut {
+            guard,
+            inner: None,
+            modified: HashSet::new(),
+            _kind: PhantomData,
+        };
+        let txn_id = result.guard.storage().txn_id();
+
+        let base_table = <D::BaseTable as TableDesc>::get_table_mut(
+            &mut <Guard as StorageGuardMut<D::Storage>>::storage(&mut result.guard).tables,
+        );
+        base_table.assert_owner(owner);
+
+        result.inner = Some((
+            // SAFETY: for the same reasoning as `inner_iter`, we're extending the lifetime of this
+            // internal reference to 'guard. This is safe for the same reasons, i.e. we ensure that
+            // guard is dropped last.
+            unsafe { &mut *(base_table as *mut _) },
+            inner_iter_mut_guard::<D, Guard>(&mut result.guard, txn_id),
+        ));
+        result
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn inner_next(
+        &mut self,
+    ) -> Option<(
+        &'guard D::Key,
+        &'guard <D::BaseTable as TableDesc>::Key,
+        &'guard mut <D::BaseTable as TableDesc>::Value,
+    )>
+    where
+        D::Value: Clone + Hash + Eq,
+        <<D as IndexDesc>::BaseTable as TableDesc>::Value: Clone,
+    {
+        let max_transaction_id = self.guard.storage().max_committed_id();
+        let (base, iter) = self.inner.as_mut().unwrap();
+        let (k, bk) = iter.next()?;
+        // SAFETY: we are making a mutable reference to the base table. The borrow checker does not
+        // allow this because in safe code because the lifetime of `value` is the function lifetime
+        // rather than `'guard`, due to the lifetime introduced by `as_mut` above. Working around
+        // this restriction allows `next` to be called multiple times and get multiple mutable
+        // references. This is safe because each call will return a references to a different item
+        // in the underlying collection. Furthermore, the extended lifetime `'guard` ensures that
+        // the reference does not outlive the guarding lock.
+        let base: &'guard mut Indexes<D> = unsafe { &mut *(&mut **base as *mut _) };
+        let value = base.get_mut(bk, self.guard.storage().txn_id(), max_transaction_id)?;
+        self.modified.insert(bk.clone());
+
+        Some((k, bk, value))
+    }
+}
+
+impl<'guard, Guard: StorageGuardMut<D::Storage>, D: IndexDesc, Kind> Drop
+    for IndexIteratorMut<'guard, Guard, D, Kind>
+{
+    fn drop(&mut self) {
+        let storage = self.guard.storage();
+        let txn_id = storage.txn_id();
+        let max_transaction_id = storage.max_committed_id();
+        let table = <D::BaseTable as TableDesc>::get_table_mut(&mut storage.tables);
+        for k in &self.modified {
+            table.rebuild_indexes_for_key(k, txn_id, max_transaction_id);
+        }
+    }
+}
+
+impl<'guard, Guard: StorageGuardMut<D::Storage>, D: IndexDesc> Iterator
+    for IndexIteratorMut<'guard, Guard, D, KeysAndValues>
+where
+    D::Value: Clone + Hash + Eq,
+    <<D as IndexDesc>::BaseTable as TableDesc>::Value: Clone,
+{
+    type Item = (
+        &'guard D::Key,
+        &'guard <D::BaseTable as TableDesc>::Key,
+        &'guard mut <D::BaseTable as TableDesc>::Value,
+    );
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner_next()
+    }
+}
+
+impl<'guard, Guard: StorageGuardMut<D::Storage>, D: IndexDesc> Iterator
+    for IndexIteratorMut<'guard, Guard, D, Values>
+where
+    D::Value: Clone + Hash + Eq,
+    <<D as IndexDesc>::BaseTable as TableDesc>::Value: Clone,
+{
+    type Item = (
+        &'guard <D::BaseTable as TableDesc>::Key,
+        &'guard mut <D::BaseTable as TableDesc>::Value,
+    );
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner_next().map(|(_, bk, v)| (bk, v))
+    }
+}
+
+// Create an iterator over a table's data to use as a base for the above iterators.
 fn inner_iter<'guard, D, Guard>(guard: &Guard, txn_id: TxnId) -> InnerIterator<'guard, D>
 where
     D: TableDesc + 'guard,
@@ -213,4 +424,38 @@ where
     // to outlive `'guard`.
     let tables = unsafe { &*tables };
     D::get_table(tables).iter(txn_id)
+}
+
+// Create an immutable iterator from a mutable guard (`StorageGuardMut`).
+fn inner_iter_mut_guard<'guard, D, Guard>(
+    guard: &mut Guard,
+    txn_id: TxnId,
+) -> InnerIterator<'guard, D>
+where
+    D: TableDesc + 'guard,
+    Guard: StorageGuardMut<D::Storage> + 'guard,
+{
+    let tables: *const _ = &mut guard.storage().tables;
+    // SAFETY: see `inner_iter`.
+    let tables = unsafe { &*tables };
+    D::get_table(tables).iter(txn_id)
+}
+
+// Create a mutable iterator from a mutable guard.
+fn inner_iter_mut<'guard, D, Guard>(
+    guard: &mut Guard,
+    txn_id: TxnId,
+    max_transaction_id: TxnId,
+    owner: Owner,
+) -> InnerIteratorMut<'guard, D, D::Indexes>
+where
+    D: TableDesc + 'guard,
+    Guard: StorageGuardMut<D::Storage> + 'guard,
+{
+    let tables: *mut _ = &mut guard.storage().tables;
+    // SAFETY: see `inner_iter`.
+    let tables = unsafe { &mut *tables };
+    let table = D::get_table_mut(tables);
+    table.assert_owner(owner);
+    table.iter_mut(txn_id, max_transaction_id)
 }

--- a/ts_kv_store/src/iter.rs
+++ b/ts_kv_store/src/iter.rs
@@ -285,8 +285,7 @@ impl<'guard, Guard, D: IndexDesc, Kind> Drop for IndexIterator<'guard, Guard, D,
 
 /// An iterator for an indexed table (described by the generic parameter `D`) in the KV
 /// store. Gives mutable access to base table values.
-pub struct IndexIteratorMut<'guard, Guard: StorageGuardMut<D::Storage> + 'guard, D: IndexDesc, Kind>
-{
+pub struct IndexIteratorMut<'guard, Guard: StorageGuardMut<D::Storage> + 'guard, D: IndexDesc> {
     /// Guard on the KV store's storage (all of it).
     guard: Guard,
     /// An iterator over the `HashMap` representing the table.
@@ -295,11 +294,10 @@ pub struct IndexIteratorMut<'guard, Guard: StorageGuardMut<D::Storage> + 'guard,
     ///   - `inner.is_some()` once `new` has completed.
     inner: Option<(&'guard mut Indexes<D>, InnerIterator<'guard, D>)>,
     modified: HashSet<D::Value>,
-    _kind: PhantomData<Kind>,
 }
 
-impl<'guard, Guard: StorageGuardMut<D::Storage> + 'guard, D: IndexDesc, Kind>
-    IndexIteratorMut<'guard, Guard, D, Kind>
+impl<'guard, Guard: StorageGuardMut<D::Storage> + 'guard, D: IndexDesc>
+    IndexIteratorMut<'guard, Guard, D>
 where
     <<D as IndexDesc>::BaseTable as TableDesc>::Value: Clone,
 {
@@ -312,7 +310,6 @@ where
             guard,
             inner: None,
             modified: HashSet::new(),
-            _kind: PhantomData,
         };
         let txn_id = result.guard.storage().txn_id();
 
@@ -330,19 +327,35 @@ where
         ));
         result
     }
+}
 
-    #[allow(clippy::type_complexity)]
-    fn inner_next(
-        &mut self,
-    ) -> Option<(
+impl<'guard, Guard: StorageGuardMut<D::Storage>, D: IndexDesc> Drop
+    for IndexIteratorMut<'guard, Guard, D>
+{
+    fn drop(&mut self) {
+        let storage = self.guard.storage();
+        let txn_id = storage.txn_id();
+        let max_transaction_id = storage.max_committed_id();
+        let table = <D::BaseTable as TableDesc>::get_table_mut(&mut storage.tables);
+        for k in &self.modified {
+            table.rebuild_indexes_for_key(k, txn_id, max_transaction_id);
+        }
+    }
+}
+
+impl<'guard, Guard: StorageGuardMut<D::Storage>, D: IndexDesc> Iterator
+    for IndexIteratorMut<'guard, Guard, D>
+where
+    D::Value: Clone + Hash + Eq,
+    <<D as IndexDesc>::BaseTable as TableDesc>::Value: Clone,
+{
+    type Item = (
         &'guard D::Key,
         &'guard <D::BaseTable as TableDesc>::Key,
         &'guard mut <D::BaseTable as TableDesc>::Value,
-    )>
-    where
-        D::Value: Clone + Hash + Eq,
-        <<D as IndexDesc>::BaseTable as TableDesc>::Value: Clone,
-    {
+    );
+
+    fn next(&mut self) -> Option<Self::Item> {
         let max_transaction_id = self.guard.storage().max_committed_id();
         let (base, iter) = self.inner.as_mut().unwrap();
         let (k, bk) = iter.next()?;
@@ -358,53 +371,6 @@ where
         self.modified.insert(bk.clone());
 
         Some((k, bk, value))
-    }
-}
-
-impl<'guard, Guard: StorageGuardMut<D::Storage>, D: IndexDesc, Kind> Drop
-    for IndexIteratorMut<'guard, Guard, D, Kind>
-{
-    fn drop(&mut self) {
-        let storage = self.guard.storage();
-        let txn_id = storage.txn_id();
-        let max_transaction_id = storage.max_committed_id();
-        let table = <D::BaseTable as TableDesc>::get_table_mut(&mut storage.tables);
-        for k in &self.modified {
-            table.rebuild_indexes_for_key(k, txn_id, max_transaction_id);
-        }
-    }
-}
-
-impl<'guard, Guard: StorageGuardMut<D::Storage>, D: IndexDesc> Iterator
-    for IndexIteratorMut<'guard, Guard, D, KeysAndValues>
-where
-    D::Value: Clone + Hash + Eq,
-    <<D as IndexDesc>::BaseTable as TableDesc>::Value: Clone,
-{
-    type Item = (
-        &'guard D::Key,
-        &'guard <D::BaseTable as TableDesc>::Key,
-        &'guard mut <D::BaseTable as TableDesc>::Value,
-    );
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.inner_next()
-    }
-}
-
-impl<'guard, Guard: StorageGuardMut<D::Storage>, D: IndexDesc> Iterator
-    for IndexIteratorMut<'guard, Guard, D, Values>
-where
-    D::Value: Clone + Hash + Eq,
-    <<D as IndexDesc>::BaseTable as TableDesc>::Value: Clone,
-{
-    type Item = (
-        &'guard <D::BaseTable as TableDesc>::Key,
-        &'guard mut <D::BaseTable as TableDesc>::Value,
-    );
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.inner_next().map(|(_, bk, v)| (bk, v))
     }
 }
 

--- a/ts_kv_store/src/operations.rs
+++ b/ts_kv_store/src/operations.rs
@@ -15,7 +15,8 @@ use std::{
 };
 
 use crate::{
-    Error, IndexIterator, Owner, Result, TableIterator, iter,
+    Error, IndexIterator, Owner, Result, TableIterator,
+    iter::{self, IndexIteratorMut, TableIteratorMut},
     schema::{self, IndexDesc, TableDesc},
     storage::Storage,
 };
@@ -450,21 +451,39 @@ pub(crate) trait TabularOpsMut<TableStorage: schema::GeneratedStorage>:
         table.remove(key, txn_id, max_committed_id);
     }
 
-    fn for_each_mut(
+    fn iter_mut<'guard>(
         self,
-        f: impl FnMut(&<Self::TableDesc as TableDesc>::Key, &mut <Self::TableDesc as TableDesc>::Value),
         owner: Owner,
-    ) where
-        <Self::TableDesc as TableDesc>::Value: Clone,
+    ) -> impl Iterator<
+        Item = (
+            &'guard <Self::TableDesc as TableDesc>::Key,
+            &'guard mut <Self::TableDesc as TableDesc>::Value,
+        ),
+    >
+    where
+        Self::WriteLock: 'guard,
+        Self::TableDesc: 'guard,
+        <<Self as TabularOpsMut<TableStorage>>::TableDesc as TableDesc>::Value: Clone,
     {
-        let mut storage = self.write_lock();
-        let storage = storage.storage();
-        let txn_id = storage.txn_id();
-        let max_committed_id = storage.max_committed_id();
-        let table = Self::TableDesc::get_table_mut(&mut storage.tables);
-        table.assert_owner(owner);
+        let guard = self.write_lock();
+        TableIteratorMut::<'guard, Self::WriteLock, Self::TableDesc, iter::KeysAndValues>::new(
+            guard, owner,
+        )
+    }
 
-        table.for_each_mut(f, txn_id, max_committed_id);
+    fn values_mut<'guard>(
+        self,
+        owner: Owner,
+    ) -> impl Iterator<Item = &'guard mut <Self::TableDesc as TableDesc>::Value>
+    where
+        Self::WriteLock: 'guard,
+        Self::TableDesc: 'guard,
+        <<Self as TabularOpsMut<TableStorage>>::TableDesc as TableDesc>::Value: Clone,
+    {
+        let guard = self.write_lock();
+        TableIteratorMut::<'guard, Self::WriteLock, Self::TableDesc, iter::Values>::new(
+            guard, owner,
+        )
     }
 }
 
@@ -489,7 +508,6 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
 
     fn insert(self, key: BaseKey<Self::IndexDesc>, value: BaseValue<Self::IndexDesc>, owner: Owner)
     where
-        BaseKey<Self::IndexDesc>: Clone,
         IndexValue<Self::IndexDesc>: Hash + Eq,
     {
         let mut storage = self.write_lock();
@@ -557,35 +575,50 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
         index.remove(key, txn_id, max_committed_id);
     }
 
-    fn for_each_mut(
+    #[allow(clippy::type_complexity)]
+    fn iter_mut<'guard>(
         self,
-        mut f: impl FnMut(&BaseKey<Self::IndexDesc>, &mut BaseValue<Self::IndexDesc>),
         owner: Owner,
-    ) where
+    ) -> impl Iterator<
+        Item = (
+            &'guard IndexKey<Self::IndexDesc>,
+            &'guard BaseKey<Self::IndexDesc>,
+            &'guard mut BaseValue<Self::IndexDesc>,
+        ),
+    >
+    where
+        Self::WriteLock: 'guard,
+        Self::IndexDesc: 'guard,
         IndexValue<Self::IndexDesc>: Hash + Eq,
         BaseKey<Self::IndexDesc>: Clone,
         BaseValue<Self::IndexDesc>: Clone,
     {
-        let mut storage = self.write_lock();
-        let storage = storage.storage();
-        let txn_id = storage.txn_id();
-        let max_committed_id = storage.max_committed_id();
+        let guard = self.write_lock();
+        IndexIteratorMut::<'guard, Self::WriteLock, Self::IndexDesc, iter::KeysAndValues>::new(
+            guard, owner,
+        )
+    }
 
-        let (base, index) = schema::get_two_tables_mut::<_, Base<Self::IndexDesc>, Self::IndexDesc>(
-            &mut storage.tables,
-        );
-        base.assert_owner(owner);
-
-        for (_, base_key) in index.iter(txn_id) {
-            base.with_mut(
-                base_key,
-                |value| {
-                    f(base_key, value);
-                },
-                txn_id,
-                max_committed_id,
-            );
-        }
+    fn values_mut<'guard>(
+        self,
+        owner: Owner,
+    ) -> impl Iterator<
+        Item = (
+            &'guard BaseKey<Self::IndexDesc>,
+            &'guard mut BaseValue<Self::IndexDesc>,
+        ),
+    >
+    where
+        Self::WriteLock: 'guard,
+        Self::IndexDesc: 'guard,
+        IndexValue<Self::IndexDesc>: Hash + Eq,
+        BaseKey<Self::IndexDesc>: Clone,
+        BaseValue<Self::IndexDesc>: Clone,
+    {
+        let guard = self.write_lock();
+        IndexIteratorMut::<'guard, Self::WriteLock, Self::IndexDesc, iter::Values>::new(
+            guard, owner,
+        )
     }
 }
 

--- a/ts_kv_store/src/operations.rs
+++ b/ts_kv_store/src/operations.rs
@@ -594,9 +594,7 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
         BaseValue<Self::IndexDesc>: Clone,
     {
         let guard = self.write_lock();
-        IndexIteratorMut::<'guard, Self::WriteLock, Self::IndexDesc, iter::KeysAndValues>::new(
-            guard, owner,
-        )
+        IndexIteratorMut::<'guard, Self::WriteLock, Self::IndexDesc>::new(guard, owner)
     }
 
     fn values_mut<'guard>(
@@ -610,15 +608,15 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
     >
     where
         Self::WriteLock: 'guard,
-        Self::IndexDesc: 'guard,
-        IndexValue<Self::IndexDesc>: Hash + Eq,
-        BaseKey<Self::IndexDesc>: Clone,
         BaseValue<Self::IndexDesc>: Clone,
     {
         let guard = self.write_lock();
-        IndexIteratorMut::<'guard, Self::WriteLock, Self::IndexDesc, iter::Values>::new(
-            guard, owner,
-        )
+        TableIteratorMut::<
+            'guard,
+            Self::WriteLock,
+            <Self::IndexDesc as IndexDesc>::BaseTable,
+            iter::KeysAndValues,
+        >::new(guard, owner)
     }
 }
 

--- a/ts_kv_store/src/raw.rs
+++ b/ts_kv_store/src/raw.rs
@@ -248,20 +248,14 @@ impl<D: schema::TableDesc> KvTable<'_, D> {
     /// Insert a `value` into the table.
     ///
     /// Panics if the value is already indexed with the same index key.
-    pub fn insert(&self, key: D::Key, value: D::Value)
-    where
-        D::Key: Clone,
-    {
+    pub fn insert(&self, key: D::Key, value: D::Value) {
         self.try_insert(key, value).unwrap();
     }
 
     /// Insert a `value` into the table.
     ///
     /// Returns an error if `insert` would panic.
-    pub fn try_insert(&self, key: D::Key, value: D::Value) -> Result<()>
-    where
-        D::Key: Clone,
-    {
+    pub fn try_insert(&self, key: D::Key, value: D::Value) -> Result<()> {
         let mut txn = self.store.begin_transaction(self.owner);
         let mut txn_table = KvTableTransactional::<D> { txn: &mut txn };
         TabularOpsMut::insert(&mut txn_table, key, value, self.owner);
@@ -312,15 +306,22 @@ impl<D: schema::TableDesc> KvTable<'_, D> {
         <&Self as TabularOps<_>>::values(self, self.owner)
     }
 
-    /// Iterate all the key/value pairs in a table. Values are mutable.
-    pub fn for_each_mut(&self, f: impl FnMut(&D::Key, &mut D::Value))
+    /// Iterate all the key/value pairs in a table.
+    ///
+    /// If you need a mutable iterator without access scoped by a closure, use `iter_mut` within a
+    /// transaction.
+    pub fn with_iter_mut<F, T>(&self, mut f: F) -> T
     where
+        F: for<'a> FnMut(Box<dyn Iterator<Item = (&'a D::Key, &'a mut D::Value)> + 'a>) -> T,
         D::Value: Clone,
     {
         let mut txn = self.store.begin_transaction(self.owner);
         let mut txn_table = KvTableTransactional::<D> { txn: &mut txn };
-        TabularOpsMut::for_each_mut(&mut txn_table, f, self.owner);
+        let iter = TabularOpsMut::iter_mut(&mut txn_table, self.owner);
+        let result = f(Box::new(iter));
+        // Should never panic since transaction should only fail on index inserts.
         txn.commit().unwrap();
+        result
     }
 }
 
@@ -632,21 +633,37 @@ mod test {
     }
 
     #[test]
-    fn table_for_each_mut_empty_calls_closure_zero_times() {
+    fn table_with_iter_mut_modifies_values() {
         let store = KvStore::new();
         let table = store.table::<Items>(OWNER);
-        let mut count = 0;
-        table.for_each_mut(|_, _| count += 1);
+        table.insert("k", "hello".to_owned());
+        table.with_iter_mut(|mut i| i.next().unwrap().1.push('!'));
+        assert_eq!(table.get("k"), Some("hello!".to_owned()));
+    }
+
+    #[test]
+    fn table_with_iter_mut_empty_yields_none() {
+        let store = KvStore::new();
+        let table = store.table::<Items>(OWNER);
+        let count = table.with_iter_mut(|i| i.count());
         assert_eq!(count, 0);
     }
 
     #[test]
-    fn table_for_each_mut_modifies_values() {
+    fn table_with_iter_mut_visits_all_rows() {
         let store = KvStore::new();
         let table = store.table::<Items>(OWNER);
-        table.insert("k", "hello".to_owned());
-        table.for_each_mut(|_, v| v.push('!'));
-        assert_eq!(table.get("k"), Some("hello!".to_owned()));
+        table.insert("a", "x".to_owned());
+        table.insert("b", "y".to_owned());
+        table.insert("c", "z".to_owned());
+        table.with_iter_mut(|i| {
+            for (_, v) in i {
+                v.push('!');
+            }
+        });
+        assert_eq!(table.get("a"), Some("x!".to_owned()));
+        assert_eq!(table.get("b"), Some("y!".to_owned()));
+        assert_eq!(table.get("c"), Some("z!".to_owned()));
     }
 
     #[test]

--- a/ts_kv_store/src/raw.rs
+++ b/ts_kv_store/src/raw.rs
@@ -312,13 +312,15 @@ impl<D: schema::TableDesc> KvTable<'_, D> {
     /// transaction.
     pub fn with_iter_mut<F, T>(&self, mut f: F) -> T
     where
-        F: for<'a> FnMut(Box<dyn Iterator<Item = (&'a D::Key, &'a mut D::Value)> + 'a>) -> T,
+        F: for<'a> FnMut(&mut dyn Iterator<Item = (&'a D::Key, &'a mut D::Value)>) -> T,
         D::Value: Clone,
     {
         let mut txn = self.store.begin_transaction(self.owner);
         let mut txn_table = KvTableTransactional::<D> { txn: &mut txn };
-        let iter = TabularOpsMut::iter_mut(&mut txn_table, self.owner);
-        let result = f(Box::new(iter));
+        let result = {
+            let mut iter = TabularOpsMut::iter_mut(&mut txn_table, self.owner);
+            f(&mut iter)
+        };
         // Should never panic since transaction should only fail on index inserts.
         txn.commit().unwrap();
         result
@@ -637,7 +639,7 @@ mod test {
         let store = KvStore::new();
         let table = store.table::<Items>(OWNER);
         table.insert("k", "hello".to_owned());
-        table.with_iter_mut(|mut i| i.next().unwrap().1.push('!'));
+        table.with_iter_mut(|i| i.next().unwrap().1.push('!'));
         assert_eq!(table.get("k"), Some("hello!".to_owned()));
     }
 

--- a/ts_kv_store/src/schema.rs
+++ b/ts_kv_store/src/schema.rs
@@ -181,7 +181,7 @@ impl<K: Hash + Eq, V: Any + Send + Sync> IndexStorage<K, V> for () {
     }
 }
 
-/// Marker trait to indicate a storage implementation.
+/// A storage implementation.
 ///
 /// This should be considered a sealed trait and not implemented except by the macros in this module.
 /// Unfortunately it has to be public because of macro visibility hygiene.

--- a/ts_kv_store/src/storage.rs
+++ b/ts_kv_store/src/storage.rs
@@ -534,6 +534,19 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
         *self.poisoned.get(txn_id).unwrap_or(&false)
     }
 
+    /// Rebuild all indexes for a specific key in this table.
+    pub(crate) fn rebuild_indexes_for_key(
+        &mut self,
+        key: &D::Key,
+        txn_id: TxnId,
+        max_committed_id: TxnId,
+    ) {
+        if let Some(v) = get_from_table::<D, D::Key>(&self.delete_mask, &self.data, key, txn_id) {
+            self.indexes.on_insert(key, v, txn_id, max_committed_id);
+        }
+    }
+
+    /// Cleanup a rolled-back transaction.
     pub fn gc_txn(&mut self, txn_id: TxnId) {
         self.delete_mask = DeleteMask::None;
         self.poisoned.gc_txn(txn_id);
@@ -547,14 +560,20 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
             "Found mismatched modified set to GC"
         );
 
-        for k in &modified.keys {
-            if let Some(value) = self.data.get_mut(k) {
-                value.gc_txn(txn_id);
+        if let Some(keys) = &modified.keys {
+            for k in keys {
+                if let Some(value) = self.data.get_mut(k) {
+                    value.gc_txn(txn_id);
 
-                // We don't need to do this, but I think we may as well free up the space.
-                if value.is_empty() {
-                    self.data.remove(k);
+                    // We don't need to do this, but I think we may as well free up the space.
+                    if value.is_empty() {
+                        self.data.remove(k);
+                    }
                 }
+            }
+        } else {
+            for datum in self.data.values_mut() {
+                datum.gc_txn(txn_id);
             }
         }
 
@@ -646,6 +665,30 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
         }
     }
 
+    /// Get a mutable iterator over the table. Does not keep indexes up to date; the caller must
+    /// call `rebuild_indexes_for_key` for any mutated key.
+    pub(crate) fn iter_mut<'a>(
+        &'a mut self,
+        txn_id: TxnId,
+        max_committed_id: TxnId,
+    ) -> TableIteratorMut<'a, D, I> {
+        debug_assert!(self.delete_mask.check_txn_id(txn_id));
+        record_mutation(&mut self.modified, None, txn_id, max_committed_id);
+
+        let (data, removed) = match &mut self.delete_mask {
+            DeleteMask::None => (self.data.iter_mut(), None),
+            DeleteMask::Some(_, removed) => (self.data.iter_mut(), Some(&*removed)),
+            DeleteMask::All(_, pending) => (pending.iter_mut(), None),
+        };
+        TableIteratorMut {
+            data,
+            removed,
+            indexes: &mut self.indexes,
+            txn_id,
+            max_committed_id,
+        }
+    }
+
     pub fn get<Q>(&self, key: &Q, txn_id: TxnId) -> Option<&D::Value>
     where
         D::Key: Borrow<Q>,
@@ -655,6 +698,29 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
             return None;
         }
         get_from_table::<D, Q>(&self.delete_mask, &self.data, key, txn_id)
+    }
+
+    /// Get a mutable reference to a value.
+    ///
+    /// Unlike most methods, `get_mut` will not update indexes after mutation. It is the caller's
+    /// responsibility to call `rebuild_indexes_for_key` whether the value is mutated or not (because
+    /// this method does clear the index for the returned key/value).
+    pub(crate) fn get_mut<Q>(
+        &mut self,
+        key: &Q,
+        txn_id: TxnId,
+        max_committed_id: TxnId,
+    ) -> Option<&mut D::Value>
+    where
+        D::Key: Borrow<Q>,
+        Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
+        D::Value: Clone,
+    {
+        let value = get_from_table_mut::<D, Q>(&mut self.delete_mask, &mut self.data, key, txn_id)?;
+        record_mutation(&mut self.modified, Some(key), txn_id, max_committed_id);
+        self.indexes.on_remove(value, txn_id, max_committed_id);
+
+        Some(value)
     }
 
     pub(crate) fn with_mut<Q, T>(
@@ -669,14 +735,9 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
         Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
         D::Value: Clone,
     {
-        let value = match self.delete_mask.get_mut(key, txn_id) {
-            MaskStatus::Unknown => self.data.get_mut(key)?.internal_clone(txn_id)?,
-            MaskStatus::Removed => return None,
-            MaskStatus::Overwritten(v) => v,
-        };
-
+        let value = get_from_table_mut::<D, Q>(&mut self.delete_mask, &mut self.data, key, txn_id)?;
+        record_mutation(&mut self.modified, Some(key), txn_id, max_committed_id);
         self.indexes.on_remove(value, txn_id, max_committed_id);
-        record_mutation(&mut self.modified, key, txn_id, max_committed_id);
         let result = f(value);
         self.indexes.on_insert(key, value, txn_id, max_committed_id);
         Some(result)
@@ -686,58 +747,6 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
         self.data
             .iter()
             .filter_map(move |(k, v)| Some((k, v.get(txn_id)?)))
-    }
-
-    fn iter_data_mut(
-        data: &mut HashMap<D::Key, VersionedValue<D::Value>>,
-        txn_id: TxnId,
-    ) -> impl Iterator<Item = (&D::Key, &mut D::Value)>
-    where
-        D::Value: Clone,
-    {
-        data.iter_mut()
-            .filter_map(move |(k, v)| Some((k, v.internal_clone(txn_id)?)))
-    }
-
-    pub(crate) fn for_each_mut(
-        &mut self,
-        mut f: impl FnMut(&D::Key, &mut D::Value),
-        txn_id: TxnId,
-        max_committed_id: TxnId,
-    ) where
-        D::Value: Clone,
-    {
-        match &mut self.delete_mask {
-            DeleteMask::None => {
-                self.indexes.clear(txn_id, max_committed_id);
-                Self::iter_data_mut(&mut self.data, txn_id).for_each(|(k, v)| {
-                    record_mutation(&mut self.modified, k, txn_id, max_committed_id);
-                    f(k, v);
-                    self.indexes.on_insert(k, v, txn_id, max_committed_id);
-                })
-            }
-            DeleteMask::All(_, pending) => {
-                self.indexes.clear(txn_id, max_committed_id);
-                pending.iter_mut().for_each(|(k, v)| {
-                    if let Some(v) = v.get_mut(txn_id) {
-                        record_mutation(&mut self.modified, k, txn_id, max_committed_id);
-                        f(k, v);
-                        self.indexes.on_insert(k, v, txn_id, max_committed_id);
-                    }
-                })
-            }
-            DeleteMask::Some(_, removed) => {
-                Self::iter_data_mut(&mut self.data, txn_id).for_each(|(k, v)| {
-                    if removed.contains(k) {
-                        return;
-                    }
-                    self.indexes.on_remove(v, txn_id, max_committed_id);
-                    record_mutation(&mut self.modified, k, txn_id, max_committed_id);
-                    f(k, v);
-                    self.indexes.on_insert(k, v, txn_id, max_committed_id);
-                })
-            }
-        }
     }
 
     pub fn insert(&mut self, key: D::Key, value: D::Value, txn_id: TxnId, max_committed_id: TxnId) {
@@ -751,7 +760,7 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
 
         match self.delete_mask.insert(key, value, txn_id) {
             MaskInsertResult::NotWritten(key, value) => {
-                record_mutation(&mut self.modified, &key, txn_id, max_committed_id);
+                record_mutation(&mut self.modified, Some(&key), txn_id, max_committed_id);
                 let entry = self.data.entry(key).or_default();
                 entry.set(value, txn_id);
             }
@@ -803,7 +812,9 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
     }
 }
 
-// Helper function for `get`, since calling `self.get` can cause lifetime issues.
+/// Helper function for getting a reference from a table taking into account the delete mask.
+///
+/// Making this a method could cause lifetime issues.
 fn get_from_table<'a, D: schema::TableDesc, Q>(
     delete_mask: &'a DeleteMask<D::Key, D::Value>,
     data: &'a HashMap<D::Key, VersionedValue<D::Value>>,
@@ -821,14 +832,36 @@ where
     })
 }
 
+/// Helper function for getting a mutable reference from a table taking into account the delete mask.
+///
+/// Making this a method could cause lifetime issues.
+fn get_from_table_mut<'a, D: schema::TableDesc, Q>(
+    delete_mask: &'a mut DeleteMask<D::Key, D::Value>,
+    data: &'a mut HashMap<D::Key, VersionedValue<D::Value>>,
+    key: &Q,
+    txn_id: TxnId,
+) -> Option<&'a mut D::Value>
+where
+    D::Key: Borrow<Q>,
+    D::Value: Clone,
+    Q: ?Sized + Hash + Eq,
+{
+    match delete_mask.get_mut(key, txn_id) {
+        MaskStatus::Unknown => data.get_mut(key)?.internal_clone(txn_id),
+        MaskStatus::Removed => None,
+        MaskStatus::Overwritten(v) => Some(v),
+    }
+}
+
 struct TxnMutations<K> {
     txn_id: TxnId,
-    keys: Vec<K>,
+    // `None` means all keys.
+    keys: Option<Vec<K>>,
 }
 
 fn record_mutation<K, Q>(
     modified: &mut Option<TxnMutations<K>>,
-    key: &Q,
+    key: Option<&Q>,
     txn_id: TxnId,
     max_committed_id: TxnId,
 ) where
@@ -836,16 +869,30 @@ fn record_mutation<K, Q>(
     Q: ?Sized + Hash + Eq + ToOwned<Owned = K>,
 {
     if txn_id != max_committed_id {
+        let Some(key) = key else {
+            match modified {
+                Some(modified) => {
+                    assert_eq!(modified.txn_id, txn_id);
+                    modified.keys = None;
+                }
+                None => {
+                    *modified = Some(TxnMutations { txn_id, keys: None });
+                }
+            };
+            return;
+        };
         let key = key.to_owned();
         match modified {
             Some(modified) => {
                 assert_eq!(modified.txn_id, txn_id);
-                modified.keys.push(key);
+                if let Some(keys) = &mut modified.keys {
+                    keys.push(key);
+                }
             }
             None => {
                 *modified = Some(TxnMutations {
                     txn_id,
-                    keys: vec![key],
+                    keys: Some(vec![key]),
                 });
             }
         }
@@ -855,7 +902,7 @@ fn record_mutation<K, Q>(
 /// Iterate the key-value pairs in a table.
 ///
 /// Takes into account the state of the table as visible to the transaction with id `self.txn_id`.
-pub struct TableIterator<'a, D: schema::TableDesc> {
+pub(crate) struct TableIterator<'a, D: schema::TableDesc> {
     data: std::collections::hash_map::Iter<'a, D::Key, VersionedValue<D::Value>>,
     delete_mask: &'a DeleteMask<D::Key, D::Value>,
     txn_id: TxnId,
@@ -885,6 +932,50 @@ impl<'a, D: schema::TableDesc> Iterator for TableIterator<'a, D> {
                 None
             }
         }
+    }
+}
+
+/// Iterate the key-value pairs in a table with mutable access.
+///
+/// Doesn't include the delete mask because of lifetime issues, so some pre-processing into `data`
+/// and `removed` is required, see `Table::iter_mut`.
+///
+/// Indexes for yielded key/value pairs are cleared, the caller is responsible for rebuilding the
+/// indexes.
+pub(crate) struct TableIteratorMut<'a, D: schema::TableDesc, I> {
+    data: std::collections::hash_map::IterMut<'a, D::Key, VersionedValue<D::Value>>,
+    removed: Option<&'a HashSet<D::Key>>,
+    indexes: &'a mut I,
+    txn_id: TxnId,
+    max_committed_id: TxnId,
+}
+
+impl<'a, D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Iterator
+    for TableIteratorMut<'a, D, I>
+where
+    D::Value: Clone,
+{
+    type Item = (&'a D::Key, &'a mut D::Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for (k, v) in &mut self.data {
+            if let Some(removed) = &self.removed
+                && removed.contains(k)
+            {
+                continue;
+            }
+            match v.internal_clone(self.txn_id) {
+                Some(v) => {
+                    // Remove this row's current index entries; they must be rebuilt from the (possibly
+                    // mutated) value after iteration finishes.
+                    self.indexes
+                        .on_remove(v, self.txn_id, self.max_committed_id);
+                    return Some((k, v));
+                }
+                None => continue,
+            }
+        }
+        None
     }
 }
 

--- a/ts_kv_store/src/transactions.rs
+++ b/ts_kv_store/src/transactions.rs
@@ -212,6 +212,13 @@ impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableSt
         // drop `self` to release the lock.
     }
 
+    /// Explicitly rollback this transaction.
+    ///
+    /// A transaction can also be rolled-back by dropping it without first calling `commit`.
+    pub fn rollback(self) {
+        // Dropping `self` causes the rollback.
+    }
+
     /// Operate on tables of key/values in the store.
     ///
     /// Example:
@@ -355,10 +362,7 @@ impl<'guard, D: TableDesc> KvTableTransactional<'guard, '_, D> {
     }
 
     /// Insert a value into the table.
-    pub fn insert(&mut self, key: D::Key, value: D::Value)
-    where
-        D::Key: Clone,
-    {
+    pub fn insert(&mut self, key: D::Key, value: D::Value) {
         <&mut Self as TabularOpsMut<_>>::insert(self, key, value, self.txn.owner)
     }
 
@@ -398,12 +402,22 @@ impl<'guard, D: TableDesc> KvTableTransactional<'guard, '_, D> {
         <&Self as TabularOps<_>>::values(self, self.txn.owner)
     }
 
-    /// Iterate all the key/value pairs in a table. Values are mutable.
-    pub fn for_each_mut(&mut self, f: impl FnMut(&D::Key, &mut D::Value))
+    /// Iterate all the key/value pairs in a table.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&D::Key, &mut D::Value)>
     where
         D::Value: Clone,
     {
-        <&mut Self as TabularOpsMut<_>>::for_each_mut(self, f, self.txn.owner)
+        let owner = self.txn.owner;
+        TabularOpsMut::iter_mut(self, owner)
+    }
+
+    /// Iterate all the values in a table.
+    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut D::Value>
+    where
+        D::Value: Clone,
+    {
+        let owner = self.txn.owner;
+        TabularOpsMut::values_mut(self, owner)
     }
 }
 
@@ -456,6 +470,13 @@ impl<'guard, TableStorage: schema::GeneratedStorage> RoTransaction<'guard, Table
     pub fn commit(self) -> Result<()> {
         // drop `self` to release the lock.
         Ok(())
+    }
+
+    /// Explicitly rollback this transaction.
+    ///
+    /// Like `commit`, this only drops this transaction's lock.
+    pub fn rollback(self) {
+        // drop `self` to release the lock.
     }
 
     /// Operate on tables of key/values in the store.
@@ -937,23 +958,112 @@ mod test {
     }
 
     #[test]
-    fn txn_table_for_each_mut_empty_calls_closure_zero_times() {
-        let store = KvStore::new();
-        let mut txn = store.begin_transaction(OWNER);
-        let mut table = txn.table::<Items>();
-        let mut count = 0;
-        table.for_each_mut(|_, _| count += 1);
-        assert_eq!(count, 0);
-    }
-
-    #[test]
-    fn txn_table_for_each_mut_modifies_values() {
+    fn txn_table_iter_mut_modifies_values() {
         let store = KvStore::new();
         let mut txn = store.begin_transaction(OWNER);
         let mut table = txn.table::<Items>();
         table.insert("k", "hello".to_owned());
-        table.for_each_mut(|_, v| v.push('!'));
+        table.iter_mut().next().unwrap().1.push('!');
         assert_eq!(table.get("k"), Some("hello!".to_owned()));
+    }
+
+    #[test]
+    fn txn_table_iter_mut_empty_yields_none() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        assert!(table.iter_mut().next().is_none());
+        assert_eq!(table.iter_mut().count(), 0);
+    }
+
+    #[test]
+    fn txn_table_iter_mut_visits_all_rows() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.insert("a", "x".to_owned());
+        table.insert("b", "y".to_owned());
+        table.insert("c", "z".to_owned());
+        for (_, v) in table.iter_mut() {
+            v.push('!');
+        }
+        assert_eq!(table.get("a"), Some("x!".to_owned()));
+        assert_eq!(table.get("b"), Some("y!".to_owned()));
+        assert_eq!(table.get("c"), Some("z!".to_owned()));
+    }
+
+    // `iter_mut` must respect a `DeleteMask::Some` produced by removing a key earlier in the
+    // same transaction: the removed key should not be visited.
+    #[test]
+    fn txn_table_iter_mut_skips_removed_key() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.insert("a", "x".to_owned());
+        table.insert("b", "y".to_owned());
+        table.insert("c", "z".to_owned());
+        table.remove(&"b");
+
+        let mut keys: Vec<_> = table.iter_mut().map(|(k, _)| *k).collect();
+        keys.sort();
+        assert_eq!(keys, vec!["a", "c"]);
+
+        // Mutations through the iterator still land, and the removed key stays gone.
+        for (_, v) in table.iter_mut() {
+            v.push('!');
+        }
+        assert_eq!(table.get("a"), Some("x!".to_owned()));
+        assert!(table.get("b").is_none());
+        assert_eq!(table.get("c"), Some("z!".to_owned()));
+    }
+
+    // `iter_mut` must respect a `DeleteMask::All` produced by clearing the table earlier in the
+    // same transaction: only rows inserted after the clear should be visited.
+    #[test]
+    fn txn_table_iter_mut_after_clear_visits_only_new_rows() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("a", "x".to_owned());
+        store.table::<Items>(OWNER).insert("b", "y".to_owned());
+
+        let mut txn = store.begin_transaction(OWNER);
+        let mut table = txn.table::<Items>();
+        table.clear();
+        table.insert("c", "z".to_owned());
+
+        let mut visited: Vec<_> = table.iter_mut().map(|(k, _)| *k).collect();
+        visited.sort();
+        assert_eq!(visited, vec!["c"]);
+
+        table.iter_mut().next().unwrap().1.push('!');
+        assert_eq!(table.get("c"), Some("z!".to_owned()));
+    }
+
+    // Rolling back a transaction that mutated values via `iter_mut` must leave the committed
+    // state untouched. This exercises the "all keys modified" (`keys == None`) GC path.
+    #[test]
+    fn txn_iter_mut_rollback_discards_changes() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("a", "x".to_owned());
+        store.table::<Items>(OWNER).insert("b", "y".to_owned());
+
+        let mut txn = store.begin_transaction(OWNER);
+        for (_, v) in txn.table::<Items>().iter_mut() {
+            v.push('!');
+        }
+        txn.rollback();
+
+        assert_eq!(store.table::<Items>(OWNER).get("a"), Some("x".to_owned()));
+        assert_eq!(store.table::<Items>(OWNER).get("b"), Some("y".to_owned()));
+
+        // The store is still usable and a fresh transaction sees the original values.
+        let mut txn = store.begin_transaction(OWNER);
+        let mut visited: Vec<_> = txn
+            .table::<Items>()
+            .iter_mut()
+            .map(|(k, v)| (*k, v.clone()))
+            .collect();
+        visited.sort();
+        assert_eq!(visited, vec![("a", "x".to_owned()), ("b", "y".to_owned())]);
     }
 
     #[test]
@@ -1785,17 +1895,22 @@ mod test {
     }
 
     #[test]
-    fn txn_for_each_mut_committed_values_commit_persists() {
+    fn txn_iter_mut_committed_values_commit_persists() {
         let store = KvStore::new();
         store.table::<Items>(OWNER).insert("a", "x".to_owned());
         store.table::<Items>(OWNER).insert("b", "y".to_owned());
 
         let mut txn = store.begin_transaction(OWNER);
-        txn.table::<Items>().for_each_mut(|_, v| v.push('!'));
+        for (_, v) in txn.table::<Items>().iter_mut() {
+            v.push('!');
+        }
+        for v in txn.table::<Items>().values_mut() {
+            v.push('!');
+        }
         txn.commit().unwrap();
 
-        assert_eq!(store.table::<Items>(OWNER).get("a"), Some("x!".to_owned()));
-        assert_eq!(store.table::<Items>(OWNER).get("b"), Some("y!".to_owned()));
+        assert_eq!(store.table::<Items>(OWNER).get("a"), Some("x!!".to_owned()));
+        assert_eq!(store.table::<Items>(OWNER).get("b"), Some("y!!".to_owned()));
     }
 
     #[test]


### PR DESCRIPTION
This PR replace the old `for_each_mut` API with mutable iterator API (slightly different for different kinds of tables/accesses). The main difficulty here (as well as some interesting lifetime/borrow checker issues) is that after mutation we have to rebuild indexes. That requires some tracking. I've opted to track individual keys since that will be more efficient if a small minority of values are mutated (which might be the case for indexes in particular). However, if the common case is that a whole table is modified then rebuilding the whole index might be more efficient. The other interesting thing is that for the raw API, we need to do the implicit commit somewhere. I explored having this in the dtor of an iterator, but this ended up needing some complex self-referential stuff, so there is a `with_iter_mut` function rather than `iter_mut`. If we really need the latter, we can probably do it, but it will require some unsafe code or pinning or something.

~~Based on #263~~
Closes #217

AI decl: used Claude to generate tests and for implementing mutation tracking in TableIteratorMut (following similar code for IndexedIteratorMut). Code has been reviewed and refactored.