### PR TITLE
elixir: factor out helpers and type conversions

### DIFF
--- a/ts_elixir/native/ts_elixir/src/config.rs
+++ b/ts_elixir/native/ts_elixir/src/config.rs
@@ -29,14 +29,14 @@ pub fn config_from_erl(
         config.key_state = value
             .decode::<Keystate>()?
             .try_into()
-            .map_err(|_| rustler::Error::Atom("badkeys"))?;
+            .map_err(|_| rustler::Error::BadArg)?;
     }
 
     if let Some(value) = erl_config.get(&atoms::control_url()) {
         config.control_server_url = value.decode::<&str>()?.parse().map_err(|e| {
             tracing::error!(error = %e, "parsing control server url");
 
-            rustler::Error::Atom("bad_url")
+            rustler::Error::BadArg
         })?;
     }
 

--- a/ts_elixir/native/ts_elixir/src/erl_ip.rs
+++ b/ts_elixir/native/ts_elixir/src/erl_ip.rs
@@ -1,0 +1,93 @@
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    str::FromStr,
+};
+
+use rustler::{Encoder, NifResult, Term};
+
+/// Erlang-formatted IP.
+///
+/// Supports decoding from either a string or `:inet` (tuple of octets or segments) format,
+/// always encodes into the `:inet` format.
+#[derive(Copy, Clone, Debug)]
+pub struct ErlIp(pub IpAddr);
+
+impl From<Ipv4Addr> for ErlIp {
+    fn from(value: Ipv4Addr) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<Ipv6Addr> for ErlIp {
+    fn from(value: Ipv6Addr) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<IpAddr> for ErlIp {
+    fn from(value: IpAddr) -> Self {
+        Self(value)
+    }
+}
+
+impl From<ErlIp> for IpAddr {
+    fn from(value: ErlIp) -> Self {
+        value.0
+    }
+}
+
+impl<'a> rustler::Decoder<'a> for ErlIp {
+    fn decode(ip: Term<'a>) -> NifResult<Self> {
+        if let Ok(tuple) = rustler::types::tuple::get_tuple(ip) {
+            if tuple.len() == 4 {
+                let mut octets = [0u8; 4];
+
+                for (i, elem) in tuple.into_iter().take(4).enumerate() {
+                    octets[i] = elem.decode()?;
+                }
+
+                return Ok(Self(Ipv4Addr::from_octets(octets).into()));
+            }
+
+            if tuple.len() == 8 {
+                let mut segments = [0u16; 8];
+
+                for (i, elem) in tuple.into_iter().take(8).enumerate() {
+                    segments[i] = elem.decode()?;
+                }
+
+                return Ok(Self(Ipv6Addr::from_segments(segments).into()));
+            }
+        }
+
+        if let Ok(s) = ip.decode::<&str>() {
+            let ip = IpAddr::from_str(s).map_err(|e| {
+                tracing::error!(error = %e, "parsing ip addr");
+
+                rustler::Error::BadArg
+            })?;
+
+            return Ok(Self(ip));
+        }
+
+        Err(rustler::Error::BadArg)
+    }
+}
+
+impl Encoder for ErlIp {
+    fn encode<'a>(&self, env: rustler::Env<'a>) -> Term<'a> {
+        match self.0 {
+            IpAddr::V4(ip) => {
+                let octets = ip.octets();
+                (octets[0], octets[1], octets[2], octets[3]).encode(env)
+            }
+            IpAddr::V6(ip) => {
+                // rustler doesn't provide `impl Encoder` for 8-length tuples
+                let segments = ip.segments().map(|segment| segment.encode(env));
+
+                let tuple = rustler::types::tuple::make_tuple(env, &segments);
+                tuple.encode(env)
+            }
+        }
+    }
+}

