### PR TITLE
ts_ffi: remove Debug impl from persisted_key_state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Put changes for the upcoming release here!
   is now `false` (tailscale-rs nodes are _not_ ephemeral unless you explicitly
   configure them to be).
   [#292](https://github.com/tailscale/tailscale-rs/pull/292).
+- **Security** (C bindings): Don't log private keys in `ts_load_key_file`. Previously
+  loaded keys were logged at INFO priority. These logs aren't persisted or streamed
+  anywhere by default, so this is only a concern in non-default configurations. Users
+  of the C bindings who persisted logs should provision new nodes with fresh keys and
+  invalidate existing credentials.
 
 ## [0.4.0](https://github.com/tailscale/tailscale-rs/releases/tag/v0.4.0) - 2026-07-08
 

--- a/ts_ffi/src/keys.rs
+++ b/ts_ffi/src/keys.rs
@@ -55,7 +55,7 @@ impl_to_from!(
 );
 
 /// Tailscale key state for running a device.
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct persisted_key_state {
     /// Private key for the node (device) identity.
@@ -129,8 +129,6 @@ pub unsafe extern "C" fn ts_load_key_file(
     match TOKIO_RUNTIME.block_on(tailscale::config::load_key_file(s, mode)) {
         Ok(state) => {
             *key_state = state.into();
-            tracing::info!(?key_state, "loaded key state");
-
             0
         }
         Err(e) => {


### PR DESCRIPTION
And remove the trace statement that inadvertently logged loaded keys.

Change-Id: I8f4af2f24591a66054ea88aa94d405636a6a6964