### PR TITLE
elixir: restore start_tracing nif

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6027,6 +6027,7 @@ dependencies = [
  "tailscale",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/ts_elixir/native/ts_elixir/Cargo.toml
+++ b/ts_elixir/native/ts_elixir/Cargo.toml
@@ -17,6 +17,7 @@ tailscale = { workspace = true }
 
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/ts_elixir/native/ts_elixir/src/lib.rs
+++ b/ts_elixir/native/ts_elixir/src/lib.rs
@@ -4,10 +4,11 @@ use std::{
     collections::HashMap,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     str::FromStr,
-    sync::{Arc, LazyLock},
+    sync::{Arc, LazyLock, Once},
 };
 
 use rustler::{Encoder, NifResult, ResourceArc, Term};
+use tracing::level_filters::LevelFilter;
 
 mod config;
 mod tcp;
@@ -101,6 +102,21 @@ where
     T: rustler::Resource,
 {
     Ok(ResourceArc::new(t))
+}
+
+#[rustler::nif]
+fn start_tracing() {
+    static TRACING_ONCE: Once = Once::new();
+
+    TRACING_ONCE.call_once(|| {
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::builder()
+                    .with_default_directive(LevelFilter::INFO.into())
+                    .from_env_lossy(),
+            )
+            .init();
+    });
 }
 
 #[rustler::nif(schedule = "DirtyIo")]


### PR DESCRIPTION
Old but still-relevant change that had been part of #172.

The `start_tracing` nif definition was removed as part of cleanup of `ts_cli_util` and the functionality never made it back in. This is only exposed as a function on the `Tailscale.Native` module (i.e. just the nif binding), which is internal, but it's useful to have it for debugging.

CI just failing as a result of https://github.com/tailscale/tailscale-rs/pull/274