--- a/ts_elixir/native/ts_elixir/src/helpers.rs
+++ b/ts_elixir/native/ts_elixir/src/helpers.rs
@@ -1,0 +1,31 @@
+use std::{error::Error, fmt::Display, net::SocketAddr};
+
+use rustler::{Encoder, NifResult, ResourceArc, Term};
+
+use crate::{atoms, erl_ip::ErlIp};
+
+pub type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync + 'static>>;
+
+/// Wrap the given [`rustler::Resource`] in a [`ResourceArc`] inside a [`NifResult`].
+pub fn ok_arc<T>(t: T) -> NifResult<ResourceArc<T>>
+where
+    T: rustler::Resource,
+{
+    Ok(ResourceArc::new(t))
+}
+
+/// Convert the argument into a [`rustler::Error`] by making it into a string.
+pub fn term_err(e: impl Display) -> rustler::Error {
+    rustler::Error::Term(Box::new(e.to_string()))
+}
+
+pub fn sockaddr_to_erl(addr: SocketAddr) -> (ErlIp, u16) {
+    (ErlIp(addr.ip()), addr.port())
+}
+
+pub fn erl_result(env: rustler::Env, r: Result<impl Encoder>) -> NifResult<Term> {
+    match r {
+        Ok(t) => Ok((atoms::ok(), t).encode(env)),
+        Err(e) => Err(term_err(e)),
+    }
+}

--- a/ts_elixir/native/ts_elixir/src/ip_or_self.rs
+++ b/ts_elixir/native/ts_elixir/src/ip_or_self.rs
@@ -1,0 +1,51 @@
+use std::net::IpAddr;
+
+use rustler::{Error, NifResult, Term};
+
+use crate::{atoms, erl_ip::ErlIp};
+
+/// A literal IP address, the atom `:ip4`, or the atom `:ip6`.
+///
+/// The latter two mean this node's IPv4 or IPv6 address, respectively.
+pub enum IpOrSelf {
+    Ip(ErlIp),
+    SelfV4,
+    SelfV6,
+}
+
+impl<'a> rustler::Decoder<'a> for IpOrSelf {
+    fn decode(ip: Term<'a>) -> NifResult<Self> {
+        if let Ok(ip) = ip.decode::<ErlIp>() {
+            return Ok(Self::Ip(ip));
+        }
+
+        let atom = ip.decode::<rustler::Atom>()?;
+        if atom == atoms::ip4() {
+            return Ok(Self::SelfV4);
+        }
+
+        if atom == atoms::ip6() {
+            return Ok(Self::SelfV6);
+        }
+
+        Err(Error::BadArg)
+    }
+}
+
+impl IpOrSelf {
+    pub async fn resolve(&self, dev: &tailscale::Device) -> NifResult<IpAddr> {
+        match self {
+            IpOrSelf::Ip(ip) => Ok(ip.0),
+            IpOrSelf::SelfV4 => dev
+                .ipv4_addr()
+                .await
+                .map(Into::into)
+                .map_err(|e| Error::Term(Box::new(e.to_string()))),
+            IpOrSelf::SelfV6 => dev
+                .ipv6_addr()
+                .await
+                .map(Into::into)
+                .map_err(|e| Error::Term(Box::new(e.to_string()))),
+        }
+    }
+}

--- a/ts_elixir/native/ts_elixir/src/lib.rs
+++ b/ts_elixir/native/ts_elixir/src/lib.rs
@@ -2,8 +2,6 @@
 
 use std::{
     collections::HashMap,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
-    str::FromStr,
     sync::{Arc, LazyLock, Once},
 };
 
@@ -12,11 +10,19 @@ use tracing::level_filters::LevelFilter;
 
 mod atomic_pid;
 mod config;
+mod erl_ip;
+mod helpers;
+mod ip_or_self;
+mod node_info;
 mod tcp;
 mod udp;
 
 pub use atomic_pid::AtomicPid;
 use config::Keystate;
+use erl_ip::ErlIp;
+use helpers::{Result, erl_result, ok_arc, sockaddr_to_erl, term_err};
+use ip_or_self::IpOrSelf;
+use node_info::NodeInfo;
 use tcp::{TcpListener, TcpStream};
 use udp::UdpSocket;
 
