### PR TITLE
tailscale, control, lang bindings: support `ephemeral` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Record breaking or significant changes here. All dates are UTC.
 
 Put changes for the upcoming release here!
 
+- **Breaking** (Rust API, lang bindings, ts_control): Support for `ephemeral`
+  config option. This was previously effectively hardcoded to `true`, the default
+  is now `false` (tailscale-rs nodes are _not_ ephemeral unless you explicitly
+  configure them to be).
+  [#292](https://github.com/tailscale/tailscale-rs/pull/292).
+
 ## [0.4.0](https://github.com/tailscale/tailscale-rs/releases/tag/v0.4.0) - 2026-07-08
 
 - Added (Rust API): Experimental support for user-defined tailnet SSH servers using

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,17 @@ pub struct Config {
 
     /// Tags this node will request.
     pub requested_tags: Vec<String>,
+
+    /// Whether this node should register itself as ephemeral.
+    ///
+    /// This means that the node will be deleted from the tailnet after it is offline for a brief
+    /// period. It can be registered again with the same keys in the future but will have a
+    /// different node id.
+    ///
+    /// See the [KB article on ephemeral nodes] for more information.
+    ///
+    /// [KB article on ephemeral nodes]: https://tailscale.com/docs/features/ephemeral-nodes
+    pub ephemeral: bool,
 }
 
 impl Config {
@@ -162,6 +173,7 @@ impl From<&Config> for ts_control::Config {
             hostname: value.requested_hostname.clone(),
             server_url: value.control_server_url.clone(),
             tags: value.requested_tags.clone(),
+            ephemeral: value.ephemeral,
         }
     }
 }
@@ -174,6 +186,7 @@ impl Default for Config {
             control_server_url: ts_control::DEFAULT_CONTROL_SERVER.clone(),
             requested_hostname: None,
             requested_tags: vec![],
+            ephemeral: false,
         }
     }
 }

--- a/ts_control/src/client/register.rs
+++ b/ts_control/src/client/register.rs
@@ -125,7 +125,7 @@ pub async fn register(
         },
         nl_key: Some(network_lock_public_key),
         auth: auth_key.map(RegisterAuth::from),
-        ephemeral: true,
+        ephemeral: config.ephemeral,
         ..Default::default()
     };
 

--- a/ts_control/src/config.rs
+++ b/ts_control/src/config.rs
@@ -23,6 +23,11 @@ pub struct Config {
 
     /// Tags to request from the control server.
     pub tags: Vec<String>,
+
+    /// Whether this node is registered as ephemeral.
+    ///
+    /// Ephemeral nodes are deleted by control after a short period of inactivity.
+    pub ephemeral: bool,
 }
 
 impl Config {
@@ -46,6 +51,7 @@ impl Debug for Config {
             .field("hostname", &self.hostname)
             .field("server_url", &self.server_url.as_str())
             .field("client_name", &self.client_name)
+            .field("ephemeral", &self.ephemeral)
             .finish()
     }
 }
@@ -57,6 +63,7 @@ impl Default for Config {
             hostname: gethostname::gethostname().into_string().ok(),
             client_name: None,
             tags: Default::default(),
+            ephemeral: false,
         }
     }
 }

--- a/ts_elixir/lib/tailscale.ex
+++ b/ts_elixir/lib/tailscale.ex
@@ -16,21 +16,21 @@ defmodule Tailscale do
 
   @typedoc """
   An IPv4 address.
-    
+
   `tailscale` is capable of interpreting either the `m::inet` format or a `String`.
   """
   @type ip4_addr() :: :inet.ip4_address() | String.t()
 
   @typedoc """
   An IPv6 address.
-    
+
   `tailscale` is capable of interpreting either the `m::inet` format or a `String`.
   """
   @type ip6_addr() :: :inet.ip6_address() | String.t()
 
   @typedoc """
   An IP address (v4 or v6).
-    
+
   `tailscale` is capable of interpreting either the `m::inet` format or a `String`.
   """
   @type ip_addr() :: ip4_addr() | ip6_addr()
@@ -50,13 +50,16 @@ defmodule Tailscale do
   - `hostname`: the hostname this device will request. If omitted, uses the hostname the OS reports.
   - `tags`: tags the device will request.
   - `control_url`: the url of the control server to use.
