### PR TITLE
all: update CHANGELOG, bump versions to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,59 @@
 
 Record breaking or significant changes here. All dates are UTC.
 
-## Unreleased - June 2026
+## Unreleased - August 2026
 
 Put changes for the upcoming release here!
+
+## [0.4.0](https://github.com/tailscale/tailscale-rs/releases/tag/v0.3.3) - 2026-07-08
 
 - Added (Rust API): Experimental support for user-defined tailnet SSH servers using
   [`russh`](https://docs.rs/russh/latest/russh/) and (optionally)
   [`ratatui`](https://docs.rs/ratatui/latest/ratatui/).
   [#178](https://github.com/tailscale/tailscale-rs/pull/178).
+- Added (ts_netmon): Monitor network interface changes across Linux and Windows (macOS coming in a
+  future release).
+  [#214](https://github.com/tailscale/tailscale-rs/pull/214).
+- Added (ts_kv_store): Transactional KV store for future use by multiple components (peer tracker,
+  control client, etc.).
+  [#208](https://github.com/tailscale/tailscale-rs/pull/208).
+  [#223](https://github.com/tailscale/tailscale-rs/pull/223).
+  [#228](https://github.com/tailscale/tailscale-rs/pull/228).
+  [#241](https://github.com/tailscale/tailscale-rs/pull/241).
+  [#252](https://github.com/tailscale/tailscale-rs/pull/252).
+  [#263](https://github.com/tailscale/tailscale-rs/pull/263).
+  [#265](https://github.com/tailscale/tailscale-rs/pull/265).
+- Added (ts_control*, ts_derp, ts_runtime): Handling of various peer change messages from the
+  control plane.
+  [#185](https://github.com/tailscale/tailscale-rs/pull/185).
+  [#248](https://github.com/tailscale/tailscale-rs/pull/248).
+- Added (ts_runtime): STUN protocol support and periodic STUN checks.
+  [#234](https://github.com/tailscale/tailscale-rs/pull/234).
+  [#244](https://github.com/tailscale/tailscale-rs/pull/244).
+- Added (ts_tunnel): Cleanup of expired sessions that no longer receive traffic.
+  [#264](https://github.com/tailscale/tailscale-rs/pull/264).
+- Added (ts_python): Type stubs for the `tailscale-py` package, along with minor improvements to
+  documentation.
+  [#211](https://github.com/tailscale/tailscale-rs/pull/211).
+  [#247](https://github.com/tailscale/tailscale-rs/pull/247).
+- Fixed (ts_keys, ts_noise): Private key types are properly zeroized on drop and are now passed by
+  reference rather than Copy.
+  [#221](https://github.com/tailscale/tailscale-rs/pull/221).
+  [#245](https://github.com/tailscale/tailscale-rs/pull/245).
+  [#249](https://github.com/tailscale/tailscale-rs/pull/249).
+  [#251](https://github.com/tailscale/tailscale-rs/pull/251).
+- Fixed (ts_packetfilter_serde): `IpRange::Wildcard.iter_prefixes()` now covers the full `::/0`
+  IPv6 address space. Thanks to @immanuwell for the report!
+  [#212](https://github.com/tailscale/tailscale-rs/pull/212).
+- Fixed (ts_netstack_smoltcp{_core}): Overlay network stack now returns an error on IP version
+  mismatch between local/remote endpoints instead of panicking.
+  [#213](https://github.com/tailscale/tailscale-rs/pull/213).
+- Fixed (ts_netstack_smoltcp_core): TCP accept loop now correctly handles CLOSE_WAIT transitions and
+  half-open sockets that transition back to the LISTEN state.
+  [#200](https://github.com/tailscale/tailscale-rs/pull/200).
+  [#239](https://github.com/tailscale/tailscale-rs/pull/239).
+- Fixed (ts_runtime): DERP connectivity is now re-established after a control client reconnect.
+  [#242](https://github.com/tailscale/tailscale-rs/pull/242).
 
 ## [0.3.3](https://github.com/tailscale/tailscale-rs/releases/tag/v0.3.3) - 2026-05-20
 
@@ -51,7 +96,8 @@ Internal release; this version is tagged, but was not published to any package r
 - Added (Rust API, Python, Elixir): `Device::self_node`.
   [#147](https://github.com/tailscale/tailscale-rs/pull/147).
 - Added (Python and Elixir bindings): optional configuration parameters.
-  [#140](https://github.com/tailscale/tailscale-rs/pull/140) and [#148](https://github.com/tailscale/tailscale-rs/pull/148).
+  [#140](https://github.com/tailscale/tailscale-rs/pull/140)
+  and [#148](https://github.com/tailscale/tailscale-rs/pull/148).
 - Fixed (ts_netstack_smoltcp): big improvement to TCP accept performance.
   [#141](https://github.com/tailscale/tailscale-rs/pull/141).
 - Updated MSRV to 1.94.1.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "checks"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "clap",
  "globwalk",
@@ -5141,7 +5141,7 @@ dependencies = [
 
 [[package]]
 name = "tailscale"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "axum",
  "bytes",
@@ -5757,7 +5757,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ts_array256"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "heapless",
  "lazy_static",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "ts_bart"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "cfg-if",
  "divan",
@@ -5788,7 +5788,7 @@ dependencies = [
 
 [[package]]
 name = "ts_bart_packetfilter"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "hashbrown 0.17.1",
  "ipnet",
@@ -5803,7 +5803,7 @@ dependencies = [
 
 [[package]]
 name = "ts_bitset"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "cfg-if",
  "divan",
@@ -5813,14 +5813,14 @@ dependencies = [
 
 [[package]]
 name = "ts_capabilityversion"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ts_cli_util"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "cfg-if",
  "clap",
@@ -5837,7 +5837,7 @@ dependencies = [
 
 [[package]]
 name = "ts_control"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -5871,7 +5871,7 @@ dependencies = [
 
 [[package]]
 name = "ts_control_noise"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "ts_control_serde"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5912,7 +5912,7 @@ dependencies = [
 
 [[package]]
 name = "ts_dataplane"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "etherparse",
  "tokio",
@@ -5929,7 +5929,7 @@ dependencies = [
 
 [[package]]
 name = "ts_derp"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "crypto_box",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "ts_devtools"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "clap",
@@ -5973,7 +5973,7 @@ dependencies = [
 
 [[package]]
 name = "ts_disco_protocol"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "aead 0.5.2",
  "crypto_box",
@@ -5987,7 +5987,7 @@ dependencies = [
 
 [[package]]
 name = "ts_dynbitset"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "proptest",
  "smallvec",
@@ -5996,7 +5996,7 @@ dependencies = [
 
 [[package]]
 name = "ts_elixir"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "rustler",
  "tailscale",
@@ -6006,7 +6006,7 @@ dependencies = [
 
 [[package]]
 name = "ts_ffi"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "cbindgen",
  "tailscale",
@@ -6018,14 +6018,14 @@ dependencies = [
 
 [[package]]
 name = "ts_hexdump"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "heapless",
 ]
 
 [[package]]
 name = "ts_http_util"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "futures",
@@ -6046,7 +6046,7 @@ dependencies = [
 
 [[package]]
 name = "ts_keys"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "crypto_box",
  "serde",
@@ -6058,14 +6058,14 @@ dependencies = [
 
 [[package]]
 name = "ts_kv_store"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "ts_netcheck"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "dashmap",
@@ -6086,7 +6086,7 @@ dependencies = [
 
 [[package]]
 name = "ts_netmon"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "cfg-if",
  "flume",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "ts_netstack_smoltcp"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "axum",
  "bytes",
@@ -6127,7 +6127,7 @@ dependencies = [
 
 [[package]]
 name = "ts_netstack_smoltcp_core"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "flume",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "ts_netstack_smoltcp_socket"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "futures-io",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "ts_nodecapability"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "cfg-if",
  "serde",
@@ -6161,7 +6161,7 @@ dependencies = [
 
 [[package]]
 name = "ts_noise"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "aead 0.5.2",
  "blake2",
@@ -6177,7 +6177,7 @@ dependencies = [
 
 [[package]]
 name = "ts_overlay_router"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "itertools",
  "tracing",
@@ -6188,7 +6188,7 @@ dependencies = [
 
 [[package]]
 name = "ts_packet"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "crypto_box",
@@ -6199,7 +6199,7 @@ dependencies = [
 
 [[package]]
 name = "ts_packetfilter"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "hashbrown 0.17.1",
  "ipnet",
@@ -6209,7 +6209,7 @@ dependencies = [
 
 [[package]]
 name = "ts_packetfilter_serde"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "ipnet",
  "nom 8.0.0",
@@ -6222,7 +6222,7 @@ dependencies = [
 
 [[package]]
 name = "ts_packetfilter_state"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "divan",
  "serde_json",
@@ -6233,7 +6233,7 @@ dependencies = [
 
 [[package]]
 name = "ts_peercapability"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "serde",
  "url",
@@ -6241,7 +6241,7 @@ dependencies = [
 
 [[package]]
 name = "ts_python"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "hex",
  "pyo3",
@@ -6252,7 +6252,7 @@ dependencies = [
 
 [[package]]
 name = "ts_runtime"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "futures",
@@ -6290,18 +6290,18 @@ dependencies = [
 
 [[package]]
 name = "ts_test_util"
-version = "0.3.3"
+version = "0.4.0"
 
 [[package]]
 name = "ts_time"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "ts_tls_util"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "tokio-rustls",
@@ -6312,14 +6312,14 @@ dependencies = [
 
 [[package]]
 name = "ts_transport"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "ts_packet",
 ]
 
 [[package]]
 name = "ts_transport_tun"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "ipnet",
@@ -6334,7 +6334,7 @@ dependencies = [
 
 [[package]]
 name = "ts_tunnel"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "aead 0.5.2",
  "base64 0.22.1",
@@ -6358,7 +6358,7 @@ dependencies = [
 
 [[package]]
 name = "ts_underlay_router"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "ts_packet",
  "ts_transport",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ members = [
 edition = "2024"
 license = "BSD-3-Clause"
 publish = true
-version = "0.3.3"
+version = "0.4.0"
 repository = "https://github.com/tailscale/tailscale-rs"
 
 # This disagrees with the README's stated MSRV. That's intentional: this field causes cargo to error
@@ -108,45 +108,45 @@ zerocopy = { version = "0.8", features = ["derive"] }
 zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 
 # local workspace deps
-tailscale = { path = ".", version = "0.3.3" }
-ts_array256 = { path = "ts_array256", version = "0.3.3" }
-ts_bart = { path = "ts_bart", version = "0.3.3" }
-ts_bart_packetfilter = { path = "ts_bart_packetfilter", version = "0.3.3" }
-ts_bitset = { path = "ts_bitset", default-features = false, version = "0.3.3" }
-ts_capabilityversion = { path = "ts_capabilityversion", version = "0.3.3" }
+tailscale = { path = ".", version = "0.4.0" }
+ts_array256 = { path = "ts_array256", version = "0.4.0" }
+ts_bart = { path = "ts_bart", version = "0.4.0" }
+ts_bart_packetfilter = { path = "ts_bart_packetfilter", version = "0.4.0" }
+ts_bitset = { path = "ts_bitset", default-features = false, version = "0.4.0" }
+ts_capabilityversion = { path = "ts_capabilityversion", version = "0.4.0" }
 ts_cli_util = { path = "ts_cli_util" }
-ts_control = { path = "ts_control", version = "0.3.3" }
-ts_control_noise = { path = "ts_control_noise", version = "0.3.3" }
-ts_control_serde = { path = "ts_control_serde", version = "0.3.3" }
-ts_dataplane = { path = "ts_dataplane", version = "0.3.3" }
-ts_derp = { path = "ts_derp", version = "0.3.3" }
-ts_disco_protocol = { path = "ts_disco_protocol", version = "0.3.3" }
-ts_dynbitset = { path = "ts_dynbitset", version = "0.3.3" }
-ts_hexdump = { path = "ts_hexdump", version = "0.3.3" }
-ts_keys = { path = "ts_keys", version = "0.3.3" }
-ts_kv_store = { path = "ts_kv_store", version = "0.3.3" }
-ts_netcheck = { path = "ts_netcheck", version = "0.3.3" }
-ts_netmon = { path = "ts_netmon", version = "0.3.3" }
-ts_netstack_smoltcp = { path = "ts_netstack_smoltcp", version = "0.3.3" }
-ts_netstack_smoltcp_core = { path = "ts_netstack_smoltcp_core", version = "0.3.3" }
-ts_netstack_smoltcp_socket = { path = "ts_netstack_smoltcp_socket", version = "0.3.3" }
-ts_nodecapability = { path = "ts_nodecapability", version = "0.3.3" }
-ts_noise = { path = "ts_noise", version = "0.3.3" }
-ts_overlay_router = { path = "ts_overlay_router", version = "0.3.3" }
-ts_packet = { path = "ts_packet", version = "0.3.3" }
-ts_packetfilter = { path = "ts_packetfilter", version = "0.3.3" }
-ts_packetfilter_serde = { path = "ts_packetfilter_serde", version = "0.3.3" }
-ts_packetfilter_state = { path = "ts_packetfilter_state", version = "0.3.3" }
-ts_peercapability = { path = "ts_peercapability", version = "0.3.3" }
-ts_http_util = { path = "ts_http_util", version = "0.3.3" }
-ts_tls_util = { path = "ts_tls_util", version = "0.3.3" }
-ts_runtime = { path = "ts_runtime", version = "0.3.3" }
+ts_control = { path = "ts_control", version = "0.4.0" }
+ts_control_noise = { path = "ts_control_noise", version = "0.4.0" }
+ts_control_serde = { path = "ts_control_serde", version = "0.4.0" }
+ts_dataplane = { path = "ts_dataplane", version = "0.4.0" }
+ts_derp = { path = "ts_derp", version = "0.4.0" }
+ts_disco_protocol = { path = "ts_disco_protocol", version = "0.4.0" }
+ts_dynbitset = { path = "ts_dynbitset", version = "0.4.0" }
+ts_hexdump = { path = "ts_hexdump", version = "0.4.0" }
+ts_keys = { path = "ts_keys", version = "0.4.0" }
+ts_kv_store = { path = "ts_kv_store", version = "0.4.0" }
+ts_netcheck = { path = "ts_netcheck", version = "0.4.0" }
+ts_netmon = { path = "ts_netmon", version = "0.4.0" }
+ts_netstack_smoltcp = { path = "ts_netstack_smoltcp", version = "0.4.0" }
+ts_netstack_smoltcp_core = { path = "ts_netstack_smoltcp_core", version = "0.4.0" }
+ts_netstack_smoltcp_socket = { path = "ts_netstack_smoltcp_socket", version = "0.4.0" }
+ts_nodecapability = { path = "ts_nodecapability", version = "0.4.0" }
+ts_noise = { path = "ts_noise", version = "0.4.0" }
+ts_overlay_router = { path = "ts_overlay_router", version = "0.4.0" }
+ts_packet = { path = "ts_packet", version = "0.4.0" }
+ts_packetfilter = { path = "ts_packetfilter", version = "0.4.0" }
+ts_packetfilter_serde = { path = "ts_packetfilter_serde", version = "0.4.0" }
+ts_packetfilter_state = { path = "ts_packetfilter_state", version = "0.4.0" }
+ts_peercapability = { path = "ts_peercapability", version = "0.4.0" }
+ts_http_util = { path = "ts_http_util", version = "0.4.0" }
+ts_tls_util = { path = "ts_tls_util", version = "0.4.0" }
+ts_runtime = { path = "ts_runtime", version = "0.4.0" }
 ts_test_util = { path = "ts_test_util" }
-ts_time = { path = "ts_time", version = "0.3.3" }
-ts_transport = { path = "ts_transport", version = "0.3.3" }
-ts_transport_tun = { path = "ts_transport_tun", version = "0.3.3" }
-ts_underlay_router = { path = "ts_underlay_router", version = "0.3.3" }
-ts_tunnel = { path = "ts_tunnel", version = "0.3.3" }
+ts_time = { path = "ts_time", version = "0.4.0" }
+ts_transport = { path = "ts_transport", version = "0.4.0" }
+ts_transport_tun = { path = "ts_transport_tun", version = "0.4.0" }
+ts_underlay_router = { path = "ts_underlay_router", version = "0.4.0" }
+ts_tunnel = { path = "ts_tunnel", version = "0.4.0" }
 
 [workspace.lints.rust]
 closure_returning_async_block = "warn"

--- a/README.md
+++ b/README.md
@@ -20,20 +20,22 @@ C, Elixir, and Python.
 ## Getting Started
 
 The following instructions are for Rust! For other languages, see the language-specific README:
+
 - [C](ts_ffi/README.md)
 - [Elixir](ts_elixir/README.md)
-- [Python](ts_python/README.md) 
+- [Python](ts_python/README.md)
 
 Add this dependency line to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tailscale = { version = "0.3" }
+tailscale = { version = "0.4" }
 ```
 
 Examples of using the `tailscale` crate can be found in [`examples/`](examples/README.md).
 
-For instructions on how to run tests, lints, etc., see [CONTRIBUTING.md](CONTRIBUTING.md). For the high-level architecture and
+For instructions on how to run tests, lints, etc., see [CONTRIBUTING.md](CONTRIBUTING.md). For the high-level
+architecture and
 repository layout, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ### Code sample
@@ -112,7 +114,8 @@ We support the following platforms and architectures:
 ## Status
 
 `tailscale-rs` is a work-in-progress - we're still rapidly iterating, fixing bugs, and adding new
-features. We aim to keep this section up-to-date, but our [issue tracker](https://github.com/tailscale/tailscale-rs/issues)
+features. We aim to keep this section up-to-date, but
+our [issue tracker](https://github.com/tailscale/tailscale-rs/issues)
 is the best way to see the latest updates.
 
 ### Implemented
@@ -120,12 +123,12 @@ is the best way to see the latest updates.
 These are features that we currently implement:
 
 - Basics
-  - Create TCP and UDP sockets on the tailnet
-  - Communicate with peers via public DERP relays
-  - Communicate with the Tailscale Go client, `tsnet`, and `libtailscale`
+    - Create TCP and UDP sockets on the tailnet
+    - Communicate with peers via public DERP relays
+    - Communicate with the Tailscale Go client, `tsnet`, and `libtailscale`
 - Language support
-  - Rust API
-  - C, Elixir, and Python bindings
+    - Rust API
+    - C, Elixir, and Python bindings
 
 ### Coming Soon
 
@@ -149,41 +152,41 @@ Unsupported features
 </summary>
 
 - Networking
-  - Peer relays
-  - Exit Nodes (either being one, or using one)
-  - MagicDNS
-  - Private DERP relays
-  - Split DNS
-  - Subnet Routers (either being one, or using one)
+    - Peer relays
+    - Exit Nodes (either being one, or using one)
+    - MagicDNS
+    - Private DERP relays
+    - Split DNS
+    - Subnet Routers (either being one, or using one)
 - Platforms
-  - AIX
-  - Android
-  - BSDs
-  - iOS
-  - Plan9
-  - QNAP
-  - Synology DSM
+    - AIX
+    - Android
+    - BSDs
+    - iOS
+    - Plan9
+    - QNAP
+    - Synology DSM
 - Observability
-  - Client Metrics
-  - Endpoint Collection
-  - Device Posture Collection
-  - Log Streaming
-  - Network Flow Logs
+    - Client Metrics
+    - Endpoint Collection
+    - Device Posture Collection
+    - Log Streaming
+    - Network Flow Logs
 - Other Features
-  - Application Capabilities
-  - Automatic Key Rotation
-  - HTTPS Certificates
-  - Kubernetes
-  - Mullvad VPN
-  - Node Sharing
-  - Taildrive
-  - Taildrop
-  - Tailnet Lock
-  - Tailscale Funnel
-  - Tailscale Serve
-  - Tailscale SSH
-  - Tailscale Services
-  - Webhooks
+    - Application Capabilities
+    - Automatic Key Rotation
+    - HTTPS Certificates
+    - Kubernetes
+    - Mullvad VPN
+    - Node Sharing
+    - Taildrive
+    - Taildrop
+    - Tailnet Lock
+    - Tailscale Funnel
+    - Tailscale Serve
+    - Tailscale SSH
+    - Tailscale Services
+    - Webhooks
 - Any other features not listed in "Implemented" or "Coming Soon"
 
 </details>

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1,4 +1,3 @@
-
 # cargo-vet config file
 
 [cargo-vet]
@@ -9,6 +8,114 @@ url = "https://raw.githubusercontent.com/google/supply-chain/main/audits.toml"
 
 [imports.mozilla]
 url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
+
+[policy.tailscale]
+audit-as-crates-io = false
+
+[policy.ts_array256]
+audit-as-crates-io = false
+
+[policy.ts_bart]
+audit-as-crates-io = false
+
+[policy.ts_bart_packetfilter]
+audit-as-crates-io = false
+
+[policy.ts_bitset]
+audit-as-crates-io = false
+
+[policy.ts_capabilityversion]
+audit-as-crates-io = false
+
+[policy.ts_control]
+audit-as-crates-io = false
+
+[policy.ts_control_noise]
+audit-as-crates-io = false
+
+[policy.ts_control_serde]
+audit-as-crates-io = false
+
+[policy.ts_dataplane]
+audit-as-crates-io = false
+
+[policy.ts_disco_protocol]
+audit-as-crates-io = false
+
+[policy.ts_dynbitset]
+audit-as-crates-io = false
+
+[policy.ts_elixir]
+audit-as-crates-io = false
+
+[policy.ts_ffi]
+audit-as-crates-io = false
+
+[policy.ts_hexdump]
+audit-as-crates-io = false
+
+[policy.ts_http_util]
+audit-as-crates-io = false
+
+[policy.ts_keys]
+audit-as-crates-io = false
+
+[policy.ts_netcheck]
+audit-as-crates-io = false
+
+[policy.ts_netstack_smoltcp]
+audit-as-crates-io = false
+
+[policy.ts_netstack_smoltcp_core]
+audit-as-crates-io = false
+
+[policy.ts_netstack_smoltcp_socket]
+audit-as-crates-io = false
+
+[policy.ts_nodecapability]
+audit-as-crates-io = false
+
+[policy.ts_overlay_router]
+audit-as-crates-io = false
+
+[policy.ts_packet]
+audit-as-crates-io = false
+
+[policy.ts_packetfilter]
+audit-as-crates-io = false
+
+[policy.ts_packetfilter_serde]
+audit-as-crates-io = false
+
+[policy.ts_packetfilter_state]
+audit-as-crates-io = false
+
+[policy.ts_peercapability]
+audit-as-crates-io = false
+
+[policy.ts_python]
+audit-as-crates-io = false
+
+[policy.ts_runtime]
+audit-as-crates-io = false
+
+[policy.ts_time]
+audit-as-crates-io = false
+
+[policy.ts_tls_util]
+audit-as-crates-io = false
+
+[policy.ts_transport]
+audit-as-crates-io = false
+
+[policy.ts_transport_tun]
+audit-as-crates-io = false
+
+[policy.ts_tunnel]
+audit-as-crates-io = false
+
+[policy.ts_underlay_router]
+audit-as-crates-io = false
 
 [[exemptions.aead]]
 version = "0.5.2"
@@ -114,21 +221,9 @@ criteria = "safe-to-deploy"
 version = "1.11.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.c2rust-bitfields]]
-version = "0.21.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.c2rust-bitfields-derive]]
-version = "0.21.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.cc]]
 version = "1.2.56"
 criteria = "safe-to-deploy"
-
-[[exemptions.cesu8]]
-version = "1.1.0"
-criteria = "safe-to-run"
 
 [[exemptions.cfg-if]]
 version = "1.0.4"
@@ -418,10 +513,6 @@ criteria = "safe-to-deploy"
 version = "0.15.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.hashbrown]]
-version = "0.16.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.heapless]]
 version = "0.8.0"
 criteria = "safe-to-deploy"
@@ -478,10 +569,6 @@ criteria = "safe-to-deploy"
 version = "0.1.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.id-arena]]
-version = "2.3.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.ident_case]]
 version = "1.0.1"
 criteria = "safe-to-deploy"
@@ -534,16 +621,8 @@ criteria = "safe-to-deploy"
 version = "0.3.91"
 criteria = "safe-to-deploy"
 
-[[exemptions.leb128fmt]]
-version = "0.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.libc]]
 version = "0.2.183"
-criteria = "safe-to-deploy"
-
-[[exemptions.libloading]]
-version = "0.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.linux-raw-sys]]
@@ -599,10 +678,6 @@ version = "0.1.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.netlink-packet-core]]
-version = "0.7.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.netlink-packet-core]]
 version = "0.8.1"
 criteria = "safe-to-deploy"
 
@@ -612,10 +687,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.netlink-packet-route]]
 version = "0.28.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.netlink-packet-utils]]
-version = "0.5.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.netlink-sys]]
@@ -628,14 +699,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.nix]]
 version = "0.31.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.noise-protocol]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.noise-rust-crypto]]
-version = "0.6.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.nom]]
@@ -710,10 +773,6 @@ criteria = "safe-to-run"
 version = "0.2.17"
 criteria = "safe-to-deploy"
 
-[[exemptions.pin-utils]]
-version = "0.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.piper]]
 version = "0.2.5"
 criteria = "safe-to-deploy"
@@ -732,14 +791,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.ppv-lite86]]
 version = "0.2.21"
-criteria = "safe-to-deploy"
-
-[[exemptions.prettyplease]]
-version = "0.2.37"
-criteria = "safe-to-deploy"
-
-[[exemptions.proc-macro2]]
-version = "1.0.106"
 criteria = "safe-to-deploy"
 
 [[exemptions.proptest]]
@@ -1006,10 +1057,6 @@ criteria = "safe-to-run"
 version = "0.5.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.tap]]
-version = "1.0.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.tempfile]]
 version = "3.27.0"
 criteria = "safe-to-run"
@@ -1174,10 +1221,6 @@ criteria = "safe-to-deploy"
 version = "1.0.2+wasi-0.2.9"
 criteria = "safe-to-deploy"
 
-[[exemptions.wasip3]]
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-criteria = "safe-to-deploy"
-
 [[exemptions.wasm-bindgen]]
 version = "0.2.114"
 criteria = "safe-to-deploy"
@@ -1192,18 +1235,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-shared]]
 version = "0.2.114"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-encoder]]
-version = "0.244.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-metadata]]
-version = "0.244.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasmparser]]
-version = "0.244.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.web-sys]]
@@ -1287,19 +1318,7 @@ version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-sys]]
-version = "0.45.0"
-criteria = "safe-to-run"
-
-[[exemptions.windows-sys]]
 version = "0.52.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-sys]]
-version = "0.59.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-sys]]
-version = "0.60.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-sys]]
@@ -1307,15 +1326,7 @@ version = "0.61.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-targets]]
-version = "0.42.2"
-criteria = "safe-to-run"
-
-[[exemptions.windows-targets]]
 version = "0.52.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-targets]]
-version = "0.53.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-threading]]
@@ -1323,95 +1334,35 @@ version = "0.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows_aarch64_gnullvm]]
-version = "0.42.2"
-criteria = "safe-to-run"
-
-[[exemptions.windows_aarch64_gnullvm]]
 version = "0.52.6"
 criteria = "safe-to-deploy"
-
-[[exemptions.windows_aarch64_gnullvm]]
-version = "0.53.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_aarch64_msvc]]
-version = "0.42.2"
-criteria = "safe-to-run"
 
 [[exemptions.windows_aarch64_msvc]]
 version = "0.52.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.windows_aarch64_msvc]]
-version = "0.53.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_i686_gnu]]
-version = "0.42.2"
-criteria = "safe-to-run"
-
 [[exemptions.windows_i686_gnu]]
 version = "0.52.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_i686_gnu]]
-version = "0.53.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows_i686_gnullvm]]
 version = "0.52.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.windows_i686_gnullvm]]
-version = "0.53.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_i686_msvc]]
-version = "0.42.2"
-criteria = "safe-to-run"
-
 [[exemptions.windows_i686_msvc]]
 version = "0.52.6"
 criteria = "safe-to-deploy"
-
-[[exemptions.windows_i686_msvc]]
-version = "0.53.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_x86_64_gnu]]
-version = "0.42.2"
-criteria = "safe-to-run"
 
 [[exemptions.windows_x86_64_gnu]]
 version = "0.52.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.windows_x86_64_gnu]]
-version = "0.53.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_x86_64_gnullvm]]
-version = "0.42.2"
-criteria = "safe-to-run"
-
 [[exemptions.windows_x86_64_gnullvm]]
 version = "0.52.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.windows_x86_64_gnullvm]]
-version = "0.53.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_x86_64_msvc]]
-version = "0.42.2"
-criteria = "safe-to-run"
-
 [[exemptions.windows_x86_64_msvc]]
 version = "0.52.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_x86_64_msvc]]
-version = "0.53.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.winnow]]
@@ -1424,30 +1375,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.wit-bindgen]]
 version = "0.51.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.wit-bindgen-core]]
-version = "0.51.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.wit-bindgen-rust]]
-version = "0.51.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.wit-bindgen-rust-macro]]
-version = "0.51.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.wit-component]]
-version = "0.244.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.wit-parser]]
-version = "0.244.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.x25519-dalek]]
-version = "2.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.x25519-dalek]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -15,6 +15,13 @@ user-id = 4484
 user-login = "hsivonen"
 user-name = "Henri Sivonen"
 
+[[publisher.euclid]]
+version = "0.22.14"
+when = "2026-03-18"
+user-id = 1281
+user-login = "nical"
+user-name = "Nicolas Silva"
+
 [[publisher.unicode-normalization]]
 version = "0.1.25"
 when = "2025-10-30"
@@ -22,9 +29,16 @@ user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
-[[publisher.unicode-xid]]
-version = "0.2.6"
-when = "2024-09-19"
+[[publisher.unicode-segmentation]]
+version = "1.13.3"
+when = "2026-06-01"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.unicode-width]]
+version = "0.2.2"
+when = "2025-10-06"
 user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
@@ -365,6 +379,13 @@ Reviewed in https://chromium-review.googlesource.com/c/chromium/src/+/5046153
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.num-integer]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.1.46"
+notes = "Contains no unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.num-traits]]
 who = "Manish Goregaokar <manishearth@google.com>"
 criteria = "safe-to-deploy"
@@ -384,6 +405,119 @@ who = "Manish Goregaokar <manishearth@google.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.0 -> 0.1.2"
 notes = "Addition of safe comparison APIs since last audit"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.78"
+notes = """
+Grepped for "crypt", "cipher", "fs", "net" - there were no hits
+(except for a benign "fs" hit in a doc comment)
+
+Notes from the `unsafe` review can be found in https://crrev.com/c/5385745.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.78 -> 1.0.79"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.79 -> 1.0.80"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.80 -> 1.0.81"
+notes = "Comment changes only"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.81 -> 1.0.82"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.82 -> 1.0.83"
+notes = "Substantive change is replacing String with Box<str>, saving memory."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.83 -> 1.0.84"
+notes = "Only doc comment changes in `src/lib.rs`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+delta = "1.0.84 -> 1.0.85"
+notes = "Test-only changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.85 -> 1.0.86"
+notes = """
+Comment-only changes in `build.rs`.
+Reordering of `Cargo.toml` entries.
+Just bumping up the version number in `lib.rs`.
+Config-related changes in `test_size.rs`.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.86 -> 1.0.87"
+notes = "No new unsafe interactions."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Liza Burakova <liza@chromium.org"
+criteria = "safe-to-deploy"
+delta = "1.0.87 -> 1.0.89"
+notes = """
+Biggest change is adding error handling in build.rs.
+Some config related changes in wrapper.rs.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.89 -> 1.0.92"
+notes = """
+I looked at the delta and the previous discussion at
+https://chromium-review.googlesource.com/c/chromium/src/+/5385745/3#message-a8e2813129fa3779dab15acede408ee26d67b7f3
+and the changes look okay to me (including the `unsafe fn from_str_unchecked`
+changes in `wrapper.rs`).
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.92 -> 1.0.93"
+notes = "No `unsafe`-related changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.93 -> 1.0.94"
+notes = "Minor doc changes and clippy lint adjustments+fixes."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.quick-error]]
@@ -548,20 +682,38 @@ end = "2025-10-23"
 notes = "I, Henri Sivonen, wrote encoding_rs for Gecko and have reviewed contributions by others. There are two caveats to the certification: 1) The crate does things that are documented to be UB but that do not appear to actually be UB due to integer types differing from the general rule; https://github.com/hsivonen/encoding_rs/issues/79 . 2) It would be prudent to re-review the code that reinterprets buffers of integers as SIMD vectors; see https://github.com/hsivonen/encoding_rs/issues/87 ."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.wildcard-audits.euclid]]
+who = "Nicolas Silva <nical@fastmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1281 # Nicolas Silva (nical)
+start = "2019-03-14"
+end = "2027-01-15"
+notes = "I wrote most of the commits in the euclid reprository and review every change that is not produced by me."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.wildcard-audits.unicode-normalization]]
 who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-11-06"
-end = "2026-02-01"
+end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.wildcard-audits.unicode-xid]]
+[[audits.mozilla.wildcard-audits.unicode-segmentation]]
 who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
-start = "2019-07-25"
+start = "2019-05-15"
+end = "2027-04-23"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.unicode-width]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-12-05"
 end = "2026-02-01"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
@@ -582,6 +734,19 @@ delta = "2.0.0 -> 2.0.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.bit-set]]
+who = "Aria Beingessner <a.beingessner@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.5.2"
+notes = "Another crate I own via contain-rs that is ancient and maintenance mode, no known issues."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-set]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.5.2 -> 0.5.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-set]]
 who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
 criteria = "safe-to-deploy"
 delta = "0.5.3 -> 0.6.0"
@@ -591,6 +756,13 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Jim Blandy <jimb@red-bean.com>"
 criteria = "safe-to-deploy"
 delta = "0.6.0 -> 0.8.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-vec]]
+who = "Aria Beingessner <a.beingessner@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.6.3"
+notes = "Another crate I own via contain-rs that is ancient and in maintenance mode but otherwise perfectly fine."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.bit-vec]]
@@ -668,6 +840,12 @@ delta = "0.4.0 -> 0.5.8"
 notes = "New unsafe code is properly guarded"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.15.0 -> 1.16.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.fnv]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
@@ -704,6 +882,30 @@ who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 version = "0.12.3"
 notes = "This version is used in rust's libstd, so effectively we're already trusting it"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.15.5 -> 0.16.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.16.0 -> 0.16.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.16.1 -> 0.17.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.17.0 -> 0.17.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.hex]]
@@ -809,6 +1011,13 @@ criteria = "safe-to-deploy"
 delta = "1.2.0 -> 1.2.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.libloading]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.9.0"
+notes = "The exposed functionality is inherently unsafe, but all such functions are correctly tagged as `unsafe` and requirements documented. It also includes extensive documentation about the choices made about differing platform APIs"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.log]]
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
@@ -873,19 +1082,40 @@ yet, but it's all valid. Otherwise it's a pretty simple crate.
 """
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.proc-macro-error-attr2]]
-who = "Kagami Sascha Rosylight <saschanaz@outlook.com>"
+[[audits.mozilla.audits.proc-macro2]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
-version = "2.0.0"
-notes = "No unsafe block."
+delta = "1.0.94 -> 1.0.106"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rmp]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.8.14"
+notes = """
+Very popular crate. 1 instance of unsafe code, which is used to adjust a slice to work around
+lifetime issues. No network or file access.
+"""
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.proc-macro-error2]]
-who = "Kagami Sascha Rosylight <saschanaz@outlook.com>"
+[[audits.mozilla.audits.rmp]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
-version = "2.0.1"
-notes = "No unsafe block with a lovely `#![forbid(unsafe_code)]`."
+delta = "0.8.14 -> 0.8.15"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rmp-serde]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "1.3.0"
+notes = "Very popular crate. No unsafe code, network or file access."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rmp-serde]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.3.0 -> 1.3.1"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.rustc-hash]]
 who = "Ben Dean-Kawamura <bdk@mozilla.com>"
@@ -912,6 +1142,12 @@ aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-c
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "1.14.0 -> 1.15.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.smallvec]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.15.1 -> 1.15.2"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.strsim]]

--- a/ts_elixir/mix.exs
+++ b/ts_elixir/mix.exs
@@ -6,7 +6,7 @@ defmodule TsElixir.MixProject do
   def project do
     [
       app: :tailscale,
-      version: "0.3.3",
+      version: "0.4.0",
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/ts_python/pyproject.toml
+++ b/ts_python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tailscale-py"
-version = "0.3.3"
+version = "0.4.0"
 description = "Work-in-progress Tailscale library written in Rust."
 license = "BSD-3-Clause"
 readme = "README.md"
@@ -9,13 +9,11 @@ requires-python = ">=3.12"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-
     "Programming Language :: Rust",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Networking",
 ]
@@ -41,7 +39,7 @@ module-name = "tailscale._internal"
 
 [tool.uv]
 # Rebuild/reinstall on a "uv sync" if the Rust source changed.
-cache-keys = [{file = "pyproject.toml"}, {file = "Cargo.toml"}, {file = "**/*.rs"}]
+cache-keys = [{ file = "pyproject.toml" }, { file = "Cargo.toml" }, { file = "**/*.rs" }]
 # Don't require '--preview-features format' on 'uv format'.
 preview-features = ["format"]
 

--- a/ts_python/uv.lock
+++ b/ts_python/uv.lock
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "tailscale-py"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Updates all versions from `0.3.3` to `0.4.0`, updates the CHANGELOG for the `0.4.0` release, and updates the `cargo vet` config/lockfile.
