### PR TITLE
hexdump: write generic iterator formatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6005,6 +6005,7 @@ dependencies = [
  "num-traits",
  "rand 0.10.2",
  "thiserror 2.0.18",
+ "ts_hexdump",
  "ts_keys",
  "zerocopy",
 ]

--- a/ts_disco_protocol/Cargo.toml
+++ b/ts_disco_protocol/Cargo.toml
@@ -20,6 +20,7 @@ num-traits = "0.2"
 num-derive = "0.4"
 
 ts_keys.workspace = true
+ts_hexdump.workspace = true
 
 [dev-dependencies]
 zerocopy = { workspace = true, features = ["std"] }

--- a/ts_disco_protocol/src/ping.rs
+++ b/ts_disco_protocol/src/ping.rs
@@ -45,11 +45,20 @@ impl Ping {
 
 impl Debug for &Ping {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Ping")
-            .field("tx_id", &self.tx_id)
-            .field("node_key", &self.node_key)
-            .field("padding", &&self.padding)
-            .finish()
+        let mut dbg = f.debug_struct("Ping");
+
+        dbg.field("node_key", &self.node_key).field(
+            "tx_id",
+            &format_args!("{:02x}", ts_hexdump::IterFmt::contiguous(&self.tx_id)),
+        );
+
+        if self.padding.iter().any(|&x| x != 0) {
+            dbg.field("padding", &format_args!("<nonzero> {:x?}", &self.padding));
+        } else {
+            dbg.field("padding", &self.padding.len());
+        };
+
+        dbg.finish()
     }
 }
 

--- a/ts_hexdump/src/iter.rs
+++ b/ts_hexdump/src/iter.rs
@@ -1,0 +1,90 @@
+use core::fmt::{
+    Binary, Debug, Display, Formatter, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
+};
+
+/// Generic iterator formatter with an optional user-provided delimiter.
+///
+/// The formatter is passed to each element of the iterator as-is, which notably means that the
+/// format arguments do _not_ apply to the top-level formatter but instead to each element
+/// individually. The implication of this is that width, precision, padding, etc. apply to the whole
+/// iterator at once.
+///
+/// # Examples
+///
+/// Intended usage is along the lines of contiguously hex-formatting a `[u8]` slice:
+///
+/// ```rust
+/// # use ts_hexdump::IterFmt;
+/// let ary = [0x1u8, 0x2, 0x3, 0x4, 0xa, 0xb];
+///
+/// // Use the width specifier to indicate your desired element width:
+/// assert_eq!(format!("{:02X}", IterFmt::contiguous(&ary)), "010203040A0B");
+///
+/// // If omitted, no padding:
+/// assert_eq!(format!("{:x}", IterFmt::contiguous(&ary)), "1234ab");
+/// ```
+pub struct IterFmt<It> {
+    iter: It,
+    delim: &'static str,
+}
+
+impl<It> IterFmt<It> {
+    /// Construct an [`IterFmt`] with no delimiter.
+    pub const fn contiguous(it: It) -> Self {
+        Self {
+            iter: it,
+            delim: "",
+        }
+    }
+
+    /// Construct an [`IterFmt`] with the specified delimiter.
+    pub fn delimited(it: It, delim: &'static str) -> Self {
+        Self { iter: it, delim }
+    }
+
+    /// Common formatter implementation.
+    ///
+    /// `inner_fmt` abstracts which trait (in the macro below) we're using to do the item format.
+    fn fmt(
+        &self,
+        f: &mut Formatter<'_>,
+        inner_fmt: &dyn Fn(It::Item, &mut Formatter) -> core::fmt::Result,
+    ) -> core::fmt::Result
+    where
+        It: IntoIterator + Clone,
+    {
+        let mut it = self.iter.clone().into_iter();
+
+        if let Some(elem) = it.next() {
+            inner_fmt(elem, f)?;
+        }
+
+        for elem in it {
+            f.write_str(self.delim)?;
+            inner_fmt(elem, f)?;
+        }
+
+        Ok(())
+    }
+}
+
+macro_rules! impl_fmt {
+    ($($trait_:ident),* $(,)?) => {
+        $(
+            impl<It> $trait_ for IterFmt<It>
+            where
+                It: IntoIterator + Clone,
+                It::Item: $trait_,
+            {
+                fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+                    self.fmt(f, &|elem, f| elem.fmt(f))
+                }
+            }
+
+        )*
+    }
+}
+
+impl_fmt!(
+    Debug, Display, LowerHex, UpperHex, Octal, Binary, Pointer, LowerExp, UpperExp
+);

--- a/ts_hexdump/src/lib.rs
+++ b/ts_hexdump/src/lib.rs
@@ -6,6 +6,10 @@ extern crate alloc;
 
 use core::{fmt, iter::FusedIterator};
 
+mod iter;
+
+pub use iter::IterFmt;
+
 /// The 16 hexadecimal digits as `char`s, with digits a-f as lowercase.
 const LOWERCASE_HEX_CHARS: [char; 16] = [
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',


### PR DESCRIPTION
`IterFmt` provides element-wise application of `core::fmt` specifiers over arbitrary iterators with a configurable delimiter. This provides the ability to do e.g.
`write!(f, "{:02x}", IterFmt::contiguous(&[0x1u8, 0xab, 0x3]))` and have it produce "01ab03" without intermediate allocation.

This is by comparison to the slice fmt trait implementations, which forward the formatting specifiers but hard-code the delimiter and surrounding braces (so you'd get `[0x01, 0xab, 0x03]` for the above example), or the `hex` crate, which requires allocation.

`IterFmt` forwards formatter implementations for all the `core::fmt` traits, so the same implementation can be used for `Debug`, `Display`, `LowerHex`, `UpperHex`, `LowerExp`, `UpperExp`, `Pointer`, `Binary`, and `Octal`. So e.g.
`format!("{:08b}", IterFmt::contiguous(&[0x1u8, 0xab, 0x3]))` also works as you might expect: a single contiguous bit sequence for the elements in the iterator.

Also make use of this in `disco::Ping` `Debug` impl.