@@ -34,49 +40,6 @@ struct Device {
     inner: Arc<tailscale::Device>,
 }
 
-#[derive(rustler::NifStruct)]
-#[module = "Tailscale.NodeInfo"]
-struct NodeInfo<'a> {
-    id: i64,
-    stable_id: String,
-    hostname: String,
-    tailnet: Option<String>,
-    tags: Vec<String>,
-    tailnet_addresses: Vec<Term<'a>>,
-    derp_region: Option<u32>,
-    node_key: String,
-    disco_key: Option<String>,
-    machine_key: Option<String>,
-    underlay_addresses: Vec<Term<'a>>,
-}
-
-impl<'a> NodeInfo<'a> {
-    fn from_node(env: rustler::Env<'a>, value: tailscale::NodeInfo) -> Self {
-        Self {
-            id: value.id,
-            stable_id: value.stable_id.0,
-            hostname: value.hostname,
-            tailnet: value.tailnet,
-            tags: value.tags,
-            tailnet_addresses: vec![
-                ip_to_erl(env, value.tailnet_address.ipv4.addr()),
-                ip_to_erl(env, value.tailnet_address.ipv6.addr()),
-            ],
-            derp_region: value.derp_region.map(|x| x.0.get()),
-            node_key: value.node_key.to_string(),
-            disco_key: value.disco_key.as_ref().map(ToString::to_string),
-            machine_key: value.machine_key.as_ref().map(ToString::to_string),
-            underlay_addresses: value
-                .underlay_addresses
-                .into_iter()
-                .map(|x| (ip_to_erl(env, x.ip()), x.port()).encode(env))
-                .collect(),
-        }
-    }
-}
-
-type Result<T> = core::result::Result<T, Box<dyn core::error::Error + Send + Sync + 'static>>;
-
 #[rustler::resource_impl]
 impl rustler::Resource for Device {}
 
@@ -90,20 +53,6 @@ static TOKIO_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
 
     rt
 });
-
-fn erl_result(env: rustler::Env, r: Result<impl Encoder>) -> Term {
-    match r {
-        Ok(t) => (atoms::ok(), t).encode(env),
-        Err(e) => (atoms::error(), e.to_string()).encode(env),
-    }
-}
-
-fn ok_arc<T>(t: T) -> Result<ResourceArc<T>>
-where
-    T: rustler::Resource,
-{
-    Ok(ResourceArc::new(t))
-}
 
 #[rustler::nif]
 fn start_tracing() {
@@ -124,25 +73,24 @@ fn start_tracing() {
 fn connect<'env>(
     env: rustler::Env<'env>,
     opts: HashMap<rustler::Atom, Term<'_>>,
-) -> NifResult<(rustler::Atom, Term<'env>)> {
+) -> NifResult<Term<'env>> {
     let (config, auth_key) = config::config_from_erl(&opts)?;
 
     let dev = TOKIO_RUNTIME.block_on(async move {
-        let dev = tailscale::Device::new(&config, auth_key).await?;
+        let dev = tailscale::Device::new(&config, auth_key)
+            .await
+            .map_err(term_err)?;
 
         ok_arc(Device {
             inner: Arc::new(dev),
         })
     });
 
-    match dev {
-        Ok(dev) => Ok((atoms::ok(), dev.encode(env))),
-        Err(e) => Err(rustler::Error::Term(Box::new(e.to_string()))),
-    }
+    dev.map(|d| d.encode(env))
 }
 
 #[rustler::nif(schedule = "DirtyIo")]
