### PR TITLE
elixir/AtomicPid: init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6024,6 +6024,7 @@ name = "ts_elixir"
 version = "0.4.0"
 dependencies = [
  "rustler",
+ "static_assertions",
  "tailscale",
  "tokio",
  "tracing",

--- a/ts_elixir/native/ts_elixir/Cargo.toml
+++ b/ts_elixir/native/ts_elixir/Cargo.toml
@@ -15,6 +15,7 @@ rustler = "0.37.2"
 
 tailscale = { workspace = true }
 
+static_assertions.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/ts_elixir/native/ts_elixir/deworkspace_cargo_toml.py
+++ b/ts_elixir/native/ts_elixir/deworkspace_cargo_toml.py
@@ -65,7 +65,14 @@ def main():
                     value['git'] = f'https://github.com/tailscale/tailscale-rs'
                     value['rev'] = args.repo_sha
                 else:
-                    value['version'] = wksp_deps[dep]['version']
+                    wksp_dep = wksp_deps[dep]
+
+                    if type(wksp_dep) == str:
+                        value['version'] = wksp_dep
+                    elif type(wksp_dep) == dict:
+                        value['version'] = wksp_dep['version']
+                    else:
+                        raise ValueError(f'dep "{dep}" has unknown dep format in workspace Cargo.toml')
 
                 del value['workspace']
 

--- a/ts_elixir/native/ts_elixir/src/atomic_pid.rs
+++ b/ts_elixir/native/ts_elixir/src/atomic_pid.rs
@@ -1,0 +1,49 @@
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use rustler::{LocalPid, sys::ErlNifPid};
+
+/// Wrapper around [`LocalPid`] providing atomic load/store.
+pub struct AtomicPid(AtomicUsize);
+
+static_assertions::assert_eq_size!(usize, ErlNifPid);
+
+impl AtomicPid {
+    /// Get the current pid.
+    pub fn load(&self, ordering: Ordering) -> LocalPid {
+        pid_from_usize(self.0.load(ordering))
+    }
+
+    /// Set the pid.
+    pub fn store(&self, pid: LocalPid, ordering: Ordering) {
+        self.0.store(pid_to_usize(pid), ordering)
+    }
+}
+
+fn pid_to_usize(pid: LocalPid) -> usize {
+    // SAFETY: `ErlNifPid` is a `usize` internally.
+    unsafe { core::mem::transmute::<ErlNifPid, usize>(*pid.as_c_arg()) }
+}
+
+fn pid_from_usize(pid: usize) -> LocalPid {
+    // SAFETY: `ErlNifPid` is a `usize` internally.
+    LocalPid::from_c_arg(unsafe { core::mem::transmute::<usize, ErlNifPid>(pid) })
+}
+
+impl From<LocalPid> for AtomicPid {
+    fn from(value: LocalPid) -> Self {
+        AtomicPid(AtomicUsize::new(pid_to_usize(value)))
+    }
+}
+
+impl From<&AtomicPid> for LocalPid {
+    fn from(value: &AtomicPid) -> Self {
+        value.load(Ordering::SeqCst)
+    }
+}
+
+impl From<AtomicPid> for LocalPid {
+    fn from(mut value: AtomicPid) -> Self {
+        let pid = *value.0.get_mut();
+        pid_from_usize(pid)
+    }
+}

--- a/ts_elixir/native/ts_elixir/src/lib.rs
+++ b/ts_elixir/native/ts_elixir/src/lib.rs
@@ -10,14 +10,15 @@ use std::{
 use rustler::{Encoder, NifResult, ResourceArc, Term};
 use tracing::level_filters::LevelFilter;
 
+mod atomic_pid;
 mod config;
 mod tcp;
 mod udp;
 
+pub use atomic_pid::AtomicPid;
+use config::Keystate;
 use tcp::{TcpListener, TcpStream};
 use udp::UdpSocket;
-
-use crate::config::Keystate;
 
 mod atoms {
     rustler::atoms! {


### PR DESCRIPTION
Old but still-relevant change that was a follow-on on #172.

Atomic wrapper for Erlang pid type. Currently unused, but will be needed in the future.

CI just failing as a result of #274
