### PR TITLE
ts_keys: return a parse error instead of panicking on invalid key strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Put changes for the upcoming release here!
   anywhere by default, so this is only a concern in non-default configurations. Users
   of the C bindings who persisted logs should provision new nodes with fresh keys and
   invalidate existing credentials.
+- Fixed (ts_keys): Return an error when parsing a key string with invalid hex digits,
+  rather than panic.
 
 ## [0.4.0](https://github.com/tailscale/tailscale-rs/releases/tag/v0.4.0) - 2026-07-08
 

--- a/ts_keys/src/macros.rs
+++ b/ts_keys/src/macros.rs
@@ -78,7 +78,7 @@ macro_rules! _create_x25519_base_key_type {
                 for i in (0..$key_name::KEY_LEN_HEX_STR).step_by(2) {
                     let slice = hex_str.get(i..i + 2).unwrap();
                     let keyidx = i / 2;
-                    let x = u8::from_str_radix(slice, 16).unwrap();
+                    let x = u8::from_str_radix(slice, 16).map_err(|_| $crate::ParseError::InvalidFormat)?;
                     key.0[keyidx] = x;
                 }
                 Ok(key)


### PR DESCRIPTION
Change-Id: I8f4af2f24591a66054ea88aa94d405636a6a6964
