### PR TITLE
elixir: fix deworkspace cargo.toml script

### DIFF
--- a/ts_elixir/native/ts_elixir/deworkspace_cargo_toml.py
+++ b/ts_elixir/native/ts_elixir/deworkspace_cargo_toml.py
@@ -60,7 +60,7 @@ def main():
         for dep in list(cargotoml[name].keys()):
             value = cargotoml[name][dep]
 
-            if type(value) == dict and value['workspace'] is True:
+            if type(value) == dict and value.get('workspace') is True:
                 if args.repo_sha and (dep.startswith('tailscale') or dep.startswith('ts_')):
                     value['git'] = f'https://github.com/tailscale/tailscale-rs'
                     value['rev'] = args.repo_sha


### PR DESCRIPTION
It erroneously expected all deps to have `workspace = true`, now checks this correctly.