### PR TITLE
ts_tunnel: fix the triggers for session rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ Put changes for the upcoming release here!
   anywhere by default, so this is only a concern in non-default configurations. Users
   of the C bindings who persisted logs should provision new nodes with fresh keys and
   invalidate existing credentials.
-- Fixed (ts_keys): Return an error when parsing a key string with invalid hex digits,
-  rather than panic.
 - **Security** (ts_netmon, Windows): Fix use-after-free in Windows network monitoring
   code. During client shutdown, there is a short window in which network change
   notifications could fire with an already freed context pointer.
@@ -30,6 +28,9 @@ Put changes for the upcoming release here!
   Private keys continue to have serde implementations for serializing to/from disk.
 - **Security** (ts_elixir): don't print fields of the Keystate struct when inspected.
   Previously a GenServer crash would print the keystate in logs.
+- Fixed (ts_keys): Return an error when parsing a key string with invalid hex digits,
+  rather than panic.
+- Fixed(ts_tunnel): adjust session rotation logic to match the spec (#286)
 
 ## [0.4.0](https://github.com/tailscale/tailscale-rs/releases/tag/v0.4.0) - 2026-07-08
 

--- a/ts_control_noise/src/codec.rs
+++ b/ts_control_noise/src/codec.rs
@@ -3,7 +3,7 @@ use std::{io::ErrorKind, marker::PhantomData};
 use bytes::{Buf, BufMut, BytesMut};
 use chacha20poly1305::{AeadInPlace, ChaCha20Poly1305, Key, KeyInit, Nonce};
 use tokio_util::codec::{Decoder, Encoder};
-use ts_noise::core::Session;
+use ts_noise::core::{Role, Session};
 use zerocopy::{IntoBytes, TryCastError, TryFromBytes, network_endian::U16};
 
 use crate::messages::{Header, MessageType};
@@ -56,9 +56,15 @@ impl Decoder for BiCodec {
 
 impl From<Session> for BiCodec {
     fn from(session: Session) -> Self {
-        Self {
-            tx: Codec::<Tx>::from(session.send),
-            rx: Codec::<Rx>::from(session.recv),
+        match session.role {
+            Role::Initiator => Self {
+                tx: Codec::<Tx>::from(session.initiator_to_responder),
+                rx: Codec::<Rx>::from(session.responder_to_initiator),
+            },
+            Role::Responder => Self {
+                tx: Codec::<Tx>::from(session.responder_to_initiator),
+                rx: Codec::<Rx>::from(session.initiator_to_responder),
+            },
         }
     }
 }

--- a/ts_noise/src/core.rs
+++ b/ts_noise/src/core.rs
@@ -39,9 +39,11 @@ fn must_hkdf<const N: usize>(chaining_key: &[u8; 32], key: &[u8]) -> [[u8; 32]; 
 /// A symmetric session.
 pub struct Session {
     /// The key to send data.
-    pub send: chacha20poly1305::Key,
+    pub initiator_to_responder: chacha20poly1305::Key,
     /// The key to receive data.
-    pub recv: chacha20poly1305::Key,
+    pub responder_to_initiator: chacha20poly1305::Key,
+    /// Local endpoint's role in the handshake.
+    pub role: Role,
 }
 
 /// Base Noise handshake state.
@@ -49,6 +51,15 @@ pub struct Session {
 pub struct State {
     hash: [u8; 32],
     chaining_key: [u8; 32],
+}
+
+/// The role of the local peer in the handshake.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Role {
+    /// Local peer initiated the handshake.
+    Initiator,
+    /// Remote peer initiated the handshake.
+    Responder,
 }
 
 impl State {
@@ -117,27 +128,15 @@ impl State {
         }
     }
 
-    /// Finalize the handshake as the initiator role.
+    /// Finalize the handshake.
     ///
     /// This is the Split() operation in the Noise spec.
-    pub fn finish_as_initiator(self) -> Session {
-        let [send, recv] = must_hkdf(&self.chaining_key, &[]);
-
+    pub fn finish(self, role: Role) -> Session {
+        let [initiator_to_responder, responder_to_initiator] = must_hkdf(&self.chaining_key, &[]);
         Session {
-            send: send.into(),
-            recv: recv.into(),
-        }
-    }
-
-    /// Finalize the handshake as the responder role.
-    ///
-    /// This is the Split() operation in the Noise spec.
-    pub fn finish_as_responder(self) -> Session {
-        let [recv, send] = must_hkdf(&self.chaining_key, &[]);
-
-        Session {
-            send: send.into(),
-            recv: recv.into(),
+            initiator_to_responder: initiator_to_responder.into(),
+            responder_to_initiator: responder_to_initiator.into(),
+            role,
         }
     }
 }

--- a/ts_noise/src/ik.rs
+++ b/ts_noise/src/ik.rs
@@ -4,7 +4,10 @@ use ts_keys::X25519KeyPair;
 use zerocopy::FromBytes;
 
 use crate::{
-    core::{Session, State},
+    core::{
+        Role::{Initiator, Responder},
+        Session, State,
+    },
     messages::{Init, Resp},
 };
 
@@ -72,7 +75,7 @@ impl ReceivedHandshake {
             .mix_dh(&my_ephemeral.private, &self.peer_ephemeral_pub) // ee
             .mix_dh(&my_ephemeral.private, &self.peer_static_pub) // se
             .seal(&mut [], &mut response.auth_tag) // payload
-            .finish_as_responder()
+            .finish(Responder)
     }
 }
 
@@ -149,7 +152,7 @@ impl SentHandshake {
             .mix_dh(&my_static.private, &peer_ephemeral_pub) // se
             .open(&mut [], &packet.auth_tag)
             .ok_or(self)? // payload
-            .finish_as_initiator();
+            .finish(Initiator);
 
         Ok(ret)
     }
@@ -206,7 +209,15 @@ mod tests {
             panic!("initiator failed to finalize handshake");
         };
 
-        assert_eq!(init_session.send, resp_session.recv);
-        assert_eq!(init_session.recv, resp_session.send);
+        assert_eq!(
+            init_session.initiator_to_responder,
+            resp_session.initiator_to_responder
+        );
+        assert_eq!(
+            init_session.responder_to_initiator,
+            resp_session.responder_to_initiator
+        );
+        assert_eq!(init_session.role, Initiator);
+        assert_eq!(resp_session.role, Responder);
     }
 }

--- a/ts_noise/src/ikpsk2.rs
+++ b/ts_noise/src/ikpsk2.rs
@@ -6,7 +6,11 @@ use ts_keys::X25519KeyPair;
 use zerocopy::FromBytes;
 
 use crate::{
-    core::{Psk, Session, State},
+    core::{
+        Psk,
+        Role::{Initiator, Responder},
+        Session, State,
+    },
     messages::{Init, Pod, Resp},
 };
 
@@ -87,7 +91,7 @@ impl ReceivedHandshake {
             .mix_dh(&my_ephemeral.private, &self.peer_static_pub) // se
             .mix_psk(psk) // psk
             .seal(&mut [], &mut response.auth_tag) // payload
-            .finish_as_responder()
+            .finish(Responder)
     }
 }
 
