### PR TITLE
control, runtime: move stateful client logic to runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5448,7 +5448,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -5853,7 +5852,9 @@ dependencies = [
  "tracy-client",
  "ts_control",
  "ts_derp",
+ "ts_keys",
  "ts_netcheck",
+ "url",
 ]
 
 [[package]]
@@ -5871,7 +5872,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tokio-stream",
  "tokio-util",
  "tracing",
  "ts_bitset",
@@ -6315,6 +6315,7 @@ dependencies = [
  "ts_packetfilter_state",
  "ts_transport",
  "ts_tunnel",
+ "url",
  "yoke",
 ]
 

--- a/examples/axum/main.rs
+++ b/examples/axum/main.rs
@@ -94,6 +94,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let dev = Device::new(&config, args.auth_key).await?;
+    if let tailscale::AuthState::NotAuthorized(url) = dev.is_authorized().await? {
+        tracing::warn!("device isn't authorized, please visit {url} in your browser");
+    }
 
     let listener = dev
         .tcp_listen((dev.ipv4_addr().await?, args.port).into())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,21 @@ pub struct Device {
     channel: Channel,
 }
 
+/// Whether this node is authorized to join the tailnet.
+pub enum AuthState {
+    /// The node has successfully registered with the control server.
+    Authorized,
+
+    /// The node has contacted the control server but was not authorized to register. The user
+    /// should visit the contained URL in a browser to interactively authorize the machine.
+    ///
+    /// Authorization failure occurs when the control server doesn't recognize the node's keys
+    /// and no valid auth token was provided. This can happen in a previously-working configuration
+    /// if the node's authorization has expired, or if it was registered as ephemeral and has been
+    /// offline long enough to be deleted.
+    NotAuthorized(url::Url),
+}
+
 impl Device {
     /// Create a device from the given [`Config`] and auth key.
     ///
@@ -195,6 +210,26 @@ impl Device {
         Ok(Self {
             runtime: rt,
             channel,
+        })
+    }
+
+    /// Report whether this node has been authorized to join the tailnet.
+    ///
+    /// If the node is not authorized, the returned [`AuthState::NotAuthorized`] contains a URL the
+    /// user can visit in the browser to interactively authorize the node.
+    ///
+    /// The future waits until the control server has been successfully contacted before returning,
+    /// i.e. it will remain pending in a network-down scenario.
+    pub async fn is_authorized(&self) -> Result<AuthState, Error> {
+        let ret = self
+            .runtime
+            .ask(ts_runtime::control_runner::AuthUrl)
+            .await
+            .map_err(ts_runtime::Error::from)?;
+
+        Ok(match ret {
+            Some(url) => AuthState::NotAuthorized(url),
+            None => AuthState::Authorized,
         })
     }
 

--- a/ts_cli_util/Cargo.toml
+++ b/ts_cli_util/Cargo.toml
@@ -17,6 +17,7 @@ tailscale.workspace = true
 ts_control.workspace = true
 ts_netcheck.workspace = true
 ts_derp.workspace = true
+ts_keys.workspace = true
 
 # Unconditionally required dependencies.
 cfg-if.workspace = true
@@ -24,6 +25,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 futures-util.workspace = true
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter", "tracing-log"] }
+url.workspace = true
 
 
 [target.'cfg(not(all(target_os = "windows", target_env = "gnu")))'.dependencies]

--- a/ts_cli_util/src/lib.rs
+++ b/ts_cli_util/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use futures_util::{Stream, StreamExt};
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{Layer, layer::SubscriberExt, util::SubscriberInitExt};
+use ts_control::MapRequestBuilder;
 use ts_derp::{RegionId, ServerConnInfo};
 use ts_netcheck::RegionResult;
 
@@ -35,14 +36,24 @@ pub struct CommonArgs {
     /// If left blank, uses the hostname reported by the OS.
     #[arg(short = 'H', long)]
     pub hostname: Option<String>,
+
+    /// URL of the control server to connect to.
+    #[arg(long)]
+    pub control_url: Option<url::Url>,
 }
 
 impl CommonArgs {
     /// Convert the args to a [`tailscale::Config`].
     pub async fn config(&self) -> Result<tailscale::Config> {
-        tailscale::Config::default_with_key_file(&self.key_state_path)
-            .await
-            .map_err(Into::into)
+        let mut config = tailscale::Config::default_with_key_file(&self.key_state_path).await?;
+
+        config.requested_hostname = self.hostname.clone();
+        config.control_server_url = self
+            .control_url
+            .clone()
+            .unwrap_or(ts_control::DEFAULT_CONTROL_SERVER.clone());
+
+        Ok(config)
     }
 
     /// Load or init the config, then connect to the configured control server.
@@ -50,20 +61,43 @@ impl CommonArgs {
         &self,
     ) -> Result<(
         tailscale::Config,
-        ts_control::AsyncControlClient,
+        ts_keys::NodeState,
+        ts_control::client::HttpConn,
         impl Stream<Item = Arc<ts_control::StateUpdate>> + Send + Sync + use<>,
     )> {
         let config: tailscale::Config = self.config().await?;
 
-        let (client, stream) = ts_control::AsyncControlClient::connect(
-            &(&config).into(),
-            &(&config.key_state).into(),
-            self.auth_key.as_deref(),
+        let conn = ts_control::connect(
+            &config.control_server_url,
+            &config.key_state.machine_key.clone().into(),
         )
         .await?;
+
+        let ctrl_conf: ts_control::Config = (&config).into();
+        let key_state = config.key_state.clone().into();
+
+        ts_control::register(
+            &ctrl_conf,
+            &config.control_server_url,
+            self.auth_key.as_deref(),
+            None,
+            &key_state,
+            &conn,
+        )
+        .await?;
+
+        let stream = ts_control::client::start_stream(
+            &ctrl_conf.server_url,
+            &key_state,
+            &ctrl_conf,
+            conn.clone(),
+        )
+        .await?
+        .map(Arc::new);
+
         tracing::info!("connected to control");
 
-        Ok((config, client, stream))
+        Ok((config, key_state, conn, stream))
     }
 }
 
@@ -110,7 +144,9 @@ pub fn init_tracing() {
 /// URL for the preferred derp server.
 #[tracing::instrument(skip(stream), ret, err)]
 pub async fn set_closest_derp(
-    client: &mut ts_control::AsyncControlClient,
+    keys: &ts_keys::NodeState,
+    control_url: &url::Url,
+    conn: &ts_control::client::HttpConn,
     stream: impl Stream<Item = Arc<ts_control::StateUpdate>>,
 ) -> Result<(RegionId, Vec<ServerConnInfo>)> {
     let mut netmap_stream = core::pin::pin![stream.filter_map(async |x| x.derp.clone())];
@@ -123,17 +159,19 @@ pub async fn set_closest_derp(
         return Err("no derp regions found".into());
     };
 
-    client
-        .set_home_region(
-            *id,
-            regions.iter().map(|result| {
-                (
-                    result.latency_map_key.as_str(),
-                    result.latency.as_secs_f64(),
-                )
-            }),
-        )
-        .await;
+    let mr = MapRequestBuilder::new(keys)
+        .as_request()
+        .preferred_derp(*id)
+        .derp_latencies(regions.iter().map(|result| {
+            (
+                result.latency_map_key.as_str(),
+                result.latency.as_secs_f64(),
+            )
+        }))
+        .build();
+
+    ts_control::client::send_map_request(mr, &control_url.join("machine/map").unwrap(), conn)
+        .await?;
 
     Ok((*id, map.get(id).unwrap().servers.clone()))
 }

--- a/ts_control/Cargo.toml
+++ b/ts_control/Cargo.toml
@@ -42,7 +42,6 @@ url = { workspace = true, features = ["serde", "std"] }
 zerocopy.workspace = true
 futures-util = { workspace = true }
 tokio = { workspace = true }
-tokio-stream = { version = "0.1", default-features = false, features = ["sync"] }
 
 [features]
 # Allow derp connections to be made without verifying TLS certs. Only for use in tests.

--- a/ts_control/src/client/connect.rs
+++ b/ts_control/src/client/connect.rs
@@ -22,10 +22,13 @@ lazy_static::lazy_static! {
     pub static ref CONTROL_PROTOCOL_VERSION: String = format!("Tailscale Control Protocol v{}", CapabilityVersion::CURRENT);
 }
 
+/// Error encountered while connecting to the control server.
 #[derive(Debug, thiserror::Error, Clone, Copy, Eq, PartialEq)]
 pub enum ConnectionError {
+    /// An internal error occurred.
     #[error("internal error during connection: {0}")]
     Internal(InternalErrorKind),
+    /// Connection failed due to network conditions; retrying later may solve the problem.
     #[error("Network error")]
     NetworkError,
 }
@@ -150,6 +153,10 @@ impl fmt::Display for ControlPublicKeys {
     }
 }
 
+/// Establish a connection to the control server.
+///
+/// Does not make use of use [`ControlDialer`][crate::ControlDialer] and so should not be used for
+/// long-duration connections that may need to reconnect (e.g. listening for netmap changes).
 #[tracing::instrument(skip_all, fields(%control_url), err)]
 pub async fn connect(
     control_url: &Url,
@@ -188,6 +195,13 @@ async fn connect_h1(url: &Url) -> Result<ts_http_util::Http1<EmptyBody>, Connect
     }
 }
 
+/// Fetch the control server's [`MachinePublicKey`], which is used to encrypt the Noise connection
+/// to the control server.
+///
+/// If the `insecure-keyfetch` feature flag is not enabled, this forces the key url scheme to HTTPS
+/// and validates the server's certificate. This is a critical, load-bearing requirement for
+/// security: if the control server key is MITMed, it's game over. `insecure-keyfetch` is provided
+/// ONLY for integration testing, where it's not practical to issue valid certs.
 #[tracing::instrument(skip_all, fields(%control_url), ret, err, level = "trace")]
 pub async fn fetch_control_key(control_url: &Url) -> Result<MachinePublicKey, ConnectionError> {
     let mut key_url = control_url.join("/key")?;
@@ -221,6 +235,8 @@ pub async fn fetch_control_key(control_url: &Url) -> Result<MachinePublicKey, Co
     Ok(control_public_key)
 }
 
+/// Execute the TS2021 upgrade: make an HTTP upgrade request over `h1_client` and perform a Noise
+/// handshake to establish an encrypted channel to control.
 #[tracing::instrument(skip_all, fields(%control_url, %init_msg), err)]
 pub async fn upgrade_ts2021(
     control_url: &Url,

--- a/ts_control/src/client/map_stream.rs
+++ b/ts_control/src/client/map_stream.rs
@@ -99,6 +99,7 @@ pub struct StateUpdate {
     pub dial_plan: Option<DialPlan>,
 }
 
+/// Read a stream of netmap responses from `reader`, converting them into `StateUpdate`s.
 pub fn map_stream(reader: impl AsyncRead + Unpin) -> impl Stream<Item = StateUpdate> {
     futures_util::stream::unfold(reader, async |mut reader| {
         let msg_len = reader
@@ -243,12 +244,13 @@ fn packet_filter(map_response: &MapResponse<'_>) -> Option<FilterUpdate> {
     ))
 }
 
+/// Send a [`MapRequest`] on the given HTTP2 connection.
 #[tracing::instrument(skip_all, fields(map_url = %url.as_str()))]
 pub async fn send_map_request(
     map_request: MapRequest<'_>,
     url: &Url,
     http2_conn: &Http2<BytesBody>,
-) -> Result<impl AsyncRead + 'static, MapStreamError> {
+) -> Result<impl AsyncRead + 'static + use<>, MapStreamError> {
     tracing::debug!("sending map request to control server...");
 
     let body = if cfg!(debug_assertions) {

--- a/ts_control/src/client/mod.rs
+++ b/ts_control/src/client/mod.rs
@@ -1,14 +1,10 @@
-use alloc::{collections::BTreeMap, sync::Arc};
+//! Functionality for connecting to and communicating with the Tailscale control server.
 
-use futures_util::{Stream, StreamExt};
-use tokio::{
-    sync::{broadcast, mpsc},
-    task::JoinSet,
-};
-use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+use futures_util::Stream;
+use ts_http_util::{BytesBody, Http2};
 use url::Url;
 
-use crate::{ControlDialer, Error, map_request_builder::MapRequestBuilder};
+use crate::{Error, map_request_builder::MapRequestBuilder};
 
 mod connect;
 mod map_stream;
@@ -19,205 +15,20 @@ mod register;
 pub use connect::{
     CONTROL_PROTOCOL_VERSION, connect, fetch_control_key, read_challenge_packet, upgrade_ts2021,
 };
-pub use map_stream::{FilterUpdate, PeerUpdate, StateUpdate};
-use map_stream::{map_stream, send_map_request};
-use ping::handle_ping;
-pub use register::register;
+pub use map_stream::{FilterUpdate, PeerUpdate, StateUpdate, map_stream, send_map_request};
+pub use ping::handle_ping;
+pub use register::{RegistrationError, register};
 
-/// A client to communicate with control.
-#[derive(Debug)]
-pub struct AsyncControlClient {
-    base_url: Url,
-    state_tx: broadcast::Sender<Arc<StateUpdate>>,
-    command_tx: mpsc::Sender<Command>,
-    _tasks: JoinSet<()>,
-}
+/// Type of the underlying http2 connection to the control server.
+pub type HttpConn = Http2<BytesBody>;
 
-impl AsyncControlClient {
-    /// Check whether it is possible to login with the given config, node keys, and auth
-    /// key.
-    pub async fn check_auth(
-        config: &crate::Config,
-        node_keys: &ts_keys::NodeState,
-        auth_key: Option<&str>,
-    ) -> Result<(), Error> {
-        let control_url = &config.server_url;
-
-        let h2_client = connect(control_url, &node_keys.machine_keys).await?;
-        register(config, control_url, auth_key, node_keys, &h2_client).await?;
-
-        Ok(())
-    }
-
-    /// Connects to the control plane, registers this Tailscale node, and starts handling the
-    /// message stream from control.
-    ///
-    /// The second element of the return value is a netmap stream which started listening
-    /// _before_ the client connected, i.e. it will not miss any updates from control.
-    #[tracing::instrument(skip_all, fields(control_url = %config.server_url))]
-    pub async fn connect(
-        config: &crate::Config,
-        node_keys: &ts_keys::NodeState,
-        auth_key: Option<&str>,
-    ) -> Result<
-        (
-            Self,
-            impl Stream<Item = Arc<StateUpdate>> + Send + Sync + use<>,
-        ),
-        Error,
-    > {
-        let control_url = &config.server_url;
-        let mut tasks = JoinSet::new();
-
-        let h2_client = connect(control_url, &node_keys.machine_keys).await?;
-        tracing::info!("connected to control, registering");
-
-        register(config, control_url, auth_key, node_keys, &h2_client).await?;
-
-        tracing::info!("registered, starting netmap stream");
-
-        let builder = MapRequestBuilder::new(node_keys).as_stream();
-
-        let mut request = if let Some(hostname) = &config.hostname {
-            builder.hostname(hostname)
-        } else {
-            builder
-        }
-        .build();
-
-        let client_name = config.format_client_name();
-        let host_info = request.host_info.get_or_insert_default();
-        host_info.app = &client_name;
-        host_info.ipn_version = crate::PKG_VERSION;
-
-        let (state_tx, state_rx) = broadcast::channel(32);
-        let (command_tx, command_rx) = mpsc::channel(32);
-
-        tasks.spawn({
-            let state_tx = state_tx.clone();
-            let control_url = control_url.clone();
-            let node_keys = node_keys.clone();
-            let auth_key = auth_key.map(ToOwned::to_owned);
-            let config = config.clone();
-
-            async move {
-                run(
-                    state_tx,
-                    command_rx,
-                    control_url.clone(),
-                    node_keys.clone(),
-                    auth_key,
-                    config,
-                )
-                .await
-            }
-        });
-
-        Ok((
-            Self {
-                base_url: control_url.clone(),
-                state_tx,
-                command_tx,
-                _tasks: tasks,
-            },
-            netmap_stream(state_rx),
-        ))
-    }
-
-    /// Set the DERP home region for this node.
-    #[tracing::instrument(skip_all, fields(map_url = %self.map_url(), %region_id), level = "trace")]
-    pub async fn set_home_region<'c>(
-        &mut self,
-        region_id: ts_derp::RegionId,
-        latencies: impl IntoIterator<Item = (&'c str, f64)>,
-    ) {
-        tracing::trace!(region = %region_id, "reporting home derp to control server");
-
-        if let Err(e) = self
-            .command_tx
-            .send(Command::SetDerpHomeRegion {
-                id: region_id,
-                latencies: latencies
-                    .into_iter()
-                    .map(|(name, sample)| (name.to_owned(), sample))
-                    .collect(),
-            })
-            .await
-        {
-            tracing::error!(error = %e, "setting home derp region");
-        }
-    }
-
-    /// Construct the URL that should be used to fetch the netmap.
-    pub fn map_url(&self) -> Url {
-        self.base_url
-            .join("machine/map")
-            .expect("map_url was parsed without issue before")
-    }
-
-    /// Get a stream of all netmap updates.
-    pub fn netmap_stream(&self) -> impl Stream<Item = Arc<StateUpdate>> + Send + Sync + use<> {
-        netmap_stream(self.state_tx.subscribe())
-    }
-}
-
-#[derive(Debug)]
-pub enum Command {
-    SetDerpHomeRegion {
-        id: ts_derp::RegionId,
-        latencies: BTreeMap<String, f64>,
-    },
-}
-
-pub async fn run(
-    state_tx: broadcast::Sender<Arc<StateUpdate>>,
-    mut command_rx: mpsc::Receiver<Command>,
-    control_url: Url,
-    node_keys: ts_keys::NodeState,
-    auth_key: Option<String>,
-    config: crate::Config,
-) {
-    let mut dialer = ControlDialer::default();
-
-    loop {
-        match run_once(
-            &state_tx,
-            &mut command_rx,
-            &control_url,
-            &node_keys,
-            auth_key.as_deref(),
-            &config,
-            &mut dialer,
-        )
-        .await
-        {
-            // TODO(npry): netmap stream resumption on reconnect
-            Ok(()) => {
-                tracing::warn!("netmap stream ended without error, attempting restart");
-            }
-            Err(e) => {
-                tracing::error!(error = %e, "netmap stream failed, attempting restart");
-                tokio::time::sleep(core::time::Duration::from_millis(500)).await;
-            }
-        }
-    }
-}
-
-async fn run_once(
-    state_tx: &broadcast::Sender<Arc<StateUpdate>>,
-    command_rx: &mut mpsc::Receiver<Command>,
+/// Start the netmap stream. This connection should already be registered successfully.
+pub async fn start_stream(
     control_url: &Url,
     node_keys: &ts_keys::NodeState,
-    auth_key: Option<&str>,
     config: &crate::Config,
-    control_dialer: &mut ControlDialer,
-) -> Result<(), Error> {
-    let h2_client = control_dialer
-        .full_connect_next(control_url, &node_keys.machine_keys)
-        .await?;
-
-    register(config, control_url, auth_key, node_keys, &h2_client).await?;
-
+    conn: HttpConn,
+) -> Result<impl Stream<Item = StateUpdate> + use<>, Error> {
     let builder = MapRequestBuilder::new(node_keys).as_stream();
 
     let request = if let Some(hostname) = &config.hostname {
@@ -229,62 +40,7 @@ async fn run_once(
 
     let map_url = control_url.join("machine/map").unwrap();
 
-    let reader = send_map_request(request, &map_url, &h2_client).await?;
-
-    let mut stream = core::pin::pin!(map_stream(reader));
+    let reader = send_map_request(request, &map_url, &conn).await?;
     tracing::info!("netmap stream started");
-
-    loop {
-        tokio::select! {
-            state_update = stream.next() => {
-                let Some(state_update) = state_update else {
-                    break;
-                };
-
-                let _ = handle_ping(&state_update, control_url, &h2_client).await;
-
-                if let Some(dial_plan) = &state_update.dial_plan
-                    && control_dialer.update_dial_plan(dial_plan)
-                {
-                    tracing::trace!(new_dial_plan = ?dial_plan);
-                }
-
-                // This errors only if there are no receivers. That's not semantically an error for
-                // us, so just ignore it.
-                let _ignore = state_tx.send(Arc::new(state_update));
-            }
-
-            command = command_rx.recv() => {
-                match command.unwrap() {
-                    Command::SetDerpHomeRegion { id, latencies } => {
-                        let mut builder = MapRequestBuilder::new(node_keys)
-                            .as_request()
-                            .preferred_derp(id)
-                            .derp_latencies(latencies.iter().map(|(k, v)| (k.as_str(), *v)));
-
-                        if let Some(hostname) = &config.hostname {
-                            builder = builder.hostname(hostname);
-                        }
-                        let req = builder.build();
-
-                        drop(send_map_request(req, &map_url, &h2_client).await?);
-                    },
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn netmap_stream(
-    rx: broadcast::Receiver<Arc<StateUpdate>>,
-) -> impl Stream<Item = Arc<StateUpdate>> + Send + Sync {
-    tokio_stream::wrappers::BroadcastStream::new(rx).filter_map(async |x| {
-        if let Err(BroadcastStreamRecvError::Lagged(n)) = &x {
-            tracing::warn!(messages_missed = n, "map_stream lagged");
-        }
-
-        x.ok()
-    })
+    Ok(map_stream(reader))
 }

--- a/ts_control/src/client/mod.rs
+++ b/ts_control/src/client/mod.rs
@@ -76,10 +76,7 @@ impl AsyncControlClient {
 
         tracing::info!("registered, starting netmap stream");
 
-        let builder = MapRequestBuilder::new(node_keys)
-            .keep_alive(true)
-            .omit_peers(false)
-            .stream(true);
+        let builder = MapRequestBuilder::new(node_keys).as_stream();
 
         let mut request = if let Some(hostname) = &config.hostname {
             builder.hostname(hostname)
@@ -221,10 +218,7 @@ async fn run_once(
 
     register(config, control_url, auth_key, node_keys, &h2_client).await?;
 
-    let builder = MapRequestBuilder::new(node_keys)
-        .keep_alive(true)
-        .omit_peers(false)
-        .stream(true);
+    let builder = MapRequestBuilder::new(node_keys).as_stream();
 
     let request = if let Some(hostname) = &config.hostname {
         builder.hostname(hostname)
@@ -264,9 +258,7 @@ async fn run_once(
                 match command.unwrap() {
                     Command::SetDerpHomeRegion { id, latencies } => {
                         let mut builder = MapRequestBuilder::new(node_keys)
-                            .keep_alive(false)
-                            .omit_peers(true)
-                            .stream(false)
+                            .as_request()
                             .preferred_derp(id)
                             .derp_latencies(latencies.iter().map(|(k, v)| (k.as_str(), *v)));
 

--- a/ts_control/src/client/ping.rs
+++ b/ts_control/src/client/ping.rs
@@ -75,7 +75,7 @@ fn parse_c2n_ping(payload: &str) -> Result<Request<String>, PingError> {
 /// Tailscale Go client, "GET /echo ..." invokes the C2N echo handler, while
 /// "POST /netfilter-kind ..." changes the netfilter implementation the client uses (on Linux only).
 /// The handler must return a full HTTP response to the request containing the requested data and/or
-/// status - for example, "HTTP/1.1 200 OK <body>" or "HTTP/1.1 400 Bad Request".
+/// status - for example, `HTTP/1.1 200 OK <body>` or `HTTP/1.1 400 Bad Request`.
 ///
 /// `tailscale-rs` returns an HTTP 400 Bad Request status with an error message to the control
 /// plane for any unimplemented C2N methods/paths.

--- a/ts_control/src/client/register.rs
+++ b/ts_control/src/client/register.rs
@@ -8,14 +8,21 @@ use url::Url;
 
 const LOAD_BALANCER_HEADER_KEY: &str = "Ts-Lb";
 
+/// Error registering this node with the control server.
 #[derive(Debug, thiserror::Error, Clone, Eq, PartialEq)]
 pub enum RegistrationError {
+    /// The machine's keys weren't authorized to join the tailnet.
+    ///
+    /// The contained URL, if present, may be visited by the user in a browser to interactively
+    /// authenticate the machine.
     #[error("machine was not authorized by control to join tailnet")]
     MachineNotAuthorized(Option<Url>),
 
+    /// A network error occurred. Retrying later may resolve the problem.
     #[error("Network error")]
     NetworkError,
 
+    /// An internal error occurred.
     #[error("error during registration: {0}")]
     Internal(InternalErrorKind),
 }
@@ -103,11 +110,17 @@ impl From<InternalErrorKind> for crate::InternalErrorKind {
     }
 }
 
+/// Send a request to the control server to register this device.
+///
+/// If the `followup` argument is present, the request blocks in a long-poll until the user
+/// authorizes the device using a browser. The url should have been produced by a previous call to
+/// `register` via [`RegistrationError::MachineNotAuthorized`].
 #[tracing::instrument(skip_all, fields(%control_url))]
 pub async fn register(
     config: &crate::Config,
     control_url: &Url,
     auth_key: Option<&str>,
+    followup: Option<Url>,
     node_keystate: &ts_keys::NodeState,
     http2_conn: &Http2<BytesBody>,
 ) -> Result<(), RegistrationError> {
@@ -125,6 +138,7 @@ pub async fn register(
         },
         nl_key: Some(network_lock_public_key),
         auth: auth_key.map(RegisterAuth::from),
+        followup,
         ephemeral: config.ephemeral,
         ..Default::default()
     };

--- a/ts_control/src/lib.rs
+++ b/ts_control/src/lib.rs
@@ -5,13 +5,13 @@ extern crate alloc;
 /// Package version of `ts_control` as reported by cargo.
 // TODO(npry): this is used to populate Hostinfo.ipn_version, which requests "long format":
 //  attach build info and whatever else that entails
-const PKG_VERSION: &str = if let Some(version) = option_env!("CARGO_PKG_VERSION") {
+pub const PKG_VERSION: &str = if let Some(version) = option_env!("CARGO_PKG_VERSION") {
     version
 } else {
     ""
 };
 
-mod client;
+pub mod client;
 mod config;
 mod control_dialer;
 mod derp;
@@ -21,16 +21,18 @@ mod node;
 
 use std::fmt;
 
-pub use client::{AsyncControlClient, FilterUpdate, PeerUpdate, StateUpdate};
+pub use client::{FilterUpdate, PeerUpdate, RegistrationError, StateUpdate, connect, register};
 #[doc(inline)]
 pub use config::{Config, DEFAULT_CONTROL_SERVER};
 pub use control_dialer::{ControlDialer, TcpDialer, complete_connection};
 pub use derp::{Map as DerpMap, Region as DerpRegion, convert_derp_map};
 pub use dial_plan::{DialCandidate, DialMode, DialPlan};
+pub use map_request_builder::MapRequestBuilder;
 pub use node::{
     Id as NodeId, Node, NodeLastSeen, NodeStatus, NodeUpdate, StableId as StableNodeId,
     TailnetAddress,
 };
+pub use ts_control_serde::{Endpoint, EndpointType};
 
 /// An error which occurred while connecting to the control server or control plane.
 #[derive(Debug, thiserror::Error, Clone, Eq, PartialEq)]

--- a/ts_control/src/map_request_builder.rs
+++ b/ts_control/src/map_request_builder.rs
@@ -1,6 +1,8 @@
 use ts_capabilityversion::CapabilityVersion;
 use ts_control_serde::{HostInfo, MapRequest, NetInfo};
 
+use crate::Endpoint;
+
 /// Builder type for [`MapRequest`]s; smooths over the annoying parts of creating a request.
 #[derive(Debug, Clone)]
 pub struct MapRequestBuilder<'a> {
@@ -42,21 +44,40 @@ impl<'a> MapRequestBuilder<'a> {
     }
 
     /// Set the [`MapRequest::keep_alive`] field.
-    pub fn keep_alive(mut self, value: bool) -> Self {
+    pub const fn keep_alive(mut self, value: bool) -> Self {
         self.req.keep_alive = value;
         self
     }
 
     /// Set the [`MapRequest::omit_peers`] field.
-    pub fn omit_peers(mut self, value: bool) -> Self {
+    pub const fn omit_peers(mut self, value: bool) -> Self {
         self.req.omit_peers = value;
         self
     }
 
     /// Set the [`MapRequest::stream`] field.
-    pub fn stream(mut self, value: bool) -> Self {
+    pub const fn stream(mut self, value: bool) -> Self {
         self.req.stream = value;
         self
+    }
+
+    /// Set the [`MapRequest::Endpoints`] field.
+    pub fn endpoints(mut self, endpoints: Vec<Endpoint>) -> Self {
+        self.req.endpoints = endpoints;
+        self
+    }
+
+    /// Set the `stream`, `omit_peers`, and `keep_alive` flags so that this is treated as
+    /// a regular request to the API to update some node parameter (rather than as the long
+    /// poll stream).
+    pub const fn as_request(self) -> Self {
+        self.stream(false).omit_peers(true).keep_alive(false)
+    }
+
+    /// Set the `stream`, `omit_peers`, and `keep_alive` flags so that this is treated as
+    /// a long-poll stream.
+    pub const fn as_stream(self) -> Self {
+        self.stream(true).omit_peers(false).keep_alive(true)
     }
 
     /// Set the [`HostInfo::hostname`] field.

--- a/ts_control/src/map_request_builder.rs
+++ b/ts_control/src/map_request_builder.rs
@@ -1,7 +1,5 @@
 use ts_capabilityversion::CapabilityVersion;
-use ts_control_serde::{HostInfo, MapRequest, NetInfo};
-
-use crate::Endpoint;
+use ts_control_serde::{Endpoint, HostInfo, MapRequest, NetInfo};
 
 /// Builder type for [`MapRequest`]s; smooths over the annoying parts of creating a request.
 #[derive(Debug, Clone)]
@@ -15,10 +13,10 @@ impl<'a> MapRequestBuilder<'a> {
     /// - [`MapRequest::omit_peers`] is `true`
     /// - [`MapRequest::stream`] is `false`
     /// - [`MapRequest::host_info`]:
-    ///     - [`HostInfo::hostname`] is populated from [`TailnetPeerConfig::hostname`]
+    ///     - [`HostInfo::hostname`] is populated from [`Config::hostname`][crate::Config::hostname]
     ///     - [`HostInfo::net_info`] is `None`, therefore:
-    ///         - [`NetInfo::derp_latency`][crate::types::NetInfo::derp_latency] is not populated
-    ///         - [`NetInfo::preferred_derp`][crate::types::NetInfo::preferred_derp] is not populated
+    ///         - [`NetInfo::derp_latency`] is not populated
+    ///         - [`NetInfo::preferred_derp`] is not populated
     pub fn new(key_state: &ts_keys::NodeState) -> Self {
         Self {
             req: MapRequest {
@@ -61,7 +59,7 @@ impl<'a> MapRequestBuilder<'a> {
         self
     }
 
-    /// Set the [`MapRequest::Endpoints`] field.
+    /// Set the [`MapRequest::endpoints`] field.
     pub fn endpoints(mut self, endpoints: Vec<Endpoint>) -> Self {
         self.req.endpoints = endpoints;
         self

--- a/ts_devtools/src/bin/derp_ping.rs
+++ b/ts_devtools/src/bin/derp_ping.rs
@@ -30,9 +30,11 @@ async fn main() -> ts_cli_util::Result<()> {
 
     let args = Args::parse();
 
-    let (config, mut control, stream) = args.common.connect_control().await?;
+    let (config, keys, ctrl_conn, stream) = args.common.connect_control().await?;
 
-    let (region_id, derp_servers) = ts_cli_util::set_closest_derp(&mut control, stream).await?;
+    let (region_id, derp_servers) =
+        ts_cli_util::set_closest_derp(&keys, &config.control_server_url, &ctrl_conn, stream)
+            .await?;
 
     let mut tasks = JoinSet::new();
 

--- a/ts_devtools/src/bin/pftail.rs
+++ b/ts_devtools/src/bin/pftail.rs
@@ -21,7 +21,8 @@ async fn main() -> ts_cli_util::Result<()> {
     ts_cli_util::init_tracing();
 
     let args = Args::parse();
-    let (_, _, stream) = args.common.connect_control().await?;
+
+    let (_, _, _, stream) = args.common.connect_control().await?;
     let state = Arc::new(Mutex::new(pf::BTreeFilter::new()));
 
     tracing::info!("streaming packet filter updates");

--- a/ts_runtime/Cargo.toml
+++ b/ts_runtime/Cargo.toml
@@ -43,6 +43,7 @@ tracing.workspace = true
 smallvec.workspace = true
 smol_str = "0.3"
 yoke.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 chrono.workspace = true

--- a/ts_runtime/src/control_runner.rs
+++ b/ts_runtime/src/control_runner.rs
@@ -1,8 +1,8 @@
-use core::{
-    net::{Ipv4Addr, Ipv6Addr},
-    time::Duration,
+use core::net::{Ipv4Addr, Ipv6Addr};
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
 };
-use std::sync::Arc;
 
 use futures::StreamExt;
 use kameo::{
@@ -10,20 +10,58 @@ use kameo::{
     message::{Context, StreamMessage},
     prelude::{Message, ReplySender},
     reply::DelegatedReply,
+    supervision::RestartPolicy,
 };
-use ts_control::{AsyncControlClient, Error as ControlError, Node, StateUpdate};
+use ts_control::{
+    ControlDialer, DialPlan, Endpoint, EndpointType, Error as ControlError, Node,
+    RegistrationError, StateUpdate,
+    client::{HttpConn, handle_ping, send_map_request},
+};
 
-use crate::derp_latency::{DerpLatencyMeasurement, DerpLatencyMeasurer};
+use crate::{
+    Task,
+    derp_latency::{DerpLatencyMeasurement, DerpLatencyMeasurer},
+    env::Env,
+    netmon,
+    stunner::StunAddress,
+};
+
+/// Temporary debugging configuration to report the stun- and netmon-discovered endpoints to control
+/// with a dummy port. This does not result in direct UDP connectivity because there is no socket
+/// hooked up anywhere, it just creates endpoint entries in control.
+const SEND_DUMMY_ENDPOINTS: bool = false;
+
+// placeholder: we will actually get this from the direct udp actor, which will consume
+// these netmon::State messages to just directly give us an endpoint list to report.
+// for testing, just use this dummy port. it won't result in a functional configuration
+// because there's no udp socket listening, but should surface the endpoints in control
+// and induce disco traffic from peers.
+const DUMMY_PORT: u16 = 51823;
 
 /// Actor responsible for maintaining the connection to control.
 ///
 /// This actor is responsible for proxying the map response stream onto the message bus.
 pub struct ControlRunner {
-    client: AsyncControlClient,
     params: Params,
+    state: RegState,
+
+    derp_latency_measurement: Option<DerpLatencyMeasurement>,
+
+    /// Endpoints not derived from public IPv4 STUN.
+    local_endpoints: Vec<Endpoint>,
+    /// Endpoint derived from public IPv4 STUN request.
+    stun_endpoint: Option<Endpoint>,
 
     self_node: Option<Node>,
-    pending: Vec<PendingRequest>,
+    pending_node_requests: Vec<PendingNodeRequest>,
+}
+
+enum RegState {
+    NotRegistered {
+        pending_auth_requests: Vec<ReplySender<Option<url::Url>>>,
+    },
+    AuthRequired(url::Url),
+    Registered(HttpConn),
 }
 
 /// Control runner args.
@@ -35,8 +73,8 @@ pub struct Params {
     /// Auth key (if needed).
     pub(crate) auth_key: Option<String>,
 
-    /// The [`crate::Env`] for this actor.
-    pub(crate) env: crate::Env,
+    /// The [`Env`] for this actor.
+    pub(crate) env: Env,
 }
 
 #[doc(hidden)]
@@ -49,48 +87,127 @@ pub enum ControlRunnerError {
     Crate(#[from] crate::Error),
 }
 
+#[derive(Clone)]
+struct AuthRequired(url::Url);
+
+struct RegisterResult(Result<HttpConn, RegistrationError>);
+
 impl kameo::Actor for ControlRunner {
     type Args = Params;
     type Error = ControlRunnerError;
 
     async fn on_start(params: Params, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
-        loop {
-            match AsyncControlClient::check_auth(
-                &params.config,
-                &params.env.keys,
-                params.auth_key.as_deref(),
-            )
-            .await
-            {
-                Ok(()) => break,
-                Err(ControlError::MachineNotAuthorized(u)) => {
-                    tracing::info!(auth_url = %u, "please authorize this machine or pass an auth key");
-                    tokio::time::sleep(Duration::from_secs(5)).await;
-                }
-                Err(e) => return Err(e.into()),
-            }
-        }
+        // NOTE(npry): ideally, we would use a monitor here. We actively don't want to link the
+        // dialer, because if _we_ die, the dialer must not, as its whole goal is to outlive us
+        // and provide a next-address in the presence of errors. But we want to take action in
+        // response to the dialer panicking, probably involving killing our whole supervision tree
+        // because something must be quite wrong. This can't be done with links without changing
+        // the `kameo::Actor` implementation of the dialer. That's inappropriate because it's our
+        // semantics that want to adapt to its behavior -- it shouldn't need to do adopt custom
+        // behavior to ignore our DOWN messages because we have specific requirements.
+        //
+        // Having the dialer supervise us would solve this specific problem, but is semantically
+        // incorrect because it's an internal implementation detail of this module (but the Runtime
+        // actor would have to construct the dialer directly for the supervision tree to be right).
+        // Logically (from the perspective of runtime code organization) we own the dialer, so even
+        // though it would mechanistically work to have it supervise us, it doesn't make sense.
+        //
+        // Unfortunately, kameo doesn't currently support monitors. I'm leaving this note as a clear
+        // example of a situation where those semantics are needed.
+        let (_created, dialer) = params
+            .env
+            .ensure::<DialerActor, _, _>(None, {
+                let env = params.env.clone();
 
-        let (client, stream) = AsyncControlClient::connect(
-            &params.config,
-            &params.env.keys,
-            params.auth_key.as_deref(),
-        )
-        .await?;
+                async || DialerActor {
+                    dialer: Default::default(),
+                    env,
+                }
+            })
+            .await?;
+
+        let client = dialer
+            .ask(DialNext {
+                url: params.config.server_url.clone(),
+            })
+            .await
+            .map_err(|e| e.unwrap_err())?;
+
+        Task::supervise_with(&slf, {
+            let aref = slf.downgrade();
+            let client = client.clone();
+            let params = params.clone();
+
+            move || {
+                let aref = aref.clone();
+                let client = client.clone();
+                let params = params.clone();
+
+                async move {
+                    let mut followup = None;
+
+                    loop {
+                        let result = ts_control::register(
+                            &params.config,
+                            &params.config.server_url,
+                            params.auth_key.as_deref(),
+                            followup,
+                            &params.env.keys,
+                            &client,
+                        )
+                        .await;
+
+                        if let Err(RegistrationError::MachineNotAuthorized(Some(u))) = result {
+                            tracing::warn!(auth_url = %u, "machine not authorized");
+                            followup = Some(u.clone());
+
+                            let Some(aref) = aref.upgrade() else {
+                                // if the control runner is dead, we should die shortly, no reason
+                                // to keep running.
+                                return;
+                            };
+
+                            if let Err(e) = aref.tell(AuthRequired(u)).await {
+                                tracing::error!(error = %e, "failed to tell control runner required auth");
+                            }
+
+                            continue;
+                        }
+
+                        let Some(aref) = aref.upgrade() else {
+                            return;
+                        };
+                        drop(aref.tell(RegisterResult(result.map(|_| client))).await);
+
+                        break;
+                    }
+                }
+            }
+        })
+        .restart_policy(RestartPolicy::Transient)
+        .spawn()
+        .await;
 
         params.env.subscribe::<DerpLatencyMeasurement>(&slf).await?;
+        params.env.subscribe::<Arc<netmon::State>>(&slf).await?;
+        params.env.subscribe::<StunAddress>(&slf).await?;
+
         DerpLatencyMeasurer::supervise(&slf, params.env.clone())
             .spawn()
             .await;
 
-        slf.attach_stream(stream.boxed(), (), ());
         params.env.register(None, &slf).await?;
 
         Ok(Self {
-            client,
+            state: RegState::NotRegistered {
+                pending_auth_requests: Default::default(),
+            },
             params,
+            derp_latency_measurement: None,
+            local_endpoints: Default::default(),
+            stun_endpoint: None,
             self_node: None,
-            pending: Default::default(),
+            pending_node_requests: Default::default(),
         })
     }
 }
@@ -109,7 +226,8 @@ impl ControlRunner {
 
         let (deleg, replier) = ctx.reply_sender();
         if let Some(replier) = replier {
-            self.pending.push(PendingRequest::Ipv4(replier));
+            self.pending_node_requests
+                .push(PendingNodeRequest::Ipv4(replier));
         }
 
         deleg
@@ -127,7 +245,8 @@ impl ControlRunner {
 
         let (deleg, replier) = ctx.reply_sender();
         if let Some(replier) = replier {
-            self.pending.push(PendingRequest::Ipv6(replier));
+            self.pending_node_requests
+                .push(PendingNodeRequest::Ipv6(replier));
         }
 
         deleg
@@ -145,33 +264,160 @@ impl ControlRunner {
 
         let (deleg, replier) = ctx.reply_sender();
         if let Some(replier) = replier {
-            self.pending.push(PendingRequest::SelfNode(replier));
+            self.pending_node_requests
+                .push(PendingNodeRequest::SelfNode(replier));
         }
 
         deleg
     }
-}
 
-enum PendingRequest {
-    Ipv4(ReplySender<Option<Ipv4Addr>>),
-    Ipv6(ReplySender<Option<Ipv6Addr>>),
-    SelfNode(ReplySender<Option<Node>>),
-}
+    /// Wait for a report of whether interactive auth is needed, and if so, what the URL is.
+    #[message(ctx)]
+    pub fn auth_url(
+        &mut self,
+        ctx: &mut Context<Self, DelegatedReply<Option<url::Url>>>,
+    ) -> DelegatedReply<Option<url::Url>> {
+        match &mut self.state {
+            RegState::Registered(..) => ctx.reply(None),
+            RegState::AuthRequired(u) => ctx.reply(Some(u.clone())),
+            RegState::NotRegistered {
+                pending_auth_requests,
+            } => {
+                let (deleg, replier) = ctx.reply_sender();
+                if let Some(replier) = replier {
+                    pending_auth_requests.push(replier);
+                }
 
-impl PendingRequest {
-    fn respond(self, node: &Node) {
-        match self {
-            PendingRequest::Ipv4(sender) => {
-                sender.send(Some(node.tailnet_address.ipv4.addr()));
-            }
-            PendingRequest::Ipv6(sender) => {
-                sender.send(Some(node.tailnet_address.ipv6.addr()));
-            }
-            PendingRequest::SelfNode(sender) => {
-                sender.send(Some(node.clone()));
+                deleg
             }
         }
     }
+}
+
+impl ControlRunner {
+    async fn update_map_request(&self) {
+        let RegState::Registered(conn) = &self.state else {
+            tracing::error!("attempt to update map request while not registered");
+            return;
+        };
+
+        let mut mrb = ts_control::MapRequestBuilder::new(&self.params.env.keys)
+            .as_request()
+            .endpoints(self.endpoints());
+
+        if let Some(hostname) = self.params.config.hostname.as_deref() {
+            mrb = mrb.hostname(hostname);
+        }
+
+        if let Some(latency) = &self.derp_latency_measurement {
+            if let Some(result) = latency.measurement.first() {
+                mrb = mrb.preferred_derp(result.id);
+            };
+
+            let iter = latency.measurement.iter().map(|result| {
+                (
+                    result.latency_map_key.as_str(),
+                    result.latency.as_secs_f64(),
+                )
+            });
+
+            mrb = mrb.derp_latencies(iter);
+        }
+
+        let client_name = self.params.config.format_client_name();
+
+        let mut request = mrb.build();
+        let host_info = request.host_info.get_or_insert_default();
+        host_info.app = &client_name;
+        host_info.ipn_version = ts_control::PKG_VERSION;
+
+        send_map_request(
+            request,
+            &self.params.config.server_url.join("machine/map").unwrap(),
+            conn,
+        )
+        .await
+        .unwrap();
+    }
+
+    fn endpoints(&self) -> Vec<Endpoint> {
+        let mut eps = self.local_endpoints.clone();
+        eps.extend(self.stun_endpoint);
+
+        eps
+    }
+}
+
+impl Message<AuthRequired> for ControlRunner {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        AuthRequired(auth_url): AuthRequired,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) {
+        let RegState::NotRegistered {
+            pending_auth_requests,
+        } = core::mem::replace(&mut self.state, RegState::AuthRequired(auth_url.clone()))
+        else {
+            tracing::warn!("got duplicate authrequired message");
+            return;
+        };
+
+        for req in pending_auth_requests.into_iter() {
+            req.send(Some(auth_url.clone()));
+        }
+    }
+}
+
+impl Message<RegisterResult> for ControlRunner {
+    type Reply = ();
+
+    #[tracing::instrument(skip_all, fields(result = ?msg.0))]
+    async fn handle(&mut self, msg: RegisterResult, ctx: &mut Context<Self, Self::Reply>) {
+        if matches!(self.state, RegState::Registered(..)) {
+            tracing::warn!("got register result after already in registered state");
+            return;
+        }
+
+        let conn = match msg.0 {
+            Ok(conn) => conn,
+            Err(e) => {
+                tracing::error!(error = %e, "unable to register with control server");
+                ctx.stop();
+                return;
+            }
+        };
+
+        let old_state = core::mem::replace(&mut self.state, RegState::Registered(conn.clone()));
+
+        if let RegState::NotRegistered {
+            pending_auth_requests,
+        } = old_state
+        {
+            for req in pending_auth_requests {
+                req.send(None);
+            }
+        }
+
+        let stream = ts_control::client::start_stream(
+            &self.params.config.server_url,
+            &self.params.env.keys,
+            &self.params.config,
+            conn,
+        )
+        .await
+        .unwrap()
+        .map(Arc::new);
+
+        ctx.actor_ref().attach_stream(stream.boxed(), (), ());
+    }
+}
+
+enum PendingNodeRequest {
+    Ipv4(ReplySender<Option<Ipv4Addr>>),
+    Ipv6(ReplySender<Option<Ipv6Addr>>),
+    SelfNode(ReplySender<Option<Node>>),
 }
 
 impl Message<StreamMessage<Arc<StateUpdate>, (), ()>> for ControlRunner {
@@ -180,31 +426,65 @@ impl Message<StreamMessage<Arc<StateUpdate>, (), ()>> for ControlRunner {
     async fn handle(
         &mut self,
         msg: StreamMessage<Arc<StateUpdate>, (), ()>,
-        _ctx: &mut Context<Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) {
-        match msg {
+        let msg = match msg {
             StreamMessage::Started(_) => {
                 tracing::trace!("started listening to state updates");
+                return;
             }
 
-            StreamMessage::Next(msg) => {
-                if let Some(node) = msg.node.as_ref() {
-                    self.self_node = Some(node.clone());
-                }
-
-                if let Err(e) = self.params.env.publish(msg).await {
-                    tracing::error!(error = %e, "publishing netmap update");
-                }
-            }
+            StreamMessage::Next(msg) => msg,
 
             StreamMessage::Finished(_) => {
-                tracing::error!("state update stream terminated")
+                tracing::error!("state update stream terminated");
+                ctx.stop();
+                return;
             }
+        };
+
+        if let RegState::Registered(conn) = &self.state {
+            let _ = handle_ping(&msg, &self.params.config.server_url, conn).await;
+        }
+
+        if let Some(dial_plan) = &msg.dial_plan
+            && self
+                .params
+                .env
+                .ask::<DialerActor, _>(
+                    None,
+                    UpdateDialPlan {
+                        dial_plan: dial_plan.clone(),
+                    },
+                    false,
+                )
+                .await
+                .unwrap()
+        {
+            tracing::trace!(new_dial_plan = ?dial_plan);
+        }
+
+        if let Some(node) = msg.node.as_ref() {
+            self.self_node = Some(node.clone());
+        }
+
+        if let Err(e) = self.params.env.publish(msg).await {
+            tracing::error!(error = %e, "publishing netmap update");
         }
 
         if let Some(node) = &self.self_node {
-            for req in self.pending.drain(..) {
-                req.respond(node);
+            for req in self.pending_node_requests.drain(..) {
+                match req {
+                    PendingNodeRequest::Ipv4(sender) => {
+                        sender.send(Some(node.tailnet_address.ipv4.addr()));
+                    }
+                    PendingNodeRequest::Ipv6(sender) => {
+                        sender.send(Some(node.tailnet_address.ipv6.addr()));
+                    }
+                    PendingNodeRequest::SelfNode(sender) => {
+                        sender.send(Some(node.clone()));
+                    }
+                }
             }
         }
     }
@@ -214,22 +494,99 @@ impl Message<DerpLatencyMeasurement> for ControlRunner {
     type Reply = ();
 
     async fn handle(&mut self, msg: DerpLatencyMeasurement, _ctx: &mut Context<Self, Self::Reply>) {
-        let measurements = msg.measurement.as_ref().clone();
-
-        let Some(result) = measurements.first() else {
-            tracing::debug!("derp latency measurements empty");
+        if self.derp_latency_measurement.as_ref() == Some(&msg) {
             return;
-        };
+        }
 
-        let iter = measurements.iter().map(|result| {
-            (
-                result.latency_map_key.as_str(),
-                result.latency.as_secs_f64(),
-            )
+        self.derp_latency_measurement = Some(msg);
+        self.update_map_request().await;
+    }
+}
+
+const CGNAT_RANGE: ipnet::Ipv4Net = ipnet::Ipv4Net::new_assert(Ipv4Addr::new(100, 64, 0, 0), 10);
+const TS_IP6_ULA: ipnet::Ipv6Net =
+    ipnet::Ipv6Net::new_assert(Ipv6Addr::new(0xfd7a, 0x115c, 0xa1e0, 0, 0, 0, 0, 0), 48);
+
+impl Message<Arc<netmon::State>> for ControlRunner {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: Arc<netmon::State>, _ctx: &mut Context<Self, Self::Reply>) {
+        if !SEND_DUMMY_ENDPOINTS {
+            return;
+        }
+
+        self.local_endpoints.clear();
+
+        for (_iface, addr) in msg.up_addrs() {
+            let ip = addr.addr();
+
+            let viable_endpoint = match ip {
+                IpAddr::V4(v4) => {
+                    let invalid_addr = v4.is_broadcast()
+                        || v4.is_loopback()
+                        || v4.is_unspecified()
+                        || v4.is_documentation()
+                        || v4.is_multicast();
+
+                    !invalid_addr && !CGNAT_RANGE.contains(&v4)
+                }
+                IpAddr::V6(v6) => {
+                    let invalid_addr = v6.is_multicast() || v6.is_unspecified() || v6.is_loopback();
+
+                    !invalid_addr && !TS_IP6_ULA.contains(&v6)
+                }
+            };
+
+            if !viable_endpoint {
+                continue;
+            }
+
+            let ep = Endpoint {
+                ty: EndpointType::Local,
+                endpoint: SocketAddr::new(ip, DUMMY_PORT),
+            };
+
+            self.local_endpoints.push(ep);
+        }
+
+        self.update_map_request().await;
+    }
+}
+
+impl Message<StunAddress> for ControlRunner {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: StunAddress, _ctx: &mut Context<Self, Self::Reply>) {
+        if !SEND_DUMMY_ENDPOINTS {
+            return;
+        }
+
+        self.stun_endpoint = Some(Endpoint {
+            ty: EndpointType::Stun,
+            endpoint: SocketAddr::new(msg.addr, DUMMY_PORT),
         });
 
-        tracing::debug!(selected_region_id = ?result.id, "updating home region");
+        self.update_map_request().await;
+    }
+}
 
-        self.client.set_home_region(result.id, iter).await;
+#[derive(kameo::Actor)]
+struct DialerActor {
+    dialer: ControlDialer,
+    env: Env,
+}
+
+#[kameo::messages]
+impl DialerActor {
+    #[message]
+    async fn dial_next(&mut self, url: url::Url) -> Result<HttpConn, ts_control::Error> {
+        self.dialer
+            .full_connect_next(&url, &self.env.keys.machine_keys)
+            .await
+    }
+
+    #[message]
+    fn update_dial_plan(&mut self, dial_plan: DialPlan) -> bool {
+        self.dialer.update_dial_plan(&dial_plan)
     }
 }

--- a/ts_runtime/src/derp_latency.rs
+++ b/ts_runtime/src/derp_latency.rs
@@ -8,7 +8,7 @@ use ts_netcheck::RegionResult;
 
 use crate::{Error, env::Env};
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct DerpLatencyMeasurement {
     pub measurement: Arc<Vec<RegionResult>>,
 }

--- a/ts_runtime/src/env.rs
+++ b/ts_runtime/src/env.rs
@@ -121,6 +121,27 @@ impl Env {
         self.resolve_aref(aref)
     }
 
+    /// Ensure the given actor exists in the registry.
+    ///
+    /// If it doesn't, create the actor using the given function to populate its args.
+    pub async fn ensure<A, F, Fut>(
+        &self,
+        name: Option<SmolStr>,
+        args_builder: F,
+    ) -> Result<(bool, ActorRef<A>), Error>
+    where
+        A: kameo::Actor,
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = A::Args> + Send + 'static,
+    {
+        let (created, aref) = self
+            .registry
+            .ask(registry::Ensure::new(name, args_builder))
+            .await?;
+
+        Ok((created, aref))
+    }
+
     /// Send an ask to an actor in the registry.
     ///
     /// # Parameters

--- a/ts_runtime/src/lib.rs
+++ b/ts_runtime/src/lib.rs
@@ -157,7 +157,8 @@ forward!(
     ControlRunner,
     control_runner::Ipv4,
     control_runner::Ipv6,
-    control_runner::SelfNode
+    control_runner::SelfNode,
+    control_runner::AuthUrl,
 );
 forward!(
     PeerTracker,

--- a/ts_runtime/src/netmon.rs
+++ b/ts_runtime/src/netmon.rs
@@ -71,7 +71,6 @@ pub struct State {
     pub default_route_interface_v6: Option<InterfaceId>,
 }
 
-#[expect(dead_code)]
 impl State {
     /// Iterate the addresses on all interfaces in the `up` state.
     pub fn up_addrs(&self) -> impl Iterator<Item = (InterfaceId, ipnet::IpNet)> {

--- a/ts_runtime/src/registry.rs
+++ b/ts_runtime/src/registry.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use kameo::{
     Reply,
-    actor::{ActorRef, WeakActorRef},
+    actor::{ActorRef, Spawn, WeakActorRef},
     error::{BoxSendError, Infallible, SendError},
     message::{Context, Message},
     reply::{BoxReplySender, DelegatedReply, ForwardedReply, ReplyError},
@@ -249,6 +249,56 @@ where
     }
 }
 
+/// Request to ensure a given actor exists in the registry.
+///
+/// If the actor doesn't exist, it'll be created with the args produced by the contained function.
+/// The reply type is whether an actor was created and the ref to the actor.
+pub struct Ensure<A, F, Fut> {
+    id: Id,
+    create: F,
+    _phantom: PhantomData<(A, Fut)>,
+}
+
+impl<A, F, Fut> Ensure<A, F, Fut> {
+    /// Construct an [`Ensure`] message.
+    pub fn new(name: Option<SmolStr>, mk_args: F) -> Self
+    where
+        A: Any,
+    {
+        Self {
+            id: Id::new::<A>(name),
+            create: mk_args,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<A, F, Fut> Message<Ensure<A, F, Fut>> for Registry
+where
+    A: kameo::Actor,
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = A::Args> + Send + 'static,
+{
+    type Reply = (bool, ActorRef<A>);
+
+    async fn handle(
+        &mut self,
+        msg: Ensure<A, F, Fut>,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> (bool, ActorRef<A>) {
+        if let Some(aref) = self.actors.get(&msg.id) {
+            return (false, aref.downcast_ref().cloned().unwrap());
+        }
+
+        let args = (msg.create)().await;
+        let aref = A::spawn(args);
+
+        self.actors.insert(msg.id, Box::new(aref.downgrade()));
+
+        (true, aref)
+    }
+}
+
 /// Request to forward a message of type `M` to an actor of type `A` under a particular registered
 /// name.
 pub struct Forward<A, M> {
@@ -350,7 +400,8 @@ where
 {
     type Reply = RegistryForward<M, A::Reply>;
 
-    #[tracing::instrument(skip_all, fields(msgty = type_name::<M>(), actor = type_name::<A>(), name = %msg.id.name))]
+    #[tracing::instrument(skip_all, fields(msgty = type_name::<M>(), actor = type_name::<A>(), name = %msg.id.name
+    ))]
     async fn handle(
         &mut self,
         msg: Forward<A, M>,


### PR DESCRIPTION
Move the stateful control client logic to runtime. 

The main intent of this change is to put all the state for `MapRequest` construction in one place, rather than adding it piecemeal as fields on `AsyncControlClient` and writing a separate quasi-actor message (in the command paradigm I had set up there with a tokio `select!` loop) to update each discrete piece of state. This was very actor shaped, and crossing the boundary to the tokio quasi-actor to kameo and vice versa seemed like unnecessary pain.

Instead, the control actor holds the relevant state, updating it directly in response to other messages from the runtime, such as derp latency measurements and endpoint updates (the direct inspiration for this change) and then triggering a maprequest to update control. This makes `ts_control` into a dumb, minimal pipe that sends netmaps up to the actor and recevies maprequests. This does make `ts_control` less usable standalone, but this is a less important usecase than runtime, and as the fixes to `ts_cli_util` demonstrate, it's not too bad to hold this way.

The control dialer is factored out as an actor that is spawned by (but not linked to) the control actor. This is in order to outlive it, so that dial plan updates can persist in case the control actor has to restart. This is supported by a new `Ensure` registry message that spawns an actor if it doesn't exist, returning the `ActorRef` in either case. See the comment for more details on why it works this way.

This provides provisional support for sending udp endpoints to control based on observations from netmon and the stun actor. The actual port number used is nonsense because there is no socket listening, but the endpoints show up in control and do elicit udp traffic from peers trying to communicate. This behavior is hidden behind a const bool which is off by default, and the actual tracking of the endpoints will migrate to the direct udp actor soon after this change.

## control register auth fixup

Closes #89

Previously, if control auth failed and responded with a valid auth url, we would sit in a timer loop retrying every 5s and printing the returned url (this generated a new url each time we retried). The new urls didn't invalidate the old ones, so this did work, but it wasn't ideal or intended. The way `/machine/register` works in the case where the client isn't registered and doesn't supply a valid auth key is:

- Register (fails with auth url)
- Register again (`FollowUp: orig_url`)
    - Sit in long-poll (server holds the request open because there was a valid `FollowUp`)
- User opens the url in browser and authorizes the machine
- 2nd long-polling register call completes
- Continue control startup

Because we've refactored to be actor-shaped, this is much easier to achieve. We try to register in the control actor `on_start`, and if it fails, we spawn a `FollowUp` task and wait for it to send us a message reporting success or failure. The control actor can now be queried for an active auth url (waiting until one appears), which is forwarded all the way out to a method on `tailscale::Device`.