-fn load_key_file(env: rustler::Env, path: &str) -> impl Encoder {
+fn load_key_file(env: rustler::Env, path: &str) -> NifResult<impl Encoder> {
     let result = TOKIO_RUNTIME
         .block_on(tailscale::config::load_key_file(path, Default::default()))
         .map(Keystate::from)
@@ -152,21 +100,21 @@ fn load_key_file(env: rustler::Env, path: &str) -> impl Encoder {
 }
 
 #[rustler::nif(schedule = "DirtyIo")]
-fn ipv4_addr(env: rustler::Env, dev: ResourceArc<Device>) -> impl Encoder {
+fn ipv4_addr(env: rustler::Env, dev: ResourceArc<Device>) -> NifResult<impl Encoder> {
     let dev = dev.inner.clone();
     let addr = TOKIO_RUNTIME.block_on(dev.ipv4_addr());
 
-    erl_result(env, addr.map(|ip| ip_to_erl(env, ip)).map_err(Into::into))
+    erl_result(env, addr.map(|ip| ErlIp(ip.into())).map_err(Into::into))
 }
 
 #[rustler::nif(schedule = "DirtyIo")]
-fn ipv6_addr(env: rustler::Env<'_>, dev: ResourceArc<Device>) -> impl Encoder {
+fn ipv6_addr(dev: ResourceArc<Device>) -> NifResult<impl Encoder> {
     let dev = dev.inner.clone();
 
-    match TOKIO_RUNTIME.block_on(dev.ipv6_addr()) {
-        Err(e) => (atoms::error(), e.to_string()).encode(env),
-        Ok(ip) => (atoms::ok(), ip_to_erl(env, ip)).encode(env),
-    }
+    TOKIO_RUNTIME
+        .block_on(dev.ipv6_addr())
+        .map(ErlIp::from)
+        .map_err(term_err)
 }
 
 #[rustler::nif(schedule = "DirtyIo")]
@@ -177,7 +125,7 @@ fn peer_by_name(env: rustler::Env<'_>, dev: ResourceArc<Device>, name: &str) -> 
     match TOKIO_RUNTIME.block_on(async move { dev.peer_by_name(&name).await }) {
         Err(e) => (atoms::error(), e.to_string()).encode(env),
         Ok(None) => (atoms::ok(), Option::<()>::None).encode(env),
-        Ok(Some(peer)) => (atoms::ok(), NodeInfo::from_node(env, peer)).encode(env),
+        Ok(Some(peer)) => (atoms::ok(), NodeInfo::from(peer)).encode(env),
     }
 }
 
@@ -187,125 +135,33 @@ fn self_node(env: rustler::Env<'_>, dev: ResourceArc<Device>) -> impl Encoder {
 
     match TOKIO_RUNTIME.block_on(async move { dev.self_node().await }) {
         Err(e) => (atoms::error(), e.to_string()).encode(env),
-        Ok(peer) => (atoms::ok(), NodeInfo::from_node(env, peer)).encode(env),
+        Ok(peer) => (atoms::ok(), NodeInfo::from(peer)).encode(env),
     }
 }
 
 #[rustler::nif(schedule = "DirtyIo")]
-fn peer_by_tailnet_ip(env: rustler::Env<'_>, dev: ResourceArc<Device>, ip: Term) -> impl Encoder {
+fn peer_by_tailnet_ip(env: rustler::Env<'_>, dev: ResourceArc<Device>, ip: ErlIp) -> impl Encoder {
     let dev = dev.inner.clone();
-    let Some(ip) = ip_from_erl(ip) else {
-        return env.error_tuple("invalid ip");
-    };
 
-    match TOKIO_RUNTIME.block_on(async move { dev.peer_by_tailnet_ip(ip).await }) {
+    match TOKIO_RUNTIME.block_on(async move { dev.peer_by_tailnet_ip(ip.0).await }) {
         Err(e) => (atoms::error(), e.to_string()).encode(env),
         Ok(None) => (atoms::ok(), Option::<()>::None).encode(env),
-        Ok(Some(peer)) => (atoms::ok(), NodeInfo::from_node(env, peer)).encode(env),
+        Ok(Some(peer)) => (atoms::ok(), NodeInfo::from(peer)).encode(env),
     }
 }
 
 #[rustler::nif(schedule = "DirtyIo")]
-fn peers_with_route(env: rustler::Env<'_>, dev: ResourceArc<Device>, ip: Term) -> impl Encoder {
+fn peers_with_route(env: rustler::Env<'_>, dev: ResourceArc<Device>, ip: ErlIp) -> impl Encoder {
     let dev = dev.inner.clone();
-    let Some(ip) = ip_from_erl(ip) else {
-        return env.error_tuple("invalid ip");
-    };
 
-    match TOKIO_RUNTIME.block_on(async move { dev.peers_with_route(ip).await }) {
+    match TOKIO_RUNTIME.block_on(async move { dev.peers_with_route(ip.0).await }) {
         Err(e) => (atoms::error(), e.to_string()).encode(env),
         Ok(peers) => (
             atoms::ok(),
-            peers
-                .into_iter()
-                .map(|x| NodeInfo::from_node(env, x))
-                .collect::<Vec<_>>(),
+            peers.into_iter().map(NodeInfo::from).collect::<Vec<_>>(),
         )
             .encode(env),
     }
-}
-
-fn ip_to_erl(env: rustler::Env, ip: impl Into<IpAddr>) -> Term {
-    match ip.into() {
-        IpAddr::V4(ip) => {
-            let octets = ip.octets();
-            (octets[0], octets[1], octets[2], octets[3]).encode(env)
-        }
-        IpAddr::V6(ip) => {
-            // rustler doesn't provide `impl Encoder` for 8-length tuples
-            let segments = ip.segments().map(|segment| segment.encode(env));
-
-            let tuple = rustler::types::tuple::make_tuple(env, &segments);
-            tuple.encode(env)
-        }
-    }
-}
-
-enum IpOrSelf {
-    Ip(IpAddr),
-    SelfV4,
-    SelfV6,
-}
-
-impl IpOrSelf {
-    pub fn new(ip: Term<'_>) -> Option<Self> {
-        if let Some(ip) = ip_from_erl(ip) {
-            return Some(Self::Ip(ip));
-        }
-
-        let atom = ip.decode::<rustler::Atom>().ok()?;
-        if atom == atoms::ip4() {
-            return Some(Self::SelfV4);
-        }
-
-        if atom == atoms::ip6() {
-            return Some(Self::SelfV6);
-        }
-
-        None
-    }
-
-    pub async fn resolve(&self, dev: &tailscale::Device) -> Result<IpAddr> {
-        match self {
-            IpOrSelf::Ip(ip) => Ok(*ip),
-            IpOrSelf::SelfV4 => dev.ipv4_addr().await.map(Into::into).map_err(Into::into),
-            IpOrSelf::SelfV6 => dev.ipv6_addr().await.map(Into::into).map_err(Into::into),
-        }
-    }
-}
-
-fn ip_from_erl(ip: Term) -> Option<IpAddr> {
-    if let Ok(tuple) = rustler::types::tuple::get_tuple(ip) {
-        if tuple.len() == 4 {
-            let mut octets = [0u8; 4];
-
-            for (i, elem) in tuple.into_iter().take(4).enumerate() {
-                octets[i] = elem.decode().ok()?;
-            }
-
-            return Some(Ipv4Addr::from_octets(octets).into());
-        }
-
-        if tuple.len() == 8 {
-            let mut segments = [0u16; 8];
-
-            for (i, elem) in tuple.into_iter().take(8).enumerate() {
-                segments[i] = elem.decode().ok()?;
-            }
-
-            return Some(Ipv6Addr::from_segments(segments).into());
-        }
-    }
-
-    if let Ok(s) = ip.decode::<&str>() {
-        return IpAddr::from_str(s).ok();
-    }
-
-    None
-}
-
-fn sockaddr_to_erl(env: rustler::Env, addr: SocketAddr) -> impl Encoder {
-    (ip_to_erl(env, addr.ip()), addr.port())
 }
 
 fn load(env: rustler::Env, _term: Term) -> bool {

--- a/ts_elixir/native/ts_elixir/src/node_info.rs
+++ b/ts_elixir/native/ts_elixir/src/node_info.rs
@@ -1,0 +1,43 @@
+use crate::{erl_ip::ErlIp, helpers::sockaddr_to_erl};
+
+/// Info about a Tailscale peer.
+#[derive(rustler::NifStruct)]
+#[module = "Tailscale.NodeInfo"]
+pub struct NodeInfo {
+    id: i64,
+    stable_id: String,
+    hostname: String,
+    tailnet: Option<String>,
+    tags: Vec<String>,
+    tailnet_addresses: Vec<ErlIp>,
+    derp_region: Option<u32>,
+    node_key: String,
+    disco_key: Option<String>,
+    machine_key: Option<String>,
+    underlay_addresses: Vec<(ErlIp, u16)>,
+}
+
+impl From<tailscale::NodeInfo> for NodeInfo {
+    fn from(value: tailscale::NodeInfo) -> Self {
+        Self {
+            id: value.id,
+            stable_id: value.stable_id.0,
+            hostname: value.hostname,
+            tailnet: value.tailnet,
+            tags: value.tags,
+            tailnet_addresses: vec![
+                ErlIp::from(value.tailnet_address.ipv4.addr()),
+                ErlIp::from(value.tailnet_address.ipv6.addr()),
+            ],
+            derp_region: value.derp_region.map(|x| x.0.get()),
+            node_key: value.node_key.to_string(),
+            disco_key: value.disco_key.as_ref().map(ToString::to_string),
+            machine_key: value.machine_key.as_ref().map(ToString::to_string),
+            underlay_addresses: value
+                .underlay_addresses
+                .into_iter()
+                .map(sockaddr_to_erl)
+                .collect(),
+        }
+    }
+}

--- a/ts_elixir/native/ts_elixir/src/tcp.rs
+++ b/ts_elixir/native/ts_elixir/src/tcp.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
-use rustler::{Encoder, ResourceArc};
+use rustler::{Encoder, NifResult, ResourceArc};
 
-use crate::{IpOrSelf, Result, TOKIO_RUNTIME, atoms, erl_result, ip_from_erl, ok_arc};
+use crate::{
+    IpOrSelf, Result, TOKIO_RUNTIME, atoms, erl_ip::ErlIp, erl_result, helpers::term_err, ok_arc,
+};
 
 pub(crate) struct TcpListener {
     inner: Arc<tailscale::netstack::TcpListener>,
@@ -20,66 +22,66 @@ impl rustler::Resource for TcpStream {}
 
 #[rustler::nif(schedule = "DirtyIo")]
 fn tcp_listen(
-    env: rustler::Env,
     dev: ResourceArc<crate::Device>,
-    addr: rustler::Term,
+    addr: IpOrSelf,
     port: u16,
-) -> impl Encoder {
+) -> NifResult<impl Encoder> {
     let dev = dev.inner.clone();
-    let ip = IpOrSelf::new(addr);
 
-    let sock = TOKIO_RUNTIME.block_on(async move {
-        let addr = ip.ok_or("invalid ip addr")?.resolve(&dev).await?;
-        let sock = dev.tcp_listen((addr, port).into()).await?;
+    TOKIO_RUNTIME.block_on(async move {
+        let addr = addr.resolve(&dev).await?;
+        let sock = dev
+            .tcp_listen((addr, port).into())
+            .await
+            .map_err(term_err)?;
 
         ok_arc(TcpListener {
             inner: Arc::new(sock),
         })
-    });
-
-    erl_result(env, sock)
+    })
 }
 
 #[rustler::nif]
-fn tcp_listen_local_addr(env: rustler::Env, listener: ResourceArc<TcpListener>) -> impl Encoder {
-    crate::sockaddr_to_erl(env, listener.inner.local_addr())
+fn tcp_listen_local_addr(listener: ResourceArc<TcpListener>) -> impl Encoder {
+    crate::sockaddr_to_erl(listener.inner.local_addr())
 }
 
 #[rustler::nif(schedule = "DirtyIo")]
 fn tcp_connect(
-    env: rustler::Env<'_>,
+    env: rustler::Env,
     dev: ResourceArc<crate::Device>,
-    addr: rustler::Term,
+    addr: ErlIp,
     port: u16,
-) -> impl Encoder {
-    let addr = ip_from_erl(addr);
+) -> NifResult<impl Encoder> {
     let dev = dev.inner.clone();
 
-    let sock = TOKIO_RUNTIME.block_on(async move {
-        let addr = addr.ok_or("invalid ip addr")?;
-        let sock = dev.tcp_connect((addr, port).into()).await?;
+    TOKIO_RUNTIME
+        .block_on(async move {
+            let sock = dev
+                .tcp_connect((addr, port).into())
+                .await
+                .map_err(term_err)?;
 
-        ok_arc(TcpStream {
-            inner: Arc::new(sock),
+            ok_arc(TcpStream {
+                inner: Arc::new(sock),
+            })
         })
-    });
-
-    erl_result(env, sock)
+        .map(|sock| sock.encode(env))
 }
 
 #[rustler::nif(schedule = "DirtyIo")]
-fn tcp_accept(env: rustler::Env<'_>, sock: ResourceArc<TcpListener>) -> impl Encoder {
+fn tcp_accept(env: rustler::Env<'_>, sock: ResourceArc<TcpListener>) -> NifResult<impl Encoder> {
     let inner = sock.inner.clone();
 
-    let sock = TOKIO_RUNTIME.block_on(async move {
-        let stream = inner.accept().await?;
+    TOKIO_RUNTIME
+        .block_on(async move {
+            let stream = inner.accept().await.map_err(term_err)?;
 
-        ok_arc(TcpStream {
-            inner: Arc::new(stream),
+            ok_arc(TcpStream {
+                inner: Arc::new(stream),
+            })
         })
-    });
-
-    erl_result(env, sock)
+        .map(|sock| sock.encode(env))
 }
 
 #[rustler::nif(schedule = "DirtyIo")]
@@ -93,7 +95,7 @@ fn tcp_send(env: rustler::Env, sock: ResourceArc<TcpStream>, msg: Vec<u8>) -> ru
 }
 
 #[rustler::nif(schedule = "DirtyIo")]
-fn tcp_recv(env: rustler::Env, sock: ResourceArc<TcpStream>) -> impl Encoder {
+fn tcp_recv(env: rustler::Env, sock: ResourceArc<TcpStream>) -> NifResult<impl Encoder> {
     let inner = sock.inner.clone();
 
     let buf = TOKIO_RUNTIME.block_on(async move {
@@ -105,11 +107,11 @@ fn tcp_recv(env: rustler::Env, sock: ResourceArc<TcpStream>) -> impl Encoder {
 }
 
 #[rustler::nif]
-fn tcp_local_addr(env: rustler::Env, sock: ResourceArc<TcpStream>) -> impl Encoder {
-    crate::sockaddr_to_erl(env, sock.inner.local_addr())
+fn tcp_local_addr(sock: ResourceArc<TcpStream>) -> impl Encoder {
+    crate::sockaddr_to_erl(sock.inner.local_addr())
 }
 
 #[rustler::nif]
-fn tcp_remote_addr(env: rustler::Env, sock: ResourceArc<TcpStream>) -> impl Encoder {
-    crate::sockaddr_to_erl(env, sock.inner.remote_addr())
+fn tcp_remote_addr(sock: ResourceArc<TcpStream>) -> impl Encoder {
+    crate::sockaddr_to_erl(sock.inner.remote_addr())
 }

--- a/ts_elixir/native/ts_elixir/src/udp.rs
+++ b/ts_elixir/native/ts_elixir/src/udp.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use rustler::{Binary, Encoder, ResourceArc, Term};
+use rustler::{Binary, Encoder, NifResult, ResourceArc, Term};
 
 use crate::{
-    Device, IpOrSelf, Result, TOKIO_RUNTIME, atoms, erl_result, ip_from_erl, ip_to_erl, ok_arc,
+    Device, IpOrSelf, Result, TOKIO_RUNTIME, atoms, erl_ip::ErlIp, helpers::term_err, ok_arc,
 };
 
 pub struct UdpSocket {
@@ -14,38 +14,39 @@ pub struct UdpSocket {
 impl rustler::Resource for UdpSocket {}
 
 #[rustler::nif(schedule = "DirtyIo")]
-fn udp_bind(env: rustler::Env, dev: ResourceArc<Device>, ip: Term, port: u16) -> impl Encoder {
+fn udp_bind(
+    env: rustler::Env,
+    dev: ResourceArc<Device>,
+    ip: IpOrSelf,
+    port: u16,
+) -> NifResult<impl Encoder> {
     let dev = dev.inner.clone();
-    let ip = IpOrSelf::new(ip);
 
-    let sock = TOKIO_RUNTIME.block_on(async move {
-        let addr = ip.ok_or("invalid ip addr")?.resolve(&dev).await?;
-        let sock = dev.udp_bind((addr, port).into()).await?;
+    TOKIO_RUNTIME
+        .block_on(async move {
+            let addr = ip.resolve(&dev).await?;
+            let sock = dev.udp_bind((addr, port).into()).await.map_err(term_err)?;
 
-        ok_arc(UdpSocket {
-            inner: Arc::new(sock),
+            ok_arc(UdpSocket {
+                inner: Arc::new(sock),
+            })
         })
-    });
-
-    erl_result(env, sock)
+        .map(|sock| sock.encode(env))
 }
 
 #[rustler::nif(schedule = "DirtyIo")]
 fn udp_send<'env>(
     env: rustler::Env<'env>,
     sock: ResourceArc<UdpSocket>,
-    ip: Term,
+    ip: ErlIp,
     port: u16,
     msg: Binary,
 ) -> Term<'env> {
-    let addr = ip_from_erl(ip);
     let msg = msg.to_vec();
     let sock = sock.inner.clone();
 
     match TOKIO_RUNTIME.block_on(async move {
-        let addr = addr.ok_or("invalid ip addr")?;
-
-        sock.send_to((addr, port).into(), &msg).await?;
+        sock.send_to((ip.0, port).into(), &msg).await?;
 
         Result::<_>::Ok(())
     }) {
@@ -55,22 +56,13 @@ fn udp_send<'env>(
 }
 
 #[rustler::nif(schedule = "DirtyIo")]
-fn udp_recv(env: rustler::Env, sock: ResourceArc<UdpSocket>) -> Term {
-    let (who, msg) = match sock.inner.recv_from_bytes_blocking() {
-        Ok((who, msg)) => (who, msg),
-        Err(e) => return erl_result(env, Result::<()>::Err(e.into())),
-    };
+fn udp_recv(env: rustler::Env, sock: ResourceArc<UdpSocket>) -> NifResult<Term> {
+    let (who, msg) = sock.inner.recv_from_bytes_blocking().map_err(term_err)?;
 
-    (
-        atoms::ok(),
-        ip_to_erl(env, who.ip()),
-        who.port(),
-        msg.to_vec(),
-    )
-        .encode(env)
+    Ok((atoms::ok(), ErlIp(who.ip()), who.port(), msg.to_vec()).encode(env))
 }
 
 #[rustler::nif]
-fn udp_local_addr(env: rustler::Env, sock: ResourceArc<UdpSocket>) -> impl Encoder {
-    crate::sockaddr_to_erl(env, sock.inner.local_addr())
+fn udp_local_addr(sock: ResourceArc<UdpSocket>) -> impl Encoder {
+    crate::sockaddr_to_erl(sock.inner.local_addr())
 }


### PR DESCRIPTION
Old but still-relevant change that was part of #172.

Refactors a bunch of helpers and types out of the root `lib.rs` and makes better use of `rustler::Decoder`, which e.g. lets us take `ErlIp` and `IpOrSelf` literally as nif arguments. Also switches to use `NifResult` in a number of places, which automatically handles result wrapping to `{:ok, term} | {:err, term}` rather than the manual approach we had been using before.