### PR TITLE
ts_tunnel: refactor session state machine

### DIFF
--- a/ts_dataplane/src/lib.rs
+++ b/ts_dataplane/src/lib.rs
@@ -74,7 +74,7 @@ impl DataPlane {
 
         let ts_tunnel::SendResult {
             to_peers: encrypted,
-        } = self.wireguard.send(to_wireguard);
+        } = self.wireguard.send(Instant::now(), to_wireguard);
 
         let to_peers = self
             .ur_out
@@ -96,7 +96,8 @@ impl DataPlane {
         &mut self,
         packets: impl IntoIterator<Item = PacketMut>,
     ) -> InboundResult {
-        let ts_tunnel::RecvResult { to_local, to_peers } = self.wireguard.recv(packets);
+        let ts_tunnel::RecvResult { to_local, to_peers } =
+            self.wireguard.recv(Instant::now(), packets);
 
         let to_local = to_local
             .into_iter()

--- a/ts_tunnel/examples/handshake.rs
+++ b/ts_tunnel/examples/handshake.rs
@@ -112,7 +112,7 @@ async fn main() -> BoxResult<()> {
                 let mut packet = PacketMut::new(0);
                 packet.put_slice(b"test test");
 
-                let ts_tunnel::SendResult { to_peers } = ep.send([(peer_id, vec![packet])]);
+                let ts_tunnel::SendResult { to_peers } = ep.send(Instant::now(), [(peer_id, vec![packet])]);
 
                 for (peer_id, packets) in to_peers {
                     eprintln!("sending {} packets to {peer_id:?}", packets.len());
@@ -128,7 +128,7 @@ async fn main() -> BoxResult<()> {
                 eprintln!("receive resp (len {n}, from {from})");
                 let buf = &buf[..n];
 
-                let ts_tunnel::RecvResult { to_peers, to_local } = ep.recv(vec![PacketMut::from(buf)]);
+                let ts_tunnel::RecvResult { to_peers, to_local } = ep.recv(Instant::now(), vec![PacketMut::from(buf)]);
 
                 eprintln!(
                     "resp: {} packets to peers, {} to local",

--- a/ts_tunnel/src/endpoint.rs
+++ b/ts_tunnel/src/endpoint.rs
@@ -51,12 +51,12 @@ impl Peer {
         }
     }
 
-    fn schedule_keepalive(&mut self, scheduler: &mut Scheduler<Event>) {
+    fn schedule_keepalive(&mut self, scheduler: &mut Scheduler<Event>, now: Instant) {
         if self.keepalive.is_some() {
             self.send_another_keepalive = true;
             return;
         }
-        let tr = TimeRange::new_around(Instant::now() + KEEPALIVE_TIMEOUT, Duration::from_secs(1));
+        let tr = TimeRange::new_around(now + KEEPALIVE_TIMEOUT, Duration::from_secs(1));
         self.keepalive = Some(scheduler.add(tr, Event::MaybeSendKeepalive(self.id)));
     }
 
@@ -65,9 +65,10 @@ impl Peer {
         &mut self,
         endpoint: &mut EndpointState,
         packets: Vec<PacketMut>,
+        now: Instant,
         out: &mut SendResult,
     ) {
-        if let Some(mut packets) = self.session.send(packets, &mut endpoint.ids) {
+        if let Some(mut packets) = self.session.send(packets, &mut endpoint.ids, now) {
             tracing::trace!("enqueueing packets to peer");
             out.queue_to_peer(self.id).append(&mut packets);
             // Fall through to check if the session is in need of rotation.
@@ -78,12 +79,12 @@ impl Peer {
             return;
         }
 
-        if !self.session.needs_handshake() {
-            tracing::trace!("session does not need rotation");
+        if !self.session.needs_handshake(now) {
+            tracing::trace!("session does not need new handshake");
             return;
         }
 
-        self.start_handshake(endpoint, out);
+        self.start_handshake(endpoint, now, out);
     }
 
     #[tracing::instrument(skip_all, fields(?session_id, n_packets = packets.len()))]
@@ -92,6 +93,7 @@ impl Peer {
         endpoint: &mut EndpointState,
         session_id: SessionId,
         mut packets: Vec<PacketMut>,
+        now: Instant,
         out: &mut RecvResult,
     ) {
         let pre_len = packets.len();
@@ -103,7 +105,7 @@ impl Peer {
             }
             Ok(MessageMut::TransportDataHeader(_)) => true,
             Ok(MessageMut::HandshakeResponse(resp)) => {
-                self.recv_handshake_response(endpoint, resp, out);
+                self.recv_handshake_response(endpoint, resp, now, out);
                 false
             }
             Ok(MessageMut::CookieReply(resp)) => {
@@ -125,7 +127,7 @@ impl Peer {
             tracing::trace!(n_dropped = pre_len - post_len, "dropped packets");
         }
 
-        self.recv_transport_data(endpoint, session_id, packets, out);
+        self.recv_transport_data(endpoint, session_id, packets, now, out);
     }
 
     fn recv_cookie_reply(&mut self, packet: &CookieReply) {
@@ -140,6 +142,7 @@ impl Peer {
         &mut self,
         endpoint: &mut EndpointState,
         packet: &mut HandshakeResponse,
+        now: Instant,
         out: &mut RecvResult,
     ) {
         let Some(session) = self.handshake.finish(
@@ -147,18 +150,18 @@ impl Peer {
             &endpoint.my_key,
             &self.config.psk,
             &endpoint.my_cookie,
-            Instant::now(),
+            now,
         ) else {
             tracing::error!("handshake failed to complete");
             return;
         };
 
-        let mut packets = self.session.activate(session, &mut endpoint.ids, true);
+        let mut packets = self.session.activate(session, &mut endpoint.ids, now, true);
         out.queue_to_peer(self.id).append(&mut packets);
         if let Some(handle) = self.session_cleanup.take() {
             handle.cancel();
         };
-        let expiry = Instant::now() + SESSION_LIFETIME;
+        let expiry = now + SESSION_LIFETIME;
         self.session_cleanup = Some(endpoint.scheduler.add(
             TimeRange::new(expiry, expiry + SESSION_CLEANUP_GRACE),
             Event::ExpireSession(self.id),
@@ -170,13 +173,14 @@ impl Peer {
         endpoint: &mut EndpointState,
         session_id: SessionId,
         packets: Vec<PacketMut>,
+        now: Instant,
         out: &mut RecvResult,
     ) {
-        if let Some(recv) = self.session.get_recv(session_id, &mut endpoint.ids) {
+        if let Some(recv) = self.session.get_recv(session_id, &mut endpoint.ids, now) {
             let mut packets = recv.decrypt(packets);
             if !packets.is_empty() {
                 out.queue_to_local(self.id).append(&mut packets);
-                self.schedule_keepalive(&mut endpoint.scheduler);
+                self.schedule_keepalive(&mut endpoint.scheduler, now);
             }
             return;
         }
@@ -187,9 +191,11 @@ impl Peer {
         };
 
         out.queue_to_local(self.id).append(&mut packets);
-        self.schedule_keepalive(&mut endpoint.scheduler);
+        self.schedule_keepalive(&mut endpoint.scheduler, now);
 
-        let mut packets_for_peer = self.session.activate(session, &mut endpoint.ids, false);
+        let mut packets_for_peer = self
+            .session
+            .activate(session, &mut endpoint.ids, now, false);
         if !packets_for_peer.is_empty() {
             out.queue_to_peer(self.id).append(&mut packets_for_peer);
         }
@@ -197,7 +203,7 @@ impl Peer {
             handle.cancel();
         }
         // Session was just activated above, so it has an expiry time.
-        let expiry = self.session.expiry(&mut endpoint.ids).unwrap();
+        let expiry = self.session.expiry(&mut endpoint.ids, now).unwrap();
         self.session_cleanup = Some(
             endpoint
                 .scheduler
@@ -209,6 +215,7 @@ impl Peer {
         &mut self,
         endpoint: &mut EndpointState,
         handshake: ReceivedHandshake,
+        now: Instant,
         out: &mut RecvResult,
     ) {
         if let Some(timestamp) = self.last_seen_timestamp
@@ -231,12 +238,17 @@ impl Peer {
             handshake,
             &self.config.psk,
             &self.cookie_sender,
-            Instant::now(),
+            now,
         );
         out.queue_to_peer(self.id).push(packet);
     }
 
-    fn handshake_timeout(&mut self, endpoint: &mut EndpointState, out: &mut EventResult) {
+    fn handshake_timeout(
+        &mut self,
+        endpoint: &mut EndpointState,
+        now: Instant,
+        out: &mut EventResult,
+    ) {
         if !self.handshake.is_active() {
             // Handshake completed prior to timeout firing.
             return;
@@ -245,11 +257,16 @@ impl Peer {
         endpoint.ids.remove_handshake_session(&self.handshake);
         self.handshake = Handshake::None;
 
-        self.start_handshake(endpoint, out);
+        self.start_handshake(endpoint, now, out);
     }
 
-    fn send_keepalive(&mut self, endpoint: &mut EndpointState, out: &mut EventResult) {
-        let Some(packet) = self.session.send_keepalive(&mut endpoint.ids) else {
+    fn send_keepalive(
+        &mut self,
+        endpoint: &mut EndpointState,
+        now: Instant,
+        out: &mut EventResult,
+    ) {
+        let Some(packet) = self.session.send_keepalive(&mut endpoint.ids, now) else {
             tracing::trace!("send keepalive: session expired, skipping");
             return;
         };
@@ -258,13 +275,13 @@ impl Peer {
         self.keepalive = None;
 
         if self.send_another_keepalive {
-            self.schedule_keepalive(&mut endpoint.scheduler);
+            self.schedule_keepalive(&mut endpoint.scheduler, now);
             self.send_another_keepalive = false;
         }
     }
 
-    fn cleanup_expired(&mut self, endpoint: &mut EndpointState) {
-        self.session.cleanup_expired(&mut endpoint.ids)
+    fn cleanup_expired(&mut self, endpoint: &mut EndpointState, now: Instant) {
+        self.session.cleanup_expired(&mut endpoint.ids, now)
     }
 
     fn shutdown(&mut self, endpoint: &mut EndpointState) {
@@ -282,7 +299,12 @@ impl Peer {
 
     /// (Soft) precondition: `self.handshake == HandshakeState::None` (previous handshake is lost, but
     /// that shouldn't cause anything terrible to happen).
-    fn start_handshake(&mut self, endpoint: &mut EndpointState, out: &mut impl QueueToPeer) {
+    fn start_handshake(
+        &mut self,
+        endpoint: &mut EndpointState,
+        now: Instant,
+        out: &mut impl QueueToPeer,
+    ) {
         // TODO most of this logic might be better in the `handshake` module.
         let session_id = endpoint.ids.allocate_session(self.id);
         let (handshake, packet) = initiate_handshake(
@@ -298,10 +320,7 @@ impl Peer {
         tracing::debug!(peer_id = ?self.id, ?session_id, "enqueue handshake start");
 
         out.queue_to_peer(self.id).push(packet);
-        let tr = TimeRange::new_around(
-            Instant::now() + HANDSHAKE_TIMEOUT,
-            Duration::from_millis(500),
-        );
+        let tr = TimeRange::new_around(now + HANDSHAKE_TIMEOUT, Duration::from_millis(500));
 
         let timeout = endpoint.scheduler.add(tr, Event::HandshakeTimeout(self.id));
         self.handshake = Handshake::Initiated(handshake, timeout, mac);
@@ -387,6 +406,7 @@ impl Endpoint {
     /// Send packets to peers.
     pub fn send(
         &mut self,
+        now: Instant,
         packets: impl IntoIterator<Item = (PeerId, Vec<PacketMut>)>,
     ) -> SendResult {
         let mut ret = SendResult::default();
@@ -402,13 +422,17 @@ impl Endpoint {
                 "processing send packets"
             );
 
-            peer.send(&mut self.state, packets, &mut ret);
+            peer.send(&mut self.state, packets, now, &mut ret);
         }
         ret
     }
 
     /// Receive packets from peers.
-    pub fn recv(&mut self, packets: impl IntoIterator<Item = PacketMut>) -> RecvResult {
+    pub fn recv(
+        &mut self,
+        now: Instant,
+        packets: impl IntoIterator<Item = PacketMut>,
+    ) -> RecvResult {
         let mut ret = RecvResult::default();
 
         let mut packets = packets.into_iter().into_group_map_by(|packet| {
@@ -426,7 +450,7 @@ impl Endpoint {
         }
 
         for packet in handshakes {
-            self.process_one_handshake(packet, &mut ret);
+            self.process_one_handshake(packet, now, &mut ret);
         }
 
         tracing::trace!(n = packets.len(), "processing packets");
@@ -443,13 +467,13 @@ impl Endpoint {
                 continue;
             };
 
-            peer.recv(&mut self.state, session_id, packets, &mut ret);
+            peer.recv(&mut self.state, session_id, packets, now, &mut ret);
         }
 
         ret
     }
 
-    fn process_one_handshake(&mut self, mut packet: PacketMut, out: &mut RecvResult) {
+    fn process_one_handshake(&mut self, mut packet: PacketMut, now: Instant, out: &mut RecvResult) {
         let Ok(MessageMut::HandshakeInitiation(init)) = MessageMut::try_from(packet.as_mut())
         else {
             tracing::error!("message parsing failed");
@@ -471,7 +495,7 @@ impl Endpoint {
             return;
         };
 
-        peer.respond_to_handshake(&mut self.state, handshake, out)
+        peer.respond_to_handshake(&mut self.state, handshake, now, out)
     }
 
     /// Dispatch time-based events that are due to occur at or before the given instant.
@@ -486,19 +510,19 @@ impl Endpoint {
                     let Some(peer) = self.peers.get_mut(&peer_id) else {
                         continue;
                     };
-                    peer.handshake_timeout(&mut self.state, &mut out);
+                    peer.handshake_timeout(&mut self.state, now, &mut out);
                 }
                 Event::MaybeSendKeepalive(peer_id) => {
                     let Some(peer) = self.peers.get_mut(&peer_id) else {
                         continue;
                     };
-                    peer.send_keepalive(&mut self.state, &mut out);
+                    peer.send_keepalive(&mut self.state, now, &mut out);
                 }
                 Event::ExpireSession(peer_id) => {
                     let Some(peer) = self.peers.get_mut(&peer_id) else {
                         continue;
                     };
-                    peer.cleanup_expired(&mut self.state);
+                    peer.cleanup_expired(&mut self.state, now);
                 }
             }
         }
@@ -601,6 +625,7 @@ mod tests {
     fn test_one_peer() {
         let (a_static, b_static) = (NodeKeyPair::new(), NodeKeyPair::new());
         let psk = rand::random();
+        let now = Instant::now();
 
         let (mut a_ep, mut b_ep) = (
             Endpoint::new(a_static.clone()),
@@ -640,7 +665,7 @@ mod tests {
         // A sends to B. Results in a handshake initiation being transmitted, not the
         // requested packet (which gets buffered internally by the endpoint).
         let to_send = HashMap::from([(a_peer, Vec::from([a_to_b_packets[0].clone()]))]);
-        let a_acts = a_ep.send(to_send);
+        let a_acts = a_ep.send(now, to_send);
         assert_eq!(
             a_acts.to_peers.len(),
             1,
@@ -654,11 +679,11 @@ mod tests {
 
         // A sends another packet. No further activity, but pkt2 gets queued as well.
         let to_send = HashMap::from([(a_peer, Vec::from([a_to_b_packets[1].clone()]))]);
-        let a_acts2 = a_ep.send(to_send);
+        let a_acts2 = a_ep.send(now, to_send);
         assert_eq!(a_acts2, SendResult::default());
 
         // B processes the handshake and responds. No packets delivered to B.
-        let b_acts = b_ep.recv(packets.clone());
+        let b_acts = b_ep.recv(now, packets.clone());
         assert_eq!(b_acts.to_local.len(), 0, "unexpected received message");
         assert_eq!(
             b_acts.to_peers.len(),
@@ -672,7 +697,7 @@ mod tests {
         assert_eq!(packets.len(), 1, "unexpected packet count for B's peer");
 
         // A processes the response, and sends the two queued packets.
-        let a_acts3 = a_ep.recv(packets.clone());
+        let a_acts3 = a_ep.recv(now, packets.clone());
         assert_eq!(a_acts3.to_local.len(), 0, "unexpected received message");
         assert_eq!(
             a_acts3.to_peers.len(),
@@ -686,7 +711,7 @@ mod tests {
         assert_eq!(packets.len(), 2, "wrong number of packets for A's peer");
 
         // B receives transport messages.
-        let b_acts = b_ep.recv(packets.clone());
+        let b_acts = b_ep.recv(now, packets.clone());
         assert_eq!(b_acts.to_local.len(), 1, "didn't receive message");
         let packets = b_acts
             .to_local
@@ -698,7 +723,7 @@ mod tests {
         // B sends transport message
         let b_to_a_packet = PacketMut::from(vec![9, 10, 11, 12]);
         let to_send = HashMap::from([(b_peer, vec![b_to_a_packet.clone()])]);
-        let b_acts = b_ep.send(to_send);
+        let b_acts = b_ep.send(now, to_send);
         assert_eq!(
             b_acts.to_peers.len(),
             1,
@@ -711,7 +736,7 @@ mod tests {
         assert_eq!(packets.len(), 1, "unexpected packet count for B's peer");
 
         // A receives
-        let a_acts = a_ep.recv(packets.clone());
+        let a_acts = a_ep.recv(now, packets.clone());
         assert_eq!(a_acts.to_local.len(), 1, "didn't receive message");
         let packets = a_acts
             .to_local

--- a/ts_tunnel/src/endpoint.rs
+++ b/ts_tunnel/src/endpoint.rs
@@ -13,7 +13,7 @@ use crate::{
     ids::IdMap,
     macs::{MACReceiver, MACSender},
     messages::{CookieReply, HandshakeResponse, Message, MessageMut, SessionId},
-    session::{SESSION_CLEANUP_GRACE, SESSION_LIFETIME, Session},
+    session::Session,
     time::{TAI64N, TAI64NClock},
 };
 
@@ -156,16 +156,16 @@ impl Peer {
             return;
         };
 
-        let mut packets = self.session.activate(session, &mut endpoint.ids, now, true);
+        let (expiry, mut packets) = self.session.activate(session, &mut endpoint.ids, now, true);
         out.queue_to_peer(self.id).append(&mut packets);
         if let Some(handle) = self.session_cleanup.take() {
             handle.cancel();
         };
-        let expiry = now + SESSION_LIFETIME;
-        self.session_cleanup = Some(endpoint.scheduler.add(
-            TimeRange::new(expiry, expiry + SESSION_CLEANUP_GRACE),
-            Event::ExpireSession(self.id),
-        ));
+        self.session_cleanup = Some(
+            endpoint
+                .scheduler
+                .add(expiry, Event::ExpireSession(self.id)),
+        );
     }
 
     fn recv_transport_data(
@@ -193,17 +193,15 @@ impl Peer {
         out.queue_to_local(self.id).append(&mut packets);
         self.schedule_keepalive(&mut endpoint.scheduler, now);
 
-        let mut packets_for_peer = self
-            .session
-            .activate(session, &mut endpoint.ids, now, false);
+        let (expiry, mut packets_for_peer) =
+            self.session
+                .activate(session, &mut endpoint.ids, now, false);
         if !packets_for_peer.is_empty() {
             out.queue_to_peer(self.id).append(&mut packets_for_peer);
         }
         if let Some(handle) = self.session_cleanup.take() {
             handle.cancel();
         }
-        // Session was just activated above, so it has an expiry time.
-        let expiry = self.session.expiry(&mut endpoint.ids, now).unwrap();
         self.session_cleanup = Some(
             endpoint
                 .scheduler

--- a/ts_tunnel/src/endpoint.rs
+++ b/ts_tunnel/src/endpoint.rs
@@ -1,9 +1,5 @@
 use core::time::Duration;
-use std::{
-    cmp::min,
-    collections::{HashMap, VecDeque, vec_deque},
-    time::Instant,
-};
+use std::{collections::HashMap, time::Instant};
 
 use itertools::Itertools;
 use ts_keys::{NodeKeyPair, NodePublicKey};
@@ -13,14 +9,13 @@ use zerocopy::IntoBytes;
 
 use crate::{
     config::{PeerConfig, PeerId},
-    handshake::{Handshake, ReceivedHandshake, SessionPair, initiate_handshake},
+    handshake::{Handshake, ReceivedHandshake, initiate_handshake},
+    ids::IdMap,
     macs::{MACReceiver, MACSender},
     messages::{CookieReply, HandshakeResponse, Message, MessageMut, SessionId},
-    session::{ReceiveSession, SESSION_CLEANUP_GRACE, SESSION_LIFETIME, TransmitSession},
+    session::{SESSION_CLEANUP_GRACE, SESSION_LIFETIME, Session},
     time::{TAI64N, TAI64NClock},
 };
-
-const MAX_QUEUED_PER_PEER: usize = 32;
 
 /// If an endpoint hasn't sent any packets to a peer for `KEEPALIVE_TIMEOUT` after receiving a
 /// packet from that peer, it must send an empty keepalive message so that the peer can distinguish
@@ -28,277 +23,10 @@ const MAX_QUEUED_PER_PEER: usize = 32;
 /// See: WireGuard spec, section 6.5
 const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// A bounded packet queue that drops oldest packets when full.
-#[derive(Default)]
-struct Queue(VecDeque<PacketMut>);
-
-impl Queue {
-    /// Shorthand for Queue::default then Queue::append.
-    fn new_with(packets: Vec<PacketMut>) -> Self {
-        let mut queue = Self::default();
-        queue.append(packets);
-        queue
-    }
-
-    fn append(&mut self, packets: Vec<PacketMut>) {
-        let new_packets = min(packets.len(), MAX_QUEUED_PER_PEER);
-        let drop_incoming = packets.len() - new_packets;
-        let keep_queued = MAX_QUEUED_PER_PEER - new_packets;
-        let drop_queued = self.0.len().saturating_sub(keep_queued);
-        self.0.drain(..drop_queued);
-        packets
-            .into_iter()
-            .skip(drop_incoming)
-            .for_each(|packet| self.0.push_back(packet));
-    }
-}
-
-impl From<Queue> for Vec<PacketMut> {
-    fn from(queue: Queue) -> Self {
-        queue.0.into()
-    }
-}
-
-impl IntoIterator for Queue {
-    type Item = PacketMut;
-    type IntoIter = vec_deque::IntoIter<PacketMut>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
-/// State of a peer's session.
-enum SessionState {
-    /// No active session, packets may be queued for future transmission.
-    None(Queue),
-    /// Active session available.
-    Active {
-        recv: Box<ReceiveSession>,
-        recv_prev: Option<Box<ReceiveSession>>,
-        send: TransmitSession,
-    },
-}
-
-impl SessionState {
-    /// Take the session state, leaving SessionState::None in its place.
-    fn take(&mut self) -> SessionState {
-        std::mem::replace(self, SessionState::None(Queue::default()))
-    }
-
-    /// Activate the session using the provided send/receive sessions.
-    ///
-    /// Existing sessions are rotated appropriately. Returns encrypted packets to send to the
-    /// peer, if any were queued.
-    fn activate(&mut self, endpoint: &mut EndpointState, next: SessionPair) -> Vec<PacketMut> {
-        tracing::trace!(recv_id = ?next.recv.id(), "activating new session");
-
-        match self.take() {
-            SessionState::None(queue) => {
-                let mut ret = queue.into();
-                next.send.encrypt(&mut ret);
-                *self = SessionState::Active {
-                    send: next.send,
-                    recv: Box::new(next.recv),
-                    recv_prev: None,
-                };
-                ret
-            }
-            SessionState::Active {
-                recv,
-                mut recv_prev,
-                ..
-            } => {
-                recv_prev
-                    .take()
-                    .inspect(|recv_prev| endpoint.ids.remove_session(recv_prev.id()));
-                *self = SessionState::Active {
-                    send: next.send,
-                    recv: Box::new(next.recv),
-                    recv_prev: Some(recv),
-                };
-                vec![]
-            }
-        }
-    }
-
-    /// Deactivate the session, releasing any active session IDs.
-    fn deactivate(&mut self, endpoint: &mut EndpointState) {
-        if let SessionState::Active {
-            recv,
-            mut recv_prev,
-            ..
-        } = self.take()
-        {
-            endpoint.ids.remove_session(recv.id());
-            recv_prev
-                .as_mut()
-                .inspect(|recv_prev| endpoint.ids.remove_session(recv_prev.id()));
-        }
-    }
-
-    /// Encrypt a keepalive packet for transmission.
-    ///
-    /// Returns None if the session cannot currently transmit.
-    fn encrypt_keepalive(&mut self) -> Option<PacketMut> {
-        if let SessionState::Active { send, .. } = self
-            && !send.expired(Instant::now())
-        {
-            let mut packet = vec![PacketMut::new(0)];
-            send.encrypt(&mut packet);
-            packet.pop()
-        } else {
-            None
-        }
-    }
-
-    /// Encrypt packets for transmission.
-    ///
-    /// Returns the encrypted packets if a session is available, otherwise queues the packets and
-    /// returns None to signal that the caller needs to establish a session.
-    fn encrypt_or_queue(&mut self, mut packets: Vec<PacketMut>) -> Option<Vec<PacketMut>> {
-        match self {
-            SessionState::None(queue) => {
-                queue.append(packets);
-                None
-            }
-            SessionState::Active { send, .. } => {
-                if send.expired(Instant::now()) {
-                    // Note, this also deletes both receive sessions. This is okay: due to the
-                    // semantics of session rotation, if the transmit session has expired, all
-                    // receive sessions have also expired.
-                    *self = SessionState::None(Queue::new_with(packets));
-                    return None;
-                }
-                send.encrypt(&mut packets);
-                Some(packets)
-            }
-        }
-    }
-
-    /// Get the receive session matching the given ID, if any.
-    fn get_recv(&mut self, id: SessionId) -> Option<&mut ReceiveSession> {
-        match self {
-            SessionState::None(_) => None,
-            SessionState::Active {
-                recv, recv_prev, ..
-            } => {
-                if recv.id() == id && !recv.expired(Instant::now()) {
-                    Some(recv)
-                } else if let Some(recv_prev) = recv_prev.as_mut()
-                    && recv_prev.id() == id
-                    && !recv.expired(Instant::now())
-                {
-                    Some(recv_prev)
-                } else {
-                    None
-                }
-            }
-        }
-    }
-
-    /// Report whether the transmit side of the session is stale and in need of key rotation.
-    ///
-    /// Returns true if no session exists.
-    fn needs_rotation(&self) -> bool {
-        match self {
-            SessionState::None(_) => true,
-            SessionState::Active { send, .. } => send.stale(Instant::now()),
-        }
-    }
-
-    fn expire_sessions(&mut self, endpoint: &mut EndpointState) {
-        match self {
-            SessionState::None(_) => (),
-            SessionState::Active {
-                recv, recv_prev, ..
-            } => {
-                if recv.expired(Instant::now()) {
-                    // If the latest recv session is expired, send is also expired and any
-                    // recv_prev will be as well.
-                    self.deactivate(endpoint)
-                } else if let Some(prev) = recv_prev
-                    && prev.expired(Instant::now())
-                {
-                    recv_prev
-                        .take()
-                        .inspect(|recv_prev| endpoint.ids.remove_session(recv_prev.id()));
-                }
-            }
-        }
-    }
-}
-
-/// Tracks and allocates session IDs for peer sessions.
-#[derive(Default)]
-struct IdMap {
-    sessions: HashMap<SessionId, PeerId>,
-    // TODO: track recently abandoned session IDs, avoid reusing them for
-    // one or two session lifetimes to avoid confusion with reordered packets.
-    node_keys: HashMap<NodePublicKey, PeerId>,
-}
-
-impl IdMap {
-    /// Return the peer handle for a node public key, if any.
-    fn get_by_nodekey(&self, key: &NodePublicKey) -> Option<PeerId> {
-        self.node_keys.get(key).copied()
-    }
-
-    /// Return the peer handle for a session, if any.
-    fn get_by_session_id(&self, key: &SessionId) -> Option<&PeerId> {
-        self.sessions.get(key)
-    }
-
-    /// Add a peer handle for communicating with the given peer pubkey.
-    ///
-    /// Returns `false` if a peer already exists for the key.
-    fn add_peer(&mut self, id: PeerId, key: &NodePublicKey) -> bool {
-        if self.node_keys.contains_key(key) {
-            return false;
-        }
-
-        self.node_keys.insert(*key, id);
-        true
-    }
-
-    /// Allocate a new session ID for communication with the given peer.
-    ///
-    /// Note that due to key rotation, a peer can have multiple session IDs in use at once.
-    fn allocate_session(&mut self, peer: PeerId) -> SessionId {
-        loop {
-            let ret = SessionId::random();
-            if let std::collections::hash_map::Entry::Vacant(e) = self.sessions.entry(ret) {
-                e.insert(peer);
-                return ret;
-            }
-        }
-    }
-
-    /// Abandon the given session ID.
-    ///
-    /// Panics if the session ID isn't currently in use.
-    fn remove_session(&mut self, id: SessionId) {
-        self.sessions.remove(&id).unwrap();
-    }
-
-    fn remove_handshake_session(&mut self, handshake: &Handshake) {
-        if let Some(id) = handshake.session_id() {
-            self.remove_session(id);
-        }
-    }
-
-    /// Delete the peer handle for the given key.
-    ///
-    /// Panics if there is no peer currently using that key.
-    fn remove_peer(&mut self, key: &NodePublicKey) {
-        self.node_keys.remove(key).unwrap();
-    }
-}
-
 struct Peer {
     id: PeerId,
     config: PeerConfig,
-    session: SessionState,
+    session: Session,
     handshake: Handshake,
     last_seen_timestamp: Option<TAI64N>,
     cookie_sender: MACSender,
@@ -313,7 +41,7 @@ impl Peer {
         Self {
             id,
             config,
-            session: SessionState::None(Queue::default()),
+            session: Default::default(),
             handshake: Handshake::None,
             last_seen_timestamp: None,
             cookie_sender: macs,
@@ -339,7 +67,7 @@ impl Peer {
         packets: Vec<PacketMut>,
         out: &mut SendResult,
     ) {
-        if let Some(mut packets) = self.session.encrypt_or_queue(packets) {
+        if let Some(mut packets) = self.session.send(packets, &mut endpoint.ids) {
             tracing::trace!("enqueueing packets to peer");
             out.queue_to_peer(self.id).append(&mut packets);
             // Fall through to check if the session is in need of rotation.
@@ -350,7 +78,7 @@ impl Peer {
             return;
         }
 
-        if !self.session.needs_rotation() {
+        if !self.session.needs_handshake() {
             tracing::trace!("session does not need rotation");
             return;
         }
@@ -425,15 +153,7 @@ impl Peer {
             return;
         };
 
-        let mut packets = self.session.activate(endpoint, session);
-        if packets.is_empty() {
-            // Upon completing a handshake, the initiator must send at least one packet to confirm
-            // the session. Usually that can be a queued packet, but if we happen to complete a
-            // handshake with no queued packets available, we have to send an empty packet explicitly.
-            packets.push(PacketMut::new(0));
-            // Session was just activated, therefore it can encrypt.
-            packets = self.session.encrypt_or_queue(packets).unwrap();
-        }
+        let mut packets = self.session.activate(session, &mut endpoint.ids, true);
         out.queue_to_peer(self.id).append(&mut packets);
         if let Some(handle) = self.session_cleanup.take() {
             handle.cancel();
@@ -449,11 +169,11 @@ impl Peer {
         &mut self,
         endpoint: &mut EndpointState,
         session_id: SessionId,
-        mut packets: Vec<PacketMut>,
+        packets: Vec<PacketMut>,
         out: &mut RecvResult,
     ) {
-        if let Some(session) = self.session.get_recv(session_id) {
-            packets = session.decrypt(packets);
+        if let Some(recv) = self.session.get_recv(session_id, &mut endpoint.ids) {
+            let mut packets = recv.decrypt(packets);
             if !packets.is_empty() {
                 out.queue_to_local(self.id).append(&mut packets);
                 self.schedule_keepalive(&mut endpoint.scheduler);
@@ -469,18 +189,20 @@ impl Peer {
         out.queue_to_local(self.id).append(&mut packets);
         self.schedule_keepalive(&mut endpoint.scheduler);
 
-        let mut packets_for_peer = self.session.activate(endpoint, session);
+        let mut packets_for_peer = self.session.activate(session, &mut endpoint.ids, false);
         if !packets_for_peer.is_empty() {
             out.queue_to_peer(self.id).append(&mut packets_for_peer);
         }
         if let Some(handle) = self.session_cleanup.take() {
             handle.cancel();
         }
-        let expiry = Instant::now() + SESSION_LIFETIME;
-        self.session_cleanup = Some(endpoint.scheduler.add(
-            TimeRange::new(expiry, expiry + SESSION_CLEANUP_GRACE),
-            Event::ExpireSession(self.id),
-        ));
+        // Session was just activated above, so it has an expiry time.
+        let expiry = self.session.expiry(&mut endpoint.ids).unwrap();
+        self.session_cleanup = Some(
+            endpoint
+                .scheduler
+                .add(expiry, Event::ExpireSession(self.id)),
+        );
     }
 
     fn respond_to_handshake(
@@ -526,8 +248,8 @@ impl Peer {
         self.start_handshake(endpoint, out);
     }
 
-    fn send_keepalive(&mut self, scheduler: &mut Scheduler<Event>, out: &mut EventResult) {
-        let Some(packet) = self.session.encrypt_keepalive() else {
+    fn send_keepalive(&mut self, endpoint: &mut EndpointState, out: &mut EventResult) {
+        let Some(packet) = self.session.send_keepalive(&mut endpoint.ids) else {
             tracing::trace!("send keepalive: session expired, skipping");
             return;
         };
@@ -536,20 +258,26 @@ impl Peer {
         self.keepalive = None;
 
         if self.send_another_keepalive {
-            self.schedule_keepalive(scheduler);
+            self.schedule_keepalive(&mut endpoint.scheduler);
             self.send_another_keepalive = false;
         }
     }
 
-    fn expire_sessions(&mut self, endpoint: &mut EndpointState) {
-        self.session.expire_sessions(endpoint);
+    fn cleanup_expired(&mut self, endpoint: &mut EndpointState) {
+        self.session.cleanup_expired(&mut endpoint.ids)
     }
 
     fn shutdown(&mut self, endpoint: &mut EndpointState) {
-        self.session.deactivate(endpoint);
+        self.session.deactivate(&mut endpoint.ids);
 
         endpoint.ids.remove_handshake_session(&self.handshake);
         self.handshake = Handshake::None;
+        if let Some(handle) = self.session_cleanup.take() {
+            handle.cancel();
+        }
+        if let Some(handle) = self.keepalive.take() {
+            handle.cancel();
+        }
     }
 
     /// (Soft) precondition: `self.handshake == HandshakeState::None` (previous handshake is lost, but
@@ -764,13 +492,13 @@ impl Endpoint {
                     let Some(peer) = self.peers.get_mut(&peer_id) else {
                         continue;
                     };
-                    peer.send_keepalive(&mut self.state.scheduler, &mut out);
+                    peer.send_keepalive(&mut self.state, &mut out);
                 }
                 Event::ExpireSession(peer_id) => {
                     let Some(peer) = self.peers.get_mut(&peer_id) else {
                         continue;
                     };
-                    peer.expire_sessions(&mut self.state);
+                    peer.cleanup_expired(&mut self.state);
                 }
             }
         }

--- a/ts_tunnel/src/handshake.rs
+++ b/ts_tunnel/src/handshake.rs
@@ -11,7 +11,7 @@ use crate::{
     endpoint::Event,
     macs::{MACReceiver, MACSender, Mac},
     messages::*,
-    session::{ReceiveSession, TransmitSession},
+    session::{BidiSession, BidiSessionKeys},
     time::TAI64N,
 };
 
@@ -53,7 +53,7 @@ impl ReceivedHandshake {
         psk: &Psk,
         macs: &MACSender,
         now: Instant,
-    ) -> (SessionPair, PacketMut) {
+    ) -> (BidiSession, PacketMut) {
         let mut response = HandshakeResponse {
             sender_id: session_id,
             receiver_id: self.send_id,
@@ -62,13 +62,20 @@ impl ReceivedHandshake {
 
         let session_keys = self.noise.finish(psk, response.noise.as_mut_bytes());
 
-        let send = TransmitSession::new(session_keys.send, self.send_id, now);
-        let recv = ReceiveSession::new(session_keys.recv, session_id, now);
+        let session = BidiSession::new(
+            BidiSessionKeys {
+                send_key: session_keys.send,
+                send_id: self.send_id,
+                recv_key: session_keys.recv,
+                recv_id: session_id,
+            },
+            now,
+        );
         let mut pkt = PacketMut::new(size_of::<HandshakeResponse>());
         // Packet is allocated above with the correct size.
         response.write_to(pkt.as_mut()).unwrap();
         macs.write_macs(pkt.as_mut());
-        (SessionPair { send, recv }, pkt)
+        (session, pkt)
     }
 
     pub fn peer_static(&self) -> NodePublicKey {
@@ -110,11 +117,6 @@ pub struct SentHandshake {
     noise: ikpsk2::SentHandshake<TAI64N>,
 }
 
-pub struct SessionPair {
-    pub send: TransmitSession,
-    pub recv: ReceiveSession,
-}
-
 /// A handshake with a peer.
 pub(crate) enum Handshake {
     /// No handshake in progress.
@@ -125,7 +127,7 @@ pub(crate) enum Handshake {
     Initiated(SentHandshake, Handle<Event>, Mac),
     /// We are the responder, awaiting an initial transport
     /// message to confirm the new session.
-    Responded(Box<SessionPair>),
+    Responded(Box<BidiSession>),
 }
 
 impl Handshake {
@@ -137,7 +139,7 @@ impl Handshake {
     pub(crate) fn session_id(&self) -> Option<SessionId> {
         match self {
             Handshake::Initiated(handshake, ..) => Some(handshake.id),
-            Handshake::Responded(tentative) => Some(tentative.recv.id()),
+            Handshake::Responded(tentative) => Some(tentative.recv_id()),
             Handshake::None => None,
         }
     }
@@ -194,7 +196,7 @@ impl Handshake {
         psk: &Psk,
         cookies: &MACReceiver,
         now: Instant,
-    ) -> Option<SessionPair> {
+    ) -> Option<BidiSession> {
         let (mut sent_handshake, timeout, _) = self.take_initiated()?;
 
         if !cookies.verify_macs(packet.as_bytes()) {
@@ -213,12 +215,19 @@ impl Handshake {
                 }
             };
 
-        let send = TransmitSession::new(session_keys.send, packet.sender_id, now);
-        let recv = ReceiveSession::new(session_keys.recv, sent_handshake.id, now);
+        let session = BidiSession::new(
+            BidiSessionKeys {
+                send_key: session_keys.send,
+                send_id: packet.sender_id,
+                recv_key: session_keys.recv,
+                recv_id: sent_handshake.id,
+            },
+            now,
+        );
 
         timeout.cancel();
 
-        Some(SessionPair { send, recv })
+        Some(session)
     }
 
     /// Confirm a handshake as responder, using the provided ciphertext packets.
@@ -234,16 +243,16 @@ impl Handshake {
         &mut self,
         session_id: SessionId,
         mut packets: Vec<PacketMut>,
-    ) -> Option<(SessionPair, Vec<PacketMut>)> {
+    ) -> Option<(BidiSession, Vec<PacketMut>)> {
         let Handshake::Responded(tentative) = self else {
             return None;
         };
 
-        if tentative.recv.id() != session_id {
+        if tentative.recv_id() != session_id {
             return None;
         };
 
-        packets = tentative.recv.decrypt(packets);
+        packets = tentative.decrypt(packets);
         if packets.is_empty() {
             return None;
         }
@@ -312,14 +321,14 @@ mod tests {
         // They can now communicate
         let a_plaintext = vec![PacketMut::from("xyzzy".as_bytes())];
         let mut packets = a_plaintext.clone();
-        a_session.send.encrypt(packets.iter_mut());
-        let b_received = b_session.recv.decrypt(packets);
+        a_session.encrypt(packets.iter_mut());
+        let b_received = b_session.decrypt(packets);
         assert_eq!(b_received, a_plaintext);
 
         let b_plaintext = vec![PacketMut::from("plover".as_bytes())];
         packets = b_plaintext.clone();
-        b_session.send.encrypt(&mut packets);
-        let a_received = a_session.recv.decrypt(packets);
+        b_session.encrypt(&mut packets);
+        let a_received = a_session.decrypt(packets);
         assert_eq!(a_received, b_plaintext);
     }
 }

--- a/ts_tunnel/src/ids.rs
+++ b/ts_tunnel/src/ids.rs
@@ -1,0 +1,74 @@
+use std::collections::HashMap;
+
+use ts_keys::NodePublicKey;
+
+use crate::{PeerId, handshake::Handshake, messages::SessionId};
+
+/// Tracks and allocates session IDs for peer sessions.
+#[derive(Default)]
+pub struct IdMap {
+    sessions: HashMap<SessionId, PeerId>,
+    // TODO: track recently abandoned session IDs, avoid reusing them for
+    // one or two session lifetimes to avoid confusion with reordered packets.
+    node_keys: HashMap<NodePublicKey, PeerId>,
+}
+
+impl IdMap {
+    /// Return the peer handle for a node public key, if any.
+    pub fn get_by_nodekey(&self, key: &NodePublicKey) -> Option<PeerId> {
+        self.node_keys.get(key).copied()
+    }
+
+    /// Return the peer handle for a session, if any.
+    pub fn get_by_session_id(&self, key: &SessionId) -> Option<&PeerId> {
+        self.sessions.get(key)
+    }
+
+    /// Add a peer handle for communicating with the given peer pubkey.
+    ///
+    /// Returns `false` if a peer already exists for the key.
+    pub fn add_peer(&mut self, id: PeerId, key: &NodePublicKey) -> bool {
+        if self.node_keys.contains_key(key) {
+            return false;
+        }
+
+        self.node_keys.insert(*key, id);
+        true
+    }
+
+    /// Allocate a new session ID for communication with the given peer.
+    ///
+    /// Note that due to key rotation, a peer can have multiple session IDs in use at once.
+    pub fn allocate_session(&mut self, peer: PeerId) -> SessionId {
+        loop {
+            let ret = SessionId::random();
+            if let std::collections::hash_map::Entry::Vacant(e) = self.sessions.entry(ret) {
+                e.insert(peer);
+                return ret;
+            }
+        }
+    }
+
+    /// Abandon the given session ID.
+    ///
+    /// Panics if the session ID isn't currently in use.
+    pub fn remove_session(&mut self, id: SessionId) {
+        self.sessions.remove(&id).unwrap();
+    }
+
+    /// Abandon the session ID associated with a handshake.
+    ///
+    /// Panics if the handshake's ID wasn't allocated in this IdMap.
+    pub fn remove_handshake_session(&mut self, handshake: &Handshake) {
+        if let Some(id) = handshake.session_id() {
+            self.remove_session(id);
+        }
+    }
+
+    /// Delete the peer handle for the given key.
+    ///
+    /// Panics if there is no peer currently using that key.
+    pub fn remove_peer(&mut self, key: &NodePublicKey) {
+        self.node_keys.remove(key).unwrap();
+    }
+}

--- a/ts_tunnel/src/ids.rs
+++ b/ts_tunnel/src/ids.rs
@@ -42,10 +42,11 @@ impl IdMap {
     pub fn allocate_session(&mut self, peer: PeerId) -> SessionId {
         loop {
             let ret = SessionId::random();
-            if let std::collections::hash_map::Entry::Vacant(e) = self.sessions.entry(ret) {
-                e.insert(peer);
-                return ret;
+            if self.sessions.contains_key(&ret) {
+                continue;
             }
+            self.sessions.insert(ret, peer);
+            return ret;
         }
     }
 

--- a/ts_tunnel/src/lib.rs
+++ b/ts_tunnel/src/lib.rs
@@ -3,6 +3,7 @@
 mod config;
 mod endpoint;
 mod handshake;
+mod ids;
 mod macs;
 mod messages;
 mod replay;

--- a/ts_tunnel/src/session.rs
+++ b/ts_tunnel/src/session.rs
@@ -284,11 +284,6 @@ impl BidiSession {
         self.recv.id
     }
 
-    /// Return the time at which the session expires.
-    pub fn expiry(&self) -> Instant {
-        self.recv.expiry
-    }
-
     pub fn rotation_time(&self) -> Instant {
         self.recv.expiry - SESSION_LIFETIME + SESSION_FRESH_LIFETIME
     }
@@ -383,14 +378,6 @@ impl ActiveSession {
     fn expired(&self, now: Instant) -> bool {
         self.cur.expired(now)
     }
-
-    fn soonest_expiry(&self) -> Instant {
-        if let Some(prev) = self.prev.as_ref() {
-            prev.expiry
-        } else {
-            self.cur.expiry()
-        }
-    }
 }
 
 /// A communication session to a peer.
@@ -430,15 +417,15 @@ impl Session {
 
     /// Activate the session with the given keys.
     ///
-    /// If any packets were queued waiting for an active session, they are encrypted and
-    /// returned.
+    /// Returns the expiry time for the session. If any packets were queued waiting
+    /// for an active session, they are encrypted and returned.
     pub fn activate(
         &mut self,
         next: BidiSession,
         ids: &mut IdMap,
         now: Instant,
         need_keepalive: bool,
-    ) -> Vec<PacketMut> {
+    ) -> (TimeRange, Vec<PacketMut>) {
         tracing::trace!(recv_id = ?next.recv.id(), "activating new session");
 
         let (active, mut packets) = match self.take() {
@@ -454,7 +441,13 @@ impl Session {
         }
         active.cur.encrypt(&mut packets);
         *self = Self::Active(active);
-        packets
+        (
+            TimeRange::new(
+                now + SESSION_LIFETIME,
+                now + SESSION_LIFETIME + SESSION_CLEANUP_GRACE,
+            ),
+            packets,
+        )
     }
 
     /// Discard all state for this session.
@@ -542,13 +535,6 @@ impl Session {
                 session.prev = None;
             }
         }
-    }
-
-    /// Returns the soonest time at which some session state may be expired, necessitating
-    /// a call to [`Session::cleanup_expired`]
-    pub fn expiry(&mut self, ids: &mut IdMap, now: Instant) -> Option<TimeRange> {
-        let soonest = self.as_active(ids, now)?.soonest_expiry();
-        Some(TimeRange::new(soonest, soonest + SESSION_CLEANUP_GRACE))
     }
 }
 
@@ -648,8 +634,8 @@ mod tests {
                 },
                 now,
             );
-            let p1 = self.session.activate(s1, &mut self.ids, now, false);
-            let p2 = other.session.activate(s2, &mut other.ids, now, false);
+            let (_, p1) = self.session.activate(s1, &mut self.ids, now, false);
+            let (_, p2) = other.session.activate(s2, &mut other.ids, now, false);
             (p1, p2)
         }
 

--- a/ts_tunnel/src/session.rs
+++ b/ts_tunnel/src/session.rs
@@ -1,5 +1,7 @@
 use core::fmt::{Debug, Formatter};
 use std::{
+    cmp::min,
+    collections::{VecDeque, vec_deque},
     sync::Mutex,
     time::{Duration, Instant},
 };
@@ -7,12 +9,15 @@ use std::{
 use aead::AeadInPlace;
 use chacha20poly1305::{ChaCha20Poly1305, KeyInit};
 use ts_packet::PacketMut;
+use ts_time::TimeRange;
 use zerocopy::{
     FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes, Unaligned,
     little_endian::{U32, U64},
 };
 
 use crate::{
+    handshake::SessionPair,
+    ids::IdMap,
     messages::{SessionId, TransportDataHeader},
     replay::ReplayWindow,
 };
@@ -177,7 +182,7 @@ impl TransmitSession {
 pub struct ReceiveSession {
     cipher: ChaCha20Poly1305,
     id: SessionId,
-    created: Instant,
+    expiry: Instant,
     window: ReplayWindow,
 }
 
@@ -194,7 +199,7 @@ impl ReceiveSession {
         ReceiveSession {
             cipher: ChaCha20Poly1305::new(&key),
             id,
-            created: now,
+            expiry: now + SESSION_LIFETIME,
             window: ReplayWindow::default(),
         }
     }
@@ -263,7 +268,262 @@ impl ReceiveSession {
     }
 
     pub fn expired(&self, now: Instant) -> bool {
-        now.duration_since(self.created) > SESSION_LIFETIME
+        now > self.expiry
+    }
+}
+
+const MAX_QUEUED_PER_PEER: usize = 32;
+
+/// A bounded packet queue that drops oldest packets when full.
+#[derive(Default)]
+pub struct Queue(VecDeque<PacketMut>);
+
+impl Queue {
+    /// Shorthand for Queue::default then Queue::append.
+    fn new_with(packets: Vec<PacketMut>) -> Self {
+        let mut queue = Self::default();
+        queue.append(packets);
+        queue
+    }
+
+    fn append(&mut self, packets: Vec<PacketMut>) {
+        let new_packets = min(packets.len(), MAX_QUEUED_PER_PEER);
+        let drop_incoming = packets.len() - new_packets;
+        let keep_queued = MAX_QUEUED_PER_PEER - new_packets;
+        let drop_queued = self.0.len().saturating_sub(keep_queued);
+        self.0.drain(..drop_queued);
+        packets
+            .into_iter()
+            .skip(drop_incoming)
+            .for_each(|packet| self.0.push_back(packet));
+    }
+}
+
+impl From<Queue> for Vec<PacketMut> {
+    fn from(queue: Queue) -> Self {
+        queue.0.into()
+    }
+}
+
+impl IntoIterator for Queue {
+    type Item = PacketMut;
+    type IntoIter = vec_deque::IntoIter<PacketMut>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+/// A bidirectional established session.
+pub struct ActiveSession {
+    recv: Box<ReceiveSession>,
+    send: Box<TransmitSession>,
+    recv_prev: Option<Box<ReceiveSession>>,
+}
+
+impl From<SessionPair> for ActiveSession {
+    fn from(pair: SessionPair) -> Self {
+        Self {
+            recv: Box::new(pair.recv),
+            send: Box::new(pair.send),
+            recv_prev: None,
+        }
+    }
+}
+
+impl ActiveSession {
+    /// Start using a new keypair for communication.
+    ///
+    /// The prior receive session is rotated into the previous slot, and will continue to accept
+    /// packets until the next rotation (or the hard session expiry deadline).
+    ///
+    /// If a receive session was already in the previous slot, destroys it and returns its session
+    /// ID for further cleanup.
+    fn rotate(&mut self, next: SessionPair, ids: &mut IdMap) {
+        if let Some(prev) = self.recv_prev.as_ref() {
+            ids.remove_session(prev.id());
+        }
+        let send = Box::new(next.send);
+        let recv = Box::new(next.recv);
+        if self.recv.expired(Instant::now()) {
+            ids.remove_session(self.recv.id());
+            self.recv_prev = None;
+        } else {
+            self.recv_prev = Some(std::mem::replace(&mut self.recv, recv));
+        }
+        self.send = send;
+    }
+
+    fn cleanup_ids(&mut self, ids: &mut IdMap) {
+        ids.remove_session(self.recv.id());
+        if let Some(prev) = self.recv_prev.as_ref() {
+            ids.remove_session(prev.id());
+        }
+    }
+
+    fn soonest_expiry(&self) -> Instant {
+        if let Some(prev) = self.recv_prev.as_ref() {
+            prev.expiry
+        } else {
+            self.recv.expiry
+        }
+    }
+}
+
+/// A communication session to a peer.
+pub enum Session {
+    /// No session established yet.
+    ///
+    /// This session cannot receive packets. Sent packets are queued if possible, and will be
+    /// transmitted if the session becomes active in the future.
+    None(Queue),
+    /// Active session capable of bidirectional communication.
+    Active(ActiveSession),
+}
+
+impl Default for Session {
+    fn default() -> Self {
+        Self::None(Queue::default())
+    }
+}
+
+impl Session {
+    fn take(&mut self) -> Session {
+        std::mem::replace(self, Self::None(Queue::default()))
+    }
+
+    /// Return a reference to the active session, if any.
+    ///
+    /// Incidentally performs session expiry checking and cleanup. Callers can assume that
+    /// if they get a &mut ActiveSession, it contains only valid non-expired session state.
+    fn as_active(&mut self, ids: &mut IdMap) -> Option<&mut ActiveSession> {
+        match self {
+            Self::None(_) => None,
+            Self::Active(session) => {
+                if session.recv.expired(Instant::now()) {
+                    session.cleanup_ids(ids);
+                    *self = Self::default();
+                    None
+                } else {
+                    if let Some(prev) = session.recv_prev.as_ref()
+                        && prev.expired(Instant::now())
+                    {
+                        ids.remove_session(prev.id());
+                        session.recv_prev = None;
+                    }
+                    // Re-borrow session, because rustc can't see that the assignment to *self
+                    // above is mutually exclusive with continued use of the borrow.
+                    let Self::Active(session) = self else {
+                        unreachable!();
+                    };
+                    Some(session)
+                }
+            }
+        }
+    }
+
+    /// Activate the session with the given keys.
+    ///
+    /// If any packets were queued waiting for an active session, they are encrypted and
+    /// returned.
+    pub fn activate(
+        &mut self,
+        next: SessionPair,
+        ids: &mut IdMap,
+        need_keepalive: bool,
+    ) -> Vec<PacketMut> {
+        tracing::trace!(recv_id = ?next.recv.id(), "activating new session");
+
+        let (active, mut packets) = match self.take() {
+            Self::None(queue) => (next.into(), queue.into()),
+            Self::Active(mut session) => {
+                session.rotate(next, ids);
+                (session, vec![])
+            }
+        };
+
+        if need_keepalive && packets.is_empty() {
+            packets.push(PacketMut::new(0));
+        }
+        active.send.encrypt(&mut packets);
+        *self = Self::Active(active);
+        packets
+    }
+
+    /// Discard all state for this session.
+    pub fn deactivate(&mut self, ids: &mut IdMap) {
+        if let Self::Active(mut session) = self.take() {
+            session.cleanup_ids(ids);
+        }
+        *self = Self::default();
+    }
+
+    /// Encrypt a keepalive packet for the peer.
+    ///
+    /// Returns None if the session is inactive (and thus no keepalive is necessary).
+    pub fn send_keepalive(&mut self, ids: &mut IdMap) -> Option<PacketMut> {
+        let session = self.as_active(ids)?;
+        let mut packet = vec![PacketMut::new(0)];
+        session.send.encrypt(&mut packet);
+        packet.pop()
+    }
+
+    /// Send packets to the peer.
+    ///
+    /// If the session is inactive, packets are queued for future transmission.
+    ///
+    /// Returns None to indicate that packets were queued, indicating the caller may need to
+    /// initiate a handshake.
+    pub fn send(&mut self, mut packets: Vec<PacketMut>, ids: &mut IdMap) -> Option<Vec<PacketMut>> {
+        match self {
+            Self::None(queue) => {
+                queue.append(packets);
+                None
+            }
+            Self::Active(session) => {
+                if session.send.expired(Instant::now()) {
+                    session.cleanup_ids(ids);
+                    *self = Self::None(Queue::new_with(packets));
+                    return None;
+                }
+                session.send.encrypt(&mut packets);
+                Some(packets)
+            }
+        }
+    }
+
+    /// Get the ReceiveSession for the given receiving ID, if any.
+    pub fn get_recv(&mut self, id: SessionId, ids: &mut IdMap) -> Option<&mut ReceiveSession> {
+        let session = self.as_active(ids)?;
+        if session.recv.id() == id {
+            Some(session.recv.as_mut())
+        } else if let Some(recv_prev) = session.recv_prev.as_mut()
+            && recv_prev.id() == id
+        {
+            Some(recv_prev)
+        } else {
+            None
+        }
+    }
+
+    /// Reports whether the session is in need of a fresh handshake.
+    pub fn needs_handshake(&self) -> bool {
+        match self {
+            Self::None(_) => true,
+            Self::Active(session) => session.send.stale(Instant::now()),
+        }
+    }
+
+    /// Clean up expired session state, if any.
+    pub fn cleanup_expired(&mut self, ids: &mut IdMap) {
+        self.as_active(ids);
+    }
+
+    /// Returns the soonest time at which some session state may be expired, necessitating
+    /// a call to [`Session::cleanup_expired`]
+    pub fn expiry(&mut self, ids: &mut IdMap) -> Option<TimeRange> {
+        let soonest = self.as_active(ids)?.soonest_expiry();
+        Some(TimeRange::new(soonest, soonest + SESSION_CLEANUP_GRACE))
     }
 }
 

--- a/ts_tunnel/src/session.rs
+++ b/ts_tunnel/src/session.rs
@@ -16,7 +16,6 @@ use zerocopy::{
 };
 
 use crate::{
-    handshake::SessionPair,
     ids::IdMap,
     messages::{SessionId, TransportDataHeader},
     replay::ReplayWindow,
@@ -126,58 +125,6 @@ pub const SESSION_LIFETIME: Duration = Duration::from_secs(240);
 /// session's state to persist for short additional time before requiring that it be deleted.
 pub const SESSION_CLEANUP_GRACE: Duration = Duration::from_secs(5);
 
-/// Established session that can only send.
-pub struct TransmitSession {
-    cipher: ChaCha20Poly1305,
-    nonce: NonceGenerator,
-    id: SessionId,
-    created: Instant,
-}
-
-impl TransmitSession {
-    pub fn new(key: SessionKey, id: SessionId, now: Instant) -> Self {
-        TransmitSession {
-            cipher: ChaCha20Poly1305::new(&key),
-            nonce: Default::default(),
-            id,
-            created: now,
-        }
-    }
-
-    /// Encrypt a batch of packets.
-    pub fn encrypt<'a, Into, Iter>(&self, packets: Into)
-    where
-        Iter: ExactSizeIterator<Item = &'a mut PacketMut>,
-        Into: IntoIterator<Item = &'a mut PacketMut, IntoIter = Iter>,
-    {
-        let packets = packets.into_iter();
-        let nonce = self.nonce.batch(packets.len());
-        for (packet, nonce) in packets.zip(nonce) {
-            // Session encryption only fails if the provided packet can't grow, which ours can.
-            self.cipher
-                .encrypt_in_place(nonce.as_ref(), &[], packet)
-                .unwrap();
-            let header = TransportDataHeader {
-                receiver_id: self.id,
-                nonce: nonce.counter,
-                ..Default::default()
-            };
-            packet.grow_front(size_of::<TransportDataHeader>());
-            // Write only fails if the packet is too small, and we just extended it to have
-            // enough space.
-            header.write_to_prefix(packet.as_mut()).unwrap();
-        }
-    }
-
-    pub fn stale(&self, now: Instant) -> bool {
-        now.duration_since(self.created) > SESSION_FRESH_LIFETIME
-    }
-
-    pub fn expired(&self, now: Instant) -> bool {
-        now.duration_since(self.created) > SESSION_LIFETIME
-    }
-}
-
 /// Established session that can only receive.
 pub struct ReceiveSession {
     cipher: ChaCha20Poly1305,
@@ -249,7 +196,7 @@ impl ReceiveSession {
         }
 
         let nonce = Nonce::from(header.nonce);
-        pkt.truncate_front(size_of::<TransportDataHeader>());
+        pkt.truncate_front(size_of_val(header));
 
         match self.cipher.decrypt_in_place(nonce.as_ref(), &[], pkt) {
             Ok(_) => {
@@ -263,12 +210,102 @@ impl ReceiveSession {
         }
     }
 
+    /// Return the session ID that will appear on received packets meant for this session.
     pub fn id(&self) -> SessionId {
         self.id
     }
 
+    /// Report whether the session is expired.
     pub fn expired(&self, now: Instant) -> bool {
         now > self.expiry
+    }
+}
+
+/// Established session that can send and receive.
+pub struct BidiSession {
+    recv: ReceiveSession,
+
+    send_id: SessionId,
+    send_cipher: ChaCha20Poly1305,
+    send_nonce: NonceGenerator,
+}
+
+pub struct BidiSessionKeys {
+    pub send_key: SessionKey,
+    pub send_id: SessionId,
+    pub recv_key: SessionKey,
+    pub recv_id: SessionId,
+}
+
+impl BidiSession {
+    pub fn new(keys: BidiSessionKeys, now: Instant) -> Self {
+        Self {
+            recv: ReceiveSession::new(keys.recv_key, keys.recv_id, now),
+            send_id: keys.send_id,
+            send_cipher: ChaCha20Poly1305::new(&keys.send_key),
+            send_nonce: Default::default(),
+        }
+    }
+
+    /// Encrypt wireguard transport data messages in place.
+    pub fn encrypt<'a, Into, Iter>(&self, packets: Into)
+    where
+        Iter: ExactSizeIterator<Item = &'a mut PacketMut>,
+        Into: IntoIterator<Item = &'a mut PacketMut, IntoIter = Iter>,
+    {
+        let packets = packets.into_iter();
+        let nonce = self.send_nonce.batch(packets.len());
+        for (packet, nonce) in packets.zip(nonce) {
+            // Session encryption only fails if the provided packet can't grow, which ours can.
+            self.send_cipher
+                .encrypt_in_place(nonce.as_ref(), &[], packet)
+                .unwrap();
+            let header = TransportDataHeader {
+                receiver_id: self.send_id,
+                nonce: nonce.counter,
+                ..Default::default()
+            };
+            packet.grow_front(size_of_val(&header));
+            // Write only fails if the packet is too small, and we just extended it to have
+            // enough space.
+            header.write_to_prefix(packet.as_mut()).unwrap();
+        }
+    }
+
+    /// Decrypt wireguard transport data messages in place.
+    ///
+    /// Returns the packets which successfully decrypted.
+    pub fn decrypt(&mut self, packets: Vec<PacketMut>) -> Vec<PacketMut> {
+        self.recv.decrypt(packets)
+    }
+
+    /// Return the session ID that will appear on received packets meant for this session.
+    pub fn recv_id(&self) -> SessionId {
+        self.recv.id
+    }
+
+    /// Return the time at which the session expires.
+    pub fn expiry(&self) -> Instant {
+        self.recv.expiry
+    }
+
+    pub fn rotation_time(&self) -> Instant {
+        self.recv.expiry - SESSION_LIFETIME + SESSION_FRESH_LIFETIME
+    }
+
+    /// Report whether the session is expired.
+    pub fn expired(&self, now: Instant) -> bool {
+        now > self.recv.expiry
+    }
+
+    pub fn stale(&self, now: Instant) -> bool {
+        now > self.rotation_time()
+    }
+}
+
+impl From<BidiSession> for ReceiveSession {
+    fn from(session: BidiSession) -> Self {
+        session.recv
     }
 }
 
@@ -279,23 +316,13 @@ const MAX_QUEUED_PER_PEER: usize = 32;
 pub struct Queue(VecDeque<PacketMut>);
 
 impl Queue {
-    /// Shorthand for Queue::default then Queue::append.
-    fn new_with(packets: Vec<PacketMut>) -> Self {
-        let mut queue = Self::default();
-        queue.append(packets);
-        queue
-    }
-
     fn append(&mut self, packets: Vec<PacketMut>) {
         let new_packets = min(packets.len(), MAX_QUEUED_PER_PEER);
         let drop_incoming = packets.len() - new_packets;
         let keep_queued = MAX_QUEUED_PER_PEER - new_packets;
         let drop_queued = self.0.len().saturating_sub(keep_queued);
         self.0.drain(..drop_queued);
-        packets
-            .into_iter()
-            .skip(drop_incoming)
-            .for_each(|packet| self.0.push_back(packet));
+        self.0.extend(packets.into_iter().skip(drop_incoming));
     }
 }
 
@@ -316,17 +343,15 @@ impl IntoIterator for Queue {
 
 /// A bidirectional established session.
 pub struct ActiveSession {
-    recv: Box<ReceiveSession>,
-    send: Box<TransmitSession>,
-    recv_prev: Option<Box<ReceiveSession>>,
+    cur: Box<BidiSession>,
+    prev: Option<Box<ReceiveSession>>,
 }
 
-impl From<SessionPair> for ActiveSession {
-    fn from(pair: SessionPair) -> Self {
+impl From<BidiSession> for ActiveSession {
+    fn from(session: BidiSession) -> Self {
         Self {
-            recv: Box::new(pair.recv),
-            send: Box::new(pair.send),
-            recv_prev: None,
+            cur: Box::new(session),
+            prev: None,
         }
     }
 }
@@ -336,36 +361,34 @@ impl ActiveSession {
     ///
     /// The prior receive session is rotated into the previous slot, and will continue to accept
     /// packets until the next rotation (or the hard session expiry deadline).
-    ///
-    /// If a receive session was already in the previous slot, destroys it and returns its session
-    /// ID for further cleanup.
-    fn rotate(&mut self, next: SessionPair, ids: &mut IdMap) {
-        if let Some(prev) = self.recv_prev.as_ref() {
+    fn rotate(&mut self, next: BidiSession, ids: &mut IdMap, now: Instant) {
+        if let Some(prev) = self.prev.as_ref() {
             ids.remove_session(prev.id());
         }
-        let send = Box::new(next.send);
-        let recv = Box::new(next.recv);
-        if self.recv.expired(Instant::now()) {
-            ids.remove_session(self.recv.id());
-            self.recv_prev = None;
+        let prev = std::mem::replace(self.cur.as_mut(), next);
+        if prev.expired(now) {
+            ids.remove_session(prev.recv_id());
         } else {
-            self.recv_prev = Some(std::mem::replace(&mut self.recv, recv));
+            self.prev = Some(Box::new(prev.into()));
         }
-        self.send = send;
     }
 
     fn cleanup_ids(&mut self, ids: &mut IdMap) {
-        ids.remove_session(self.recv.id());
-        if let Some(prev) = self.recv_prev.as_ref() {
+        ids.remove_session(self.cur.recv_id());
+        if let Some(prev) = self.prev.as_ref() {
             ids.remove_session(prev.id());
         }
     }
 
+    fn expired(&self, now: Instant) -> bool {
+        self.cur.expired(now)
+    }
+
     fn soonest_expiry(&self) -> Instant {
-        if let Some(prev) = self.recv_prev.as_ref() {
+        if let Some(prev) = self.prev.as_ref() {
             prev.expiry
         } else {
-            self.recv.expiry
+            self.cur.expiry()
         }
     }
 }
@@ -389,36 +412,19 @@ impl Default for Session {
 
 impl Session {
     fn take(&mut self) -> Session {
-        std::mem::replace(self, Self::None(Queue::default()))
+        std::mem::take(self)
     }
 
     /// Return a reference to the active session, if any.
     ///
-    /// Incidentally performs session expiry checking and cleanup. Callers can assume that
-    /// if they get a &mut ActiveSession, it contains only valid non-expired session state.
-    fn as_active(&mut self, ids: &mut IdMap) -> Option<&mut ActiveSession> {
-        match self {
-            Self::None(_) => None,
-            Self::Active(session) => {
-                if session.recv.expired(Instant::now()) {
-                    session.cleanup_ids(ids);
-                    *self = Self::default();
-                    None
-                } else {
-                    if let Some(prev) = session.recv_prev.as_ref()
-                        && prev.expired(Instant::now())
-                    {
-                        ids.remove_session(prev.id());
-                        session.recv_prev = None;
-                    }
-                    // Re-borrow session, because rustc can't see that the assignment to *self
-                    // above is mutually exclusive with continued use of the borrow.
-                    let Self::Active(session) = self else {
-                        unreachable!();
-                    };
-                    Some(session)
-                }
-            }
+    /// Calls [`Session::maybe_expire`], so callers can assume that the returned session
+    /// consists only of unexpired state.
+    fn as_active(&mut self, ids: &mut IdMap, now: Instant) -> Option<&mut ActiveSession> {
+        self.cleanup_expired(ids, now);
+        if let Self::Active(session) = self {
+            Some(session)
+        } else {
+            None
         }
     }
 
@@ -428,8 +434,9 @@ impl Session {
     /// returned.
     pub fn activate(
         &mut self,
-        next: SessionPair,
+        next: BidiSession,
         ids: &mut IdMap,
+        now: Instant,
         need_keepalive: bool,
     ) -> Vec<PacketMut> {
         tracing::trace!(recv_id = ?next.recv.id(), "activating new session");
@@ -437,7 +444,7 @@ impl Session {
         let (active, mut packets) = match self.take() {
             Self::None(queue) => (next.into(), queue.into()),
             Self::Active(mut session) => {
-                session.rotate(next, ids);
+                session.rotate(next, ids, now);
                 (session, vec![])
             }
         };
@@ -445,7 +452,7 @@ impl Session {
         if need_keepalive && packets.is_empty() {
             packets.push(PacketMut::new(0));
         }
-        active.send.encrypt(&mut packets);
+        active.cur.encrypt(&mut packets);
         *self = Self::Active(active);
         packets
     }
@@ -461,10 +468,10 @@ impl Session {
     /// Encrypt a keepalive packet for the peer.
     ///
     /// Returns None if the session is inactive (and thus no keepalive is necessary).
-    pub fn send_keepalive(&mut self, ids: &mut IdMap) -> Option<PacketMut> {
-        let session = self.as_active(ids)?;
+    pub fn send_keepalive(&mut self, ids: &mut IdMap, now: Instant) -> Option<PacketMut> {
+        let session = self.as_active(ids, now)?;
         let mut packet = vec![PacketMut::new(0)];
-        session.send.encrypt(&mut packet);
+        session.cur.encrypt(&mut packet);
         packet.pop()
     }
 
@@ -474,55 +481,73 @@ impl Session {
     ///
     /// Returns None to indicate that packets were queued, indicating the caller may need to
     /// initiate a handshake.
-    pub fn send(&mut self, mut packets: Vec<PacketMut>, ids: &mut IdMap) -> Option<Vec<PacketMut>> {
+    pub fn send(
+        &mut self,
+        mut packets: Vec<PacketMut>,
+        ids: &mut IdMap,
+        now: Instant,
+    ) -> Option<Vec<PacketMut>> {
+        self.cleanup_expired(ids, now);
         match self {
             Self::None(queue) => {
                 queue.append(packets);
                 None
             }
             Self::Active(session) => {
-                if session.send.expired(Instant::now()) {
-                    session.cleanup_ids(ids);
-                    *self = Self::None(Queue::new_with(packets));
-                    return None;
-                }
-                session.send.encrypt(&mut packets);
+                session.cur.encrypt(&mut packets);
                 Some(packets)
             }
         }
     }
 
     /// Get the ReceiveSession for the given receiving ID, if any.
-    pub fn get_recv(&mut self, id: SessionId, ids: &mut IdMap) -> Option<&mut ReceiveSession> {
-        let session = self.as_active(ids)?;
-        if session.recv.id() == id {
-            Some(session.recv.as_mut())
-        } else if let Some(recv_prev) = session.recv_prev.as_mut()
-            && recv_prev.id() == id
+    pub fn get_recv(
+        &mut self,
+        id: SessionId,
+        ids: &mut IdMap,
+        now: Instant,
+    ) -> Option<&mut ReceiveSession> {
+        let session = self.as_active(ids, now)?;
+        if session.cur.recv_id() == id {
+            Some(&mut session.cur.recv)
+        } else if let Some(prev) = session.prev.as_mut()
+            && prev.id() == id
         {
-            Some(recv_prev)
+            Some(prev)
         } else {
             None
         }
     }
 
     /// Reports whether the session is in need of a fresh handshake.
-    pub fn needs_handshake(&self) -> bool {
+    pub fn needs_handshake(&self, now: Instant) -> bool {
         match self {
             Self::None(_) => true,
-            Self::Active(session) => session.send.stale(Instant::now()),
+            Self::Active(session) => session.cur.stale(now),
         }
     }
 
     /// Clean up expired session state, if any.
-    pub fn cleanup_expired(&mut self, ids: &mut IdMap) {
-        self.as_active(ids);
+    pub fn cleanup_expired(&mut self, ids: &mut IdMap, now: Instant) {
+        if let Self::Active(session) = self {
+            if session.expired(now) {
+                session.cleanup_ids(ids);
+                *self = Self::default();
+                return;
+            }
+            if let Some(prev) = session.prev.as_ref()
+                && prev.expired(now)
+            {
+                ids.remove_session(prev.id());
+                session.prev = None;
+            }
+        }
     }
 
     /// Returns the soonest time at which some session state may be expired, necessitating
     /// a call to [`Session::cleanup_expired`]
-    pub fn expiry(&mut self, ids: &mut IdMap) -> Option<TimeRange> {
-        let soonest = self.as_active(ids)?.soonest_expiry();
+    pub fn expiry(&mut self, ids: &mut IdMap, now: Instant) -> Option<TimeRange> {
+        let soonest = self.as_active(ids, now)?.soonest_expiry();
         Some(TimeRange::new(soonest, soonest + SESSION_CLEANUP_GRACE))
     }
 }
@@ -530,14 +555,25 @@ impl Session {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::messages::Message;
+    use crate::{PeerId, messages::Message};
 
     #[test]
-    fn test_session() {
+    fn test_session_parts() {
         let k: [u8; 32] = rand::random();
         let session = SessionId::random();
         let now = Instant::now();
-        let send = TransmitSession::new(k.into(), session, now);
+        // NOTE: this would be catastrophically insecure in non-test code, because it reuses the
+        // same key in both directions, which leads to catastrophic nonce reuse. It's okay here
+        // because (a) it's a test and (b) we only ever transmit in one direction.
+        let send = BidiSession::new(
+            BidiSessionKeys {
+                send_key: k.into(),
+                send_id: session,
+                recv_key: k.into(),
+                recv_id: session,
+            },
+            now,
+        );
         let mut recv = ReceiveSession::new(k.into(), session, now);
 
         const CLEARTEXT: &[u8] = b"foobar";
@@ -566,28 +602,276 @@ mod tests {
         assert_eq!(pkt[0].as_ref(), CLEARTEXT);
     }
 
+    fn packet(payload: &str) -> Vec<PacketMut> {
+        vec![PacketMut::from(payload.as_bytes())]
+    }
+
+    #[derive(Default)]
+    struct PeerSession {
+        ids: IdMap,
+        recv_id: Option<SessionId>,
+        recv_id_prev: Option<SessionId>,
+        session: Session,
+    }
+
+    impl PeerSession {
+        fn allocate_id(&mut self) -> SessionId {
+            self.recv_id_prev = self.recv_id.take();
+            let id = self.ids.allocate_session(PeerId(1));
+            self.recv_id = Some(id);
+            id
+        }
+
+        fn handshake_with(
+            &mut self,
+            other: &mut Self,
+            now: Instant,
+        ) -> (Vec<PacketMut>, Vec<PacketMut>) {
+            let (k1, k2): ([u8; 32], [u8; 32]) = rand::random();
+            let sid1 = self.allocate_id();
+            let sid2 = other.allocate_id();
+            let s1 = BidiSession::new(
+                BidiSessionKeys {
+                    send_key: k1.into(),
+                    send_id: sid2,
+                    recv_key: k2.into(),
+                    recv_id: sid1,
+                },
+                now,
+            );
+            let s2 = BidiSession::new(
+                BidiSessionKeys {
+                    send_key: k2.into(),
+                    send_id: sid1,
+                    recv_key: k1.into(),
+                    recv_id: sid2,
+                },
+                now,
+            );
+            let p1 = self.session.activate(s1, &mut self.ids, now, false);
+            let p2 = other.session.activate(s2, &mut other.ids, now, false);
+            (p1, p2)
+        }
+
+        fn send(&mut self, now: Instant, packets: Vec<PacketMut>) -> Option<Vec<PacketMut>> {
+            self.session.send(packets, &mut self.ids, now)
+        }
+
+        fn get_recv(&mut self, now: Instant, packets: &[PacketMut]) -> Option<&mut ReceiveSession> {
+            let (hdr, _) =
+                TransportDataHeader::try_ref_from_prefix(packets.first()?.as_ref()).unwrap();
+            self.session.get_recv(hdr.receiver_id, &mut self.ids, now)
+        }
+
+        fn recv(&mut self, now: Instant, packets: Vec<PacketMut>) -> Vec<PacketMut> {
+            self.get_recv(now, &packets).unwrap().decrypt(packets)
+        }
+
+        fn unknown_recv(&mut self, now: Instant, packets: Vec<PacketMut>) -> bool {
+            self.get_recv(now, &packets).is_none()
+        }
+
+        fn needs_handshake(&self, now: Instant) -> bool {
+            self.session.needs_handshake(now)
+        }
+    }
+
     #[test]
-    fn session_timers() {
-        let k: [u8; 32] = rand::random();
-        let session = SessionId::random();
+    fn test_session() {
+        let mut a = PeerSession::default();
+        let mut b = PeerSession::default();
+
         let now = Instant::now();
-        let send = TransmitSession::new(k.into(), session, now);
-        let recv = ReceiveSession::new(k.into(), session, now);
+
+        assert_eq!(a.send(now, packet("foobar")), None);
+        assert_eq!(b.send(now, packet("qux")), None);
+
+        assert!(a.needs_handshake(now));
+        assert!(b.needs_handshake(now));
+
+        // Establish a session between the peers. We're cheating and not doing any of the
+        // handshake lifecycle.
+        let (a_to_b, b_to_a) = a.handshake_with(&mut b, now);
+        assert_eq!(a_to_b.len(), 1);
+        assert_eq!(b_to_a.len(), 1);
+
+        // Verify that the packets queued prior to session activation transmit correctly.
+        let a_to_b = b.recv(now, a_to_b);
+        assert_eq!(a_to_b, packet("foobar"));
+
+        let b_to_a = a.recv(now, b_to_a);
+        assert_eq!(b_to_a, packet("qux"));
+
+        assert!(!a.needs_handshake(now));
+        assert!(!b.needs_handshake(now));
+
+        // Transmit with established session.
+        let now = now + Duration::from_secs(60);
+
+        let a_to_b = a.send(now, packet("frobozz")).unwrap();
+        let a_to_b = b.recv(now, a_to_b);
+        assert_eq!(a_to_b, packet("frobozz"));
+
+        let b_to_a = b.send(now, packet("xyzzy")).unwrap();
+        let b_to_a = a.recv(now, b_to_a);
+        assert_eq!(b_to_a, packet("xyzzy"));
+
+        assert!(!a.needs_handshake(now));
+        assert!(!b.needs_handshake(now));
+
+        // Transmit with stale session.
+        let now = now + Duration::from_secs(70);
+
+        let a_to_b = a.send(now, packet("foo")).unwrap();
+        let a_to_b = b.recv(now, a_to_b);
+        assert_eq!(a_to_b, packet("foo"));
+
+        let b_to_a = b.send(now, packet("bar")).unwrap();
+        let b_to_a = a.recv(now, b_to_a);
+        assert_eq!(b_to_a, packet("bar"));
+
+        assert!(a.needs_handshake(now));
+        assert!(b.needs_handshake(now));
+
+        // Transmit with expired session.
+        let now = now + Duration::from_secs(120);
+
+        let a_to_b = a.send(now, packet("no"));
+        assert_eq!(a_to_b, None);
+
+        let b_to_a = b.send(now, packet("nope"));
+        assert_eq!(b_to_a, None);
+
+        assert!(a.needs_handshake(now));
+        assert!(b.needs_handshake(now));
+    }
+
+    #[test]
+    fn test_rotation() {
+        let mut a = PeerSession::default();
+        let mut b = PeerSession::default();
+
+        let start = Instant::now();
         let epsilon = Duration::from_secs(1);
 
-        assert!(!send.stale(now));
-        assert!(!send.stale(now + SESSION_FRESH_LIFETIME - epsilon));
-        assert!(send.stale(now + SESSION_FRESH_LIFETIME + epsilon));
-        assert!(send.stale(now + SESSION_LIFETIME + epsilon));
+        let now = start;
+        let (a_to_b, b_to_a) = a.handshake_with(&mut b, now);
+        assert!(a_to_b.is_empty());
+        assert!(b_to_a.is_empty());
 
-        assert!(!send.expired(now));
-        assert!(!send.expired(now + SESSION_FRESH_LIFETIME - epsilon));
-        assert!(!send.expired(now + SESSION_FRESH_LIFETIME + epsilon));
-        assert!(send.expired(now + SESSION_LIFETIME + epsilon));
+        let now = start + SESSION_FRESH_LIFETIME - epsilon;
+        let a_to_b = a.send(now, packet("foo")).unwrap();
+        let a_to_b = b.recv(now, a_to_b);
+        assert_eq!(a_to_b, packet("foo"));
 
+        let b_to_a = b.send(now, packet("bar")).unwrap();
+        let b_to_a = a.recv(now, b_to_a);
+        assert_eq!(b_to_a, packet("bar"));
+
+        // Rotate session, with packets delivered across the rotation.
+        let a_to_b = a.send(now, packet("before rotate A->B")).unwrap();
+        let b_to_a = b.send(now, packet("before rotate B->A")).unwrap();
+
+        let very_delayed_a_to_b = a.send(now, packet("delayed A->B")).unwrap();
+        let very_delayed_b_to_a = b.send(now, packet("delayed B->A")).unwrap();
+
+        let to_send = a.handshake_with(&mut b, now);
+        assert_eq!(to_send, (vec![], vec![]));
+
+        let a_to_b = b.recv(now, a_to_b);
+        assert_eq!(a_to_b, packet("before rotate A->B"));
+        let b_to_a = a.recv(now, b_to_a);
+        assert_eq!(b_to_a, packet("before rotate B->A"));
+
+        let a_to_b = a.send(now, packet("after rotate A->B")).unwrap();
+        let a_to_b = b.recv(now, a_to_b);
+        assert_eq!(a_to_b, packet("after rotate A->B"));
+
+        let b_to_a = b.send(now, packet("after rotate B->A")).unwrap();
+        let b_to_a = a.recv(now, b_to_a);
+        assert_eq!(b_to_a, packet("after rotate B->A"));
+
+        // Rotate again, delayed packets should not decrypt anymore.
+        let now = start + SESSION_FRESH_LIFETIME + epsilon;
+        let a_to_b = a.send(now, packet("before rotate2 A->B")).unwrap();
+        let b_to_a = b.send(now, packet("before rotate2 B->A")).unwrap();
+
+        let to_send = a.handshake_with(&mut b, now);
+        assert_eq!(to_send, (vec![], vec![]));
+
+        let a_to_b = b.recv(now, a_to_b);
+        assert_eq!(a_to_b, packet("before rotate2 A->B"));
+        let b_to_a = a.recv(now, b_to_a);
+        assert_eq!(b_to_a, packet("before rotate2 B->A"));
+
+        let a_to_b = a.send(now, packet("after rotate2 A->B")).unwrap();
+        let a_to_b = b.recv(now, a_to_b);
+        assert_eq!(a_to_b, packet("after rotate2 A->B"));
+
+        let b_to_a = b.send(now, packet("after rotate2 B->A")).unwrap();
+        let b_to_a = a.recv(now, b_to_a);
+        assert_eq!(b_to_a, packet("after rotate2 B->A"));
+
+        assert!(b.unknown_recv(now, very_delayed_a_to_b));
+        assert!(a.unknown_recv(now, very_delayed_b_to_a));
+    }
+
+    #[test]
+    fn test_expiration() {
+        let mut a = PeerSession::default();
+        let mut b = PeerSession::default();
+
+        let now = Instant::now();
+        let to_send = a.handshake_with(&mut b, now);
+        assert_eq!(to_send, (vec![], vec![]));
+
+        let a_to_b = a.send(now, packet("A->B")).unwrap();
+        let b_to_a = b.send(now, packet("B->A")).unwrap();
+
+        let now = now + SESSION_LIFETIME + SESSION_LIFETIME;
+
+        assert!(b.unknown_recv(now, a_to_b));
+        assert!(a.unknown_recv(now, b_to_a));
+
+        assert_eq!(a.send(now, packet("expired A->B")), None);
+        assert_eq!(b.send(now, packet("expired B->A")), None);
+    }
+
+    #[test]
+    fn test_session_timers() {
+        let k: [u8; 32] = rand::random();
+        let id = SessionId::random();
+        let now = Instant::now();
+        let epsilon = Duration::from_secs(1);
+
+        let recv = ReceiveSession::new(k.into(), id, now);
         assert!(!recv.expired(now));
         assert!(!recv.expired(now + SESSION_FRESH_LIFETIME - epsilon));
         assert!(!recv.expired(now + SESSION_FRESH_LIFETIME + epsilon));
         assert!(recv.expired(now + SESSION_LIFETIME + epsilon));
+
+        let k2: [u8; 32] = rand::random();
+        let id2 = SessionId::random();
+
+        let bidi = BidiSession::new(
+            BidiSessionKeys {
+                send_key: k.into(),
+                send_id: id,
+                recv_key: k2.into(),
+                recv_id: id2,
+            },
+            now,
+        );
+        assert!(!bidi.expired(now));
+        assert!(!bidi.stale(now));
+
+        assert!(!bidi.expired(now + SESSION_FRESH_LIFETIME - epsilon));
+        assert!(!bidi.stale(now + SESSION_FRESH_LIFETIME - epsilon));
+
+        assert!(!bidi.expired(now + SESSION_FRESH_LIFETIME + epsilon));
+        assert!(bidi.stale(now + SESSION_FRESH_LIFETIME + epsilon));
+
+        assert!(bidi.expired(now + SESSION_LIFETIME + epsilon));
+        assert!(bidi.stale(now + SESSION_LIFETIME + epsilon));
     }
 }


### PR DESCRIPTION
This change is a bit messier than I'd like, because it moves a bunch of code around and re-plumbs a bunch of APIs. But aside from the noise required to make everything compile again, the two commits represent the two major changes:
 - Move the SessionState enum into sessions.rs, so that endpoint code isn't mixed in with a bunch of session state transitions. This mirrors the change that @nrc did for the handshake state machine a while back.
 - Replace TransmitSession with BidiSession. Even though separate transmit/receive types is naively tidier, in practice sessions are always either bidirectional or receive-only, and reflecting this in the code allows for some deduplication of expiry times as well as complexity reduction in rotation logic.

The main incidental change that was needed here was going back to plumbing `now` through all the APIs as an explicit `Instant`, rather than using `Instant::now()` internally. This makes tests for things like session rotation and expiry easier to write, since the test can control the perception of time explicitly.