### PR TITLE
ts_netmon: fix UAF in Windows network change notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Put changes for the upcoming release here!
   invalidate existing credentials.
 - Fixed (ts_keys): Return an error when parsing a key string with invalid hex digits,
   rather than panic.
+- **Security** (ts_netmon, Windows): Fix use-after-free in Windows network monitoring
+  code. During client shutdown, there is a short window in which network change
+  notifications could fire with an already freed context pointer.
 
 ## [0.4.0](https://github.com/tailscale/tailscale-rs/releases/tag/v0.4.0) - 2026-07-08
 

--- a/ts_netmon/src/windows/event_stream/notify_stream.rs
+++ b/ts_netmon/src/windows/event_stream/notify_stream.rs
@@ -24,8 +24,12 @@ macro_rules! notify_stream {
             pub struct $name {
                 #[pin]
                 rx: flume::r#async::RecvStream<'static, $msg>,
-                _tx: Box<flume::Sender<$msg >>,
                 handle: DropHandle,
+                // SAFETY: _tx must appear after handle, because handle bounds the lifetime of a
+                // raw pointer to _tx that is handed to the OS. When dropping the struct,
+                // DropHandle must die first to cancel the notification, before the pointed-to Box
+                // is dropped.
+                _tx: Box<flume::Sender<$msg >>,
             }
         }
 


### PR DESCRIPTION
During the drop of a *Stream, there is a short window where the notification callback could fire after its context ptr has already been freed.