@@ -175,7 +179,7 @@ impl<P: Pod> SentHandshake<P> {
             .mix_psk(psk) // psk
             .open(&mut [], &packet.auth_tag)
             .ok_or(self)?
-            .finish_as_initiator();
+            .finish(Initiator);
 
         Ok(ret)
     }
@@ -238,7 +242,15 @@ mod tests {
             panic!("initiator failed to finalize handshake");
         };
 
-        assert_eq!(init_session.send, resp_session.recv);
-        assert_eq!(init_session.recv, resp_session.send);
+        assert_eq!(
+            init_session.initiator_to_responder,
+            resp_session.initiator_to_responder
+        );
+        assert_eq!(
+            init_session.responder_to_initiator,
+            resp_session.responder_to_initiator
+        );
+        assert_eq!(init_session.role, Initiator);
+        assert_eq!(resp_session.role, Responder);
     }
 }

--- a/ts_tunnel/src/endpoint.rs
+++ b/ts_tunnel/src/endpoint.rs
@@ -79,7 +79,7 @@ impl Peer {
             return;
         }
 
-        if !self.session.needs_handshake(now) {
+        if !self.session.needs_rotation(now) {
             tracing::trace!("session does not need new handshake");
             return;
         }
@@ -181,6 +181,9 @@ impl Peer {
             if !packets.is_empty() {
                 out.queue_to_local(self.id).append(&mut packets);
                 self.schedule_keepalive(&mut endpoint.scheduler, now);
+                if self.session.needs_rotation(now) {
+                    self.start_handshake(endpoint, now, out);
+                }
             }
             return;
         }

--- a/ts_tunnel/src/handshake.rs
+++ b/ts_tunnel/src/handshake.rs
@@ -11,7 +11,7 @@ use crate::{
     endpoint::Event,
     macs::{MACReceiver, MACSender, Mac},
     messages::*,
-    session::{BidiSession, BidiSessionKeys},
+    session::BidiSession,
     time::TAI64N,
 };
 
@@ -19,7 +19,7 @@ const PROLOGUE: &[u8] = b"WireGuard v1 zx2c4 Jason@zx2c4.com";
 
 /// A partially completed incoming handshake.
 pub struct ReceivedHandshake {
-    send_id: SessionId,
+    responder_to_initiator_id: SessionId,
     noise: ikpsk2::ReceivedHandshake,
     // Info decrypted from the HandshakeInitiation
     pub timestamp: TAI64N,
@@ -40,7 +40,7 @@ impl ReceivedHandshake {
             ikpsk2::ReceivedHandshake::new(&mut pkt.noise, PROLOGUE, my_static.into())?;
 
         Some(ReceivedHandshake {
-            send_id: pkt.sender_id,
+            responder_to_initiator_id: pkt.sender_id,
             noise,
             timestamp: *timestamp,
         })
@@ -49,26 +49,23 @@ impl ReceivedHandshake {
     /// Finalize the handshake, producing a HandshakeResponse.
     pub fn respond(
         self,
-        session_id: SessionId,
+        initiator_to_responder_id: SessionId,
         psk: &Psk,
         macs: &MACSender,
         now: Instant,
     ) -> (BidiSession, PacketMut) {
         let mut response = HandshakeResponse {
-            sender_id: session_id,
-            receiver_id: self.send_id,
+            sender_id: initiator_to_responder_id,
+            receiver_id: self.responder_to_initiator_id,
             ..Default::default()
         };
 
         let session_keys = self.noise.finish(psk, response.noise.as_mut_bytes());
 
         let session = BidiSession::new(
-            BidiSessionKeys {
-                send_key: session_keys.send,
-                send_id: self.send_id,
-                recv_key: session_keys.recv,
-                recv_id: session_id,
-            },
+            session_keys,
+            initiator_to_responder_id,
+            self.responder_to_initiator_id,
             now,
         );
         let mut pkt = PacketMut::new(size_of::<HandshakeResponse>());
@@ -104,7 +101,7 @@ pub fn initiate_handshake(
     );
 
     let ret = SentHandshake {
-        id: session_id,
+        responder_to_initiator_id: session_id,
         noise,
     };
 
@@ -113,7 +110,7 @@ pub fn initiate_handshake(
 
 /// A partially completed sent handshake.
 pub struct SentHandshake {
-    pub id: SessionId,
+    pub responder_to_initiator_id: SessionId,
     noise: ikpsk2::SentHandshake<TAI64N>,
 }
 
@@ -138,7 +135,7 @@ impl Handshake {
     /// Return the session id of the handshake, if any.
     pub(crate) fn session_id(&self) -> Option<SessionId> {
         match self {
-            Handshake::Initiated(handshake, ..) => Some(handshake.id),
+            Handshake::Initiated(handshake, ..) => Some(handshake.responder_to_initiator_id),
             Handshake::Responded(tentative) => Some(tentative.recv_id()),
             Handshake::None => None,
         }
@@ -216,12 +213,9 @@ impl Handshake {
             };
 
         let session = BidiSession::new(
-            BidiSessionKeys {
-                send_key: session_keys.send,
-                send_id: packet.sender_id,
-                recv_key: session_keys.recv,
-                recv_id: sent_handshake.id,
-            },
+            session_keys,
+            packet.sender_id,
+            sent_handshake.responder_to_initiator_id,
             now,
         );
 

--- a/ts_tunnel/src/session.rs
+++ b/ts_tunnel/src/session.rs
@@ -8,6 +8,7 @@ use std::{
 
 use aead::AeadInPlace;
 use chacha20poly1305::{ChaCha20Poly1305, KeyInit};
+use ts_noise::core::Role;
 use ts_packet::PacketMut;
 use ts_time::TimeRange;
 use zerocopy::{
@@ -228,22 +229,40 @@ pub struct BidiSession {
     send_id: SessionId,
     send_cipher: ChaCha20Poly1305,
     send_nonce: NonceGenerator,
-}
 
-pub struct BidiSessionKeys {
-    pub send_key: SessionKey,
-    pub send_id: SessionId,
-    pub recv_key: SessionKey,
-    pub recv_id: SessionId,
+    is_initiator: bool,
 }
 
 impl BidiSession {
-    pub fn new(keys: BidiSessionKeys, now: Instant) -> Self {
-        Self {
-            recv: ReceiveSession::new(keys.recv_key, keys.recv_id, now),
-            send_id: keys.send_id,
-            send_cipher: ChaCha20Poly1305::new(&keys.send_key),
-            send_nonce: Default::default(),
+    pub fn new(
+        keys: ts_noise::core::Session,
+        initiator_to_responder_id: SessionId,
+        responder_to_initiator_id: SessionId,
+        now: Instant,
+    ) -> Self {
+        match keys.role {
+            Role::Initiator => Self {
+                recv: ReceiveSession::new(
+                    keys.responder_to_initiator,
+                    responder_to_initiator_id,
+                    now,
+                ),
+                send_id: initiator_to_responder_id,
+                send_cipher: ChaCha20Poly1305::new(&keys.initiator_to_responder),
+                send_nonce: Default::default(),
+                is_initiator: true,
+            },
+            Role::Responder => Self {
+                recv: ReceiveSession::new(
+                    keys.initiator_to_responder,
+                    initiator_to_responder_id,
+                    now,
+                ),
+                send_id: responder_to_initiator_id,
+                send_cipher: ChaCha20Poly1305::new(&keys.responder_to_initiator),
+                send_nonce: Default::default(),
+                is_initiator: false,
+            },
         }
     }
 
@@ -293,8 +312,8 @@ impl BidiSession {
         now > self.recv.expiry
     }
 
-    pub fn stale(&self, now: Instant) -> bool {
-        now > self.rotation_time()
+    pub fn needs_rotation(&self, now: Instant) -> bool {
+        self.is_initiator && now > self.rotation_time()
     }
 }
 
@@ -512,11 +531,11 @@ impl Session {
         }
     }
 
-    /// Reports whether the session is in need of a fresh handshake.
-    pub fn needs_handshake(&self, now: Instant) -> bool {
+    /// Reports whether the session is old enough to require rotation.
+    pub fn needs_rotation(&self, now: Instant) -> bool {
         match self {
             Self::None(_) => true,
-            Self::Active(session) => session.cur.stale(now),
+            Self::Active(session) => session.cur.needs_rotation(now),
         }
     }
 
@@ -552,12 +571,13 @@ mod tests {
         // same key in both directions, which leads to catastrophic nonce reuse. It's okay here
         // because (a) it's a test and (b) we only ever transmit in one direction.
         let send = BidiSession::new(
-            BidiSessionKeys {
-                send_key: k.into(),
-                send_id: session,
-                recv_key: k.into(),
-                recv_id: session,
+            ts_noise::core::Session {
+                initiator_to_responder: k.into(),
+                responder_to_initiator: k.into(),
+                role: Role::Initiator,
             },
+            session,
+            session,
             now,
         );
         let mut recv = ReceiveSession::new(k.into(), session, now);
@@ -617,21 +637,23 @@ mod tests {
             let sid1 = self.allocate_id();
             let sid2 = other.allocate_id();
             let s1 = BidiSession::new(
-                BidiSessionKeys {
-                    send_key: k1.into(),
-                    send_id: sid2,
-                    recv_key: k2.into(),
-                    recv_id: sid1,
+                ts_noise::core::Session {
+                    initiator_to_responder: k1.into(),
+                    responder_to_initiator: k2.into(),
+                    role: Role::Initiator,
                 },
+                sid2,
+                sid1,
                 now,
             );
             let s2 = BidiSession::new(
-                BidiSessionKeys {
-                    send_key: k2.into(),
-                    send_id: sid1,
-                    recv_key: k1.into(),
-                    recv_id: sid2,
+                ts_noise::core::Session {
+                    initiator_to_responder: k1.into(),
+                    responder_to_initiator: k2.into(),
+                    role: Role::Responder,
                 },
+                sid2,
+                sid1,
                 now,
             );
             let (_, p1) = self.session.activate(s1, &mut self.ids, now, false);
@@ -658,7 +680,7 @@ mod tests {
         }
 
         fn needs_handshake(&self, now: Instant) -> bool {
-            self.session.needs_handshake(now)
+            self.session.needs_rotation(now)
         }
     }
 
@@ -717,7 +739,7 @@ mod tests {
         assert_eq!(b_to_a, packet("bar"));
 
         assert!(a.needs_handshake(now));
-        assert!(b.needs_handshake(now));
+        assert!(!b.needs_handshake(now));
 
         // Transmit with expired session.
         let now = now + Duration::from_secs(120);
@@ -840,24 +862,25 @@ mod tests {
         let id2 = SessionId::random();
 
         let bidi = BidiSession::new(
-            BidiSessionKeys {
-                send_key: k.into(),
-                send_id: id,
-                recv_key: k2.into(),
-                recv_id: id2,
+            ts_noise::core::Session {
+                initiator_to_responder: k.into(),
+                responder_to_initiator: k2.into(),
+                role: Role::Initiator,
             },
+            id,
+            id2,
             now,
         );
         assert!(!bidi.expired(now));
-        assert!(!bidi.stale(now));
+        assert!(!bidi.needs_rotation(now));
 
         assert!(!bidi.expired(now + SESSION_FRESH_LIFETIME - epsilon));
-        assert!(!bidi.stale(now + SESSION_FRESH_LIFETIME - epsilon));
+        assert!(!bidi.needs_rotation(now + SESSION_FRESH_LIFETIME - epsilon));
 
         assert!(!bidi.expired(now + SESSION_FRESH_LIFETIME + epsilon));
-        assert!(bidi.stale(now + SESSION_FRESH_LIFETIME + epsilon));
+        assert!(bidi.needs_rotation(now + SESSION_FRESH_LIFETIME + epsilon));
 
         assert!(bidi.expired(now + SESSION_LIFETIME + epsilon));
-        assert!(bidi.stale(now + SESSION_LIFETIME + epsilon));
+        assert!(bidi.needs_rotation(now + SESSION_LIFETIME + epsilon));
     }
 }


### PR DESCRIPTION
Previously, session rotation triggered only on sending by either peer. This does not conform to the spec (section 6.2): only the initiator should trigger session rotation, and it should do so on both send and receive.

Fixes #283

Change-Id: I4fef3c7306905957932220aca8bcab1f6a6a6964

---

This change is a bit larger than the minimum surgical change: now that the final consumer of an established session needs to know whether or not it's the initiator (previously it just needed to know what its send/recv keys were), I adjusted the ts_noise APIs to return the session keys in a role-agnostic way (named `initiator_to_responder` rather than `send` or `recv`) along with the local endpoint's role, and let the caller decide how to use each key based on that.

For the control protocol this is trivial since the client is always the initiator, but for ts_tunnel BidiSession's constructor is now where the keys are assigned their send/recv purpose, depending on the local role. I found that this ended up being easier to follow through the layers of handshakes and helpers, because it means you don't have to look around at the local context to figure out which traffic direction `keys.send` is supposed to be.

This PR has no regression tests for this issue, because as I implemented those I got side-tracked into refactoring the tests to be more readable. That is https://github.com/tailscale/tailscale-rs/pull/284 (currently draft), which I'll polish up and send out as a followup to this PR. The draft PR does include tests for key rotation, both from the initiator and responder's perspective, and they confirm that with this change, rotation triggers at the right time and place.