### PR TITLE
runtime: register multiderp actor

### DIFF
--- a/ts_runtime/src/multiderp.rs
+++ b/ts_runtime/src/multiderp.rs
@@ -269,6 +269,8 @@ impl kameo::Actor for Multiderp {
         env.subscribe::<Arc<PeerState>>(&slf).await?;
         env.subscribe::<DerpLatencyMeasurement>(&slf).await?;
 
+        env.register(None, &slf).await?;
+
         Ok(Self {
             env,
             dataplane,


### PR DESCRIPTION
This was causing the route updater to get stuck waiting for multiderp to register itself, which meant the underlay router never had any routes and all traffic was getting dropped.

Must have lost this one-line diff accidentally in a rebase. Checked all the other actors, looks like it was just this one.