+  - `ephemeral`: whether this node should be registered as ephemeral. Ephemeral nodes are removed
+    from the tailnet after being offline for a brief period.
   """
   @type options :: [
           auth_key: String.t(),
           keys: Tailscale.Keystate.t(),
           control_url: String.t(),
           hostname: String.t(),
-          tags: [String.t()]
+          tags: [String.t()],
+          ephemeral: boolean()
         ]
 
   @spec connect(String.t(), options()) :: {:ok, t()} | {:error, any()}
@@ -94,7 +97,7 @@ defmodule Tailscale do
   @spec ipv4_addr(t()) :: {:ok, :inet.ip4_address()} | {:error, any()}
   @doc """
   Get the current IPv4 address of this Tailscale node.
-    
+
   Blocks until the address is available.
   """
   def ipv4_addr(dev), do: Tailscale.Native.ipv4_addr(dev)
@@ -102,7 +105,7 @@ defmodule Tailscale do
   @spec ipv6_addr(t()) :: {:ok, :inet.ip6_address()} | {:error, any()}
   @doc """
   Get the current IPv6 address of this Tailscale node.
-    
+
   Blocks until the address is available.
 
   Note that this address is in `t::inet.ip6_address/0` format (16-bit segments), which may be

--- a/ts_elixir/native/ts_elixir/src/config.rs
+++ b/ts_elixir/native/ts_elixir/src/config.rs
@@ -9,6 +9,7 @@ mod atoms {
         hostname,
         tags,
         auth_key,
+        ephemeral,
     }
 }
 
@@ -50,6 +51,10 @@ pub fn config_from_erl(
 
     if let Some(value) = erl_config.get(&atoms::auth_key()) {
         auth_key = Some(value.decode()?);
+    }
+
+    if let Some(value) = erl_config.get(&atoms::ephemeral()) {
+        config.ephemeral = value.decode()?;
     }
 
     Ok((config, auth_key))

--- a/ts_ffi/src/config.rs
+++ b/ts_ffi/src/config.rs
@@ -39,6 +39,11 @@ pub struct config<'a> {
     ///
     /// If `NULL`, ephemeral key state is generated.
     pub key_state: Option<&'a mut persisted_key_state>,
+
+    /// Whether to register this node as ephemeral.
+    ///
+    /// Ephemeral nodes are removed from the tailnet after being offline for a brief period.
+    pub ephemeral: bool,
 }
 
 impl config<'_> {
@@ -96,6 +101,8 @@ impl config<'_> {
             })
         }
         .collect();
+
+        cfg.ephemeral = self.ephemeral;
 
         cfg
     }

--- a/ts_python/src/lib.rs
+++ b/ts_python/src/lib.rs
@@ -37,7 +37,7 @@ pub mod _internal {
 
     /// Connect to tailscale using the specified parameters.
     #[pyfunction]
-    #[pyo3(signature = (key_file_path: "str | None" = None , /, auth_key: "str | None" = None, *, control_server_url: "str | None" = None, hostname: "str | None" = None, tags: "list[str] | None" = None, keys: "Keystate | None" = None) -> "Awaitable[Device]")]
+    #[pyo3(signature = (key_file_path: "str | None" = None , /, auth_key: "str | None" = None, *, control_server_url: "str | None" = None, hostname: "str | None" = None, tags: "list[str] | None" = None, keys: "Keystate | None" = None, ephemeral: "bool" = false) -> "Awaitable[Device]")]
     pub fn connect(
         py: Python<'_>,
         key_file_path: Option<String>,
@@ -46,6 +46,7 @@ pub mod _internal {
         hostname: Option<String>,
         tags: Option<Vec<String>>,
         keys: Option<Keystate>,
+        ephemeral: bool,
     ) -> PyFut<'_> {
         static TRACING_ONCE: Once = Once::new();
         TRACING_ONCE.call_once(|| {
@@ -83,6 +84,8 @@ pub mod _internal {
             if let Some(keys) = &keys {
                 config.key_state = keys.try_into().map_err(|_| py_value_err("invalid keys"))?;
             }
+
+            config.ephemeral = ephemeral;
 
             let dev = ts::Device::new(&config, auth_key)
                 .await


### PR DESCRIPTION
We previously had `ephemeral` hardcoded to `true` in control, propagate this out as a configurable option to all endpoint crates. 

Worth calling out that this changes the default to `false`. This is consistent with the behavior in Go (including tsnet).