### PR TITLE
kv_store: Tokio notifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6091,6 +6091,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ts_kv_store_tokio"
+version = "0.4.0"
+dependencies = [
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "ts_kv_store",
+]
+
+[[package]]
 name = "ts_netcheck"
 version = "0.4.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "ts_http_util",
     "ts_keys",
     "ts_kv_store",
+    "ts_kv_store_tokio",
     "ts_netcheck",
     "ts_netmon",
     "ts_netstack_smoltcp",
@@ -125,6 +126,7 @@ ts_dynbitset = { path = "ts_dynbitset", version = "0.4.0" }
 ts_hexdump = { path = "ts_hexdump", version = "0.4.0" }
 ts_keys = { path = "ts_keys", version = "0.4.0" }
 ts_kv_store = { path = "ts_kv_store", version = "0.4.0" }
+ts_kv_store_tokio = { path = "ts_kv_store_tokio", version = "0.4.0" }
 ts_netcheck = { path = "ts_netcheck", version = "0.4.0" }
 ts_netmon = { path = "ts_netmon", version = "0.4.0" }
 ts_netstack_smoltcp = { path = "ts_netstack_smoltcp", version = "0.4.0" }

--- a/ts_kv_store/src/lib.rs
+++ b/ts_kv_store/src/lib.rs
@@ -105,9 +105,10 @@
 //! Subscribers and subscriptions are essentially just opaque identifiers. Subscriptions always belong
 //! to a single subscriber. A subscriber has a single owner (multiple subscribers may have the same
 //! owner). Subscriptions watch either the whole store, a whole table, a single singleton, or a single
-//! key in a table. Subscribers can be added, but not removed (though a subscriber with no subscriptions
-//! does nothing). Subscriptions can be added or removed (note that removing a subscription requires
-//! searching through all subscriptions, so is algorithmically inefficient).
+//! key in a table. Subscribers can be added or removed (removing a subscriber also removes all its
+//! subscriptions; a subscriber with no subscriptions does nothing). Subscriptions can be added or
+//! removed (note that removing a subscription or subscriber requires searching through all
+//! subscriptions, so is algorithmically inefficient).
 //!
 //! Notifications are managed by implementations of the [`Notifier`] trait (only a no-op notifier is
 //! part of this crate). Each store has exactly one notifier. The notifier does not manage subscribers
@@ -173,7 +174,7 @@
 //! never gives it up (e.g., by panicking without calling destructors, or leaking the transaction
 //! handle), then the KV store cannot be recovered.
 
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard, Weak};
 
 mod index;
 mod iter;
@@ -197,6 +198,7 @@ pub use pub_sub::{
 };
 #[doc(inline)]
 pub use raw::KvTable;
+pub use schema::GeneratedStorage;
 #[doc(inline)]
 pub use transactions::{KvTableRoTransactional, KvTableTransactional, RoTransaction, Transaction};
 
@@ -208,10 +210,17 @@ pub struct KvStore<TableStorage: schema::GeneratedStorage> {
 
 impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
     #[doc(hidden)]
-    /// Constructor intended to be used by macros. Avoid using this and prefer to use the generated
-    /// `new` for a specialized `KvStore`.
+    /// Constructor intended to be used by macros. Prefer to use the generated `new` for a
+    /// specialized `KvStore`.
     pub fn new_with_storage(storage: RwLock<storage::Storage<TableStorage>>) -> Self {
         KvStore { storage }
+    }
+
+    /// Create a new KvStore with the supplied notifier.
+    pub fn from_notifier(
+        notifier: Weak<dyn Notifier<Notification = TableStorage::Notification>>,
+    ) -> Self {
+        Self::new_with_storage(RwLock::new(storage::Storage::new(notifier)))
     }
 
     /// A convenience for operating on a KV store with a specified owner.
@@ -228,6 +237,19 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
             .register_subscriber(owner)
     }
 
+    /// Remove a subscriber from the store, along with all of its subscriptions.
+    ///
+    /// The subscriber receives no further notifications and cannot subscribe again (subscribing
+    /// with a removed subscriber gives [`Error::UnknownSubscriber`]). Unsubscribing any of its
+    /// subscriptions is harmless but pointless.
+    ///
+    /// Does nothing if the subscriber is unknown (e.g., because it has already been removed).
+    pub fn remove_subscriber(&self, subscriber: Subscriber) {
+        self.get_read_lock()
+            .subscriptions
+            .remove_subscriber(subscriber)
+    }
+
     /// Might (theoretically) panic, see the note on [`clear_lock_poison`].
     fn get_read_lock(&self) -> RwLockReadGuard<'_, storage::Storage<TableStorage>> {
         self.clear_lock_poison();
@@ -236,6 +258,7 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
         if lock.current_txn().is_none() {
             return lock;
         }
+        drop(lock);
 
         let mut lock = self.storage.write().unwrap();
         lock.clear_transaction();
@@ -296,6 +319,11 @@ pub enum Error {
     /// The specified subscriber is not known to the store (either removed or never registered).
     #[error("Unknown subscriber")]
     UnknownSubscriber,
+    /// An attempt was made to subscribe to the store, but the store has no notifier, so subscriptions
+    /// would not be sent. This is likely because there is a reference to the store but not the notifier,
+    /// so the notifier has been dropped.
+    #[error("Store has no registered notifer")]
+    MissingNotifier,
 }
 
 /// `Result` alias for a KvStore [`Error`].

--- a/ts_kv_store/src/pub_sub.rs
+++ b/ts_kv_store/src/pub_sub.rs
@@ -21,7 +21,7 @@ use std::{
     hash::Hash,
     marker::PhantomData,
     num::NonZeroUsize,
-    sync::{Arc, Mutex, atomic::AtomicUsize},
+    sync::{Arc, Mutex, Weak, atomic::AtomicUsize},
 };
 
 use crate::{
@@ -41,6 +41,13 @@ pub struct Subscriber(NonZeroUsize);
 /// Users should not rely on the `Debug` implementation to identify a subscription.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct Subscription(NonZeroUsize, Subscriber);
+
+impl Subscription {
+    /// The subscriber this subscription belongs to.
+    pub fn subscriber(&self) -> Subscriber {
+        self.1
+    }
+}
 
 /// A collection of notifications (mapped from a [`Subscription`]) for a notifier to distribute to
 /// subscribers.
@@ -180,7 +187,8 @@ pub trait Notifier: Send + Sync + std::fmt::Debug + 'static {
     /// Notify subscribers.
     ///
     /// `notifications` contains all notifications for all subscribers for a single transaction. There
-    /// is no grouping by subscriber.
+    /// is no grouping by subscriber. It is never empty: a transaction which produces no
+    /// notifications does not call this method at all.
     ///
     /// Implementers must not call back into the store because a read lock is held while this method
     /// is called.
@@ -229,13 +237,16 @@ pub struct Subscriptions<Notif: Clone> {
     /// Subscriptions to the whole store.
     all: Mutex<HashSet<Subscription>>,
     /// Subscription metadata for each table.
-    tables: Mutex<HashMap<TypeId, Box<dyn Any + Send>>>,
+    tables: Mutex<HashMap<TypeId, Box<dyn AnyTableSubscriptions>>>,
 
-    notifier: Arc<dyn Notifier<Notification = Notif>>,
+    /// A weak reference to the store's notifier. It is weak so that the notifier can hold a strong
+    /// reference back to the store without creating a reference cycle; upgrading fails (and
+    /// notifications are silently dropped) once the notifier has been dropped.
+    notifier: Weak<dyn Notifier<Notification = Notif>>,
 }
 
 impl<Notif: Clone + 'static> Subscriptions<Notif> {
-    pub(crate) fn new(notifier: Arc<dyn Notifier<Notification = Notif>>) -> Self {
+    pub(crate) fn new(notifier: Weak<dyn Notifier<Notification = Notif>>) -> Self {
         Subscriptions {
             cur_subscriber_id: Default::default(),
             cur_subscription_id: Default::default(),
@@ -247,9 +258,16 @@ impl<Notif: Clone + 'static> Subscriptions<Notif> {
         }
     }
 
-    /// Sends `notifications` to subscribers. Call after a successful commit.
-    pub(crate) fn on_commit(&self, notifications: Notifications<Notif>) {
-        self.notifier.notify(notifications);
+    /// Deliver `notifications` to the notifier, doing nothing if there is nothing to deliver or the
+    /// notifier has been dropped.
+    pub(crate) fn notify(&self, notifications: Notifications<Notif>) {
+        if notifications.0.is_empty() {
+            return;
+        }
+
+        if let Some(notifier) = self.notifier.upgrade() {
+            notifier.notify(notifications);
+        }
     }
 
     /// Whether there are subscribers to the table `D`.
@@ -265,7 +283,7 @@ impl<Notif: Clone + 'static> Subscriptions<Notif> {
         let Some(table) = tables.get(&TypeId::of::<D>()) else {
             return false;
         };
-        let table: &TableSubscriptions<D::Key> = table.downcast_ref().unwrap();
+        let table = table.downcast_ref::<D::Key>();
 
         !table.subscriptions_all.is_empty() || !table.subscriptions.is_empty()
     }
@@ -286,7 +304,7 @@ impl<Notif: Clone + 'static> Subscriptions<Notif> {
         let Some(table) = tables.get(&TypeId::of::<D>()) else {
             return;
         };
-        let table: &TableSubscriptions<D::Key> = table.downcast_ref().unwrap();
+        let table = table.downcast_ref::<D::Key>();
 
         for s in &table.subscriptions_all {
             notifications.append_notifications(*s, &all_events);
@@ -355,19 +373,32 @@ impl<Notif: Clone + 'static> Subscriptions<Notif> {
         result
     }
 
-    /// Create and remember a new subscription ID.
+    /// Create and remember a new subscription ID for `subscriber`.
     ///
-    /// Does not subscribe to anything.
-    fn register_subscription(&self, subscriber: Subscriber) -> Result<Subscription> {
-        self.subscribers
-            .lock()
-            .unwrap()
-            .get(&subscriber)
-            .ok_or(Error::UnknownSubscriber)?;
+    /// Holds the `subscribers` lock while `f` runs, so that [`Self::remove_subscriber`]
+    /// cannot remove the subscriber between checking that it exists and the subscription being
+    /// recorded (in `f`).
+    fn register_subscription(
+        &self,
+        subscriber: Subscriber,
+        f: impl FnOnce(Subscription),
+    ) -> Result<Subscription> {
+        let Some(_notifier) = self.notifier.upgrade() else {
+            return Err(Error::MissingNotifier);
+        };
+        let subscribers = self.subscribers.lock().unwrap();
+        if !subscribers.contains_key(&subscriber) {
+            return Err(Error::UnknownSubscriber);
+        }
+
         let id = self
             .cur_subscription_id
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        Ok(Subscription(NonZeroUsize::new(id + 1).unwrap(), subscriber))
+        let subscription = Subscription(NonZeroUsize::new(id + 1).unwrap(), subscriber);
+
+        f(subscription);
+
+        Ok(subscription)
     }
 
     /// Associate a subscription ID with a singleton KV pair.
@@ -375,13 +406,14 @@ impl<Notif: Clone + 'static> Subscriptions<Notif> {
         &self,
         subscriber: Subscriber,
     ) -> Result<Subscription> {
-        let subscription = self.register_subscription(subscriber)?;
-        let mut singletons = self.singletons.lock().unwrap();
-        singletons
-            .entry(TypeId::of::<S>())
-            .or_default()
-            .insert(subscription);
-        Ok(subscription)
+        self.register_subscription(subscriber, |subscription| {
+            self.singletons
+                .lock()
+                .unwrap()
+                .entry(TypeId::of::<S>())
+                .or_default()
+                .insert(subscription);
+        })
     }
 
     /// Remove a subscription ID from watching a singleton KV pair.
@@ -399,10 +431,9 @@ impl<Notif: Clone + 'static> Subscriptions<Notif> {
         &self,
         subscriber: Subscriber,
     ) -> Result<Subscription> {
-        let subscription = self.register_subscription(subscriber)?;
-        let mut all = self.all.lock().unwrap();
-        all.insert(subscription);
-        Ok(subscription)
+        self.register_subscription(subscriber, |subscription| {
+            self.all.lock().unwrap().insert(subscription);
+        })
     }
 
     /// Remove a global subscription.
@@ -420,18 +451,18 @@ impl<Notif: Clone + 'static> Subscriptions<Notif> {
     where
         D::Key: Send,
     {
-        let subscription = self.register_subscription(subscriber)?;
-        let mut tables = self.tables.lock().unwrap();
-        tables
-            .entry(TypeId::of::<D>())
-            .or_insert_with(|| Box::new(TableSubscriptions::<D::Key>::default()))
-            .downcast_mut::<TableSubscriptions<D::Key>>()
-            .unwrap()
-            .subscriptions
-            .entry(key)
-            .or_default()
-            .insert(subscription);
-        Ok(subscription)
+        self.register_subscription(subscriber, |subscription| {
+            self.tables
+                .lock()
+                .unwrap()
+                .entry(TypeId::of::<D>())
+                .or_insert_with(|| Box::new(TableSubscriptions::<D::Key>::default()))
+                .downcast_mut::<D::Key>()
+                .subscriptions
+                .entry(key)
+                .or_default()
+                .insert(subscription);
+        })
     }
 
     /// Associate a subscription ID with a table (watching a single keys).
@@ -442,16 +473,16 @@ impl<Notif: Clone + 'static> Subscriptions<Notif> {
     where
         D::Key: Send,
     {
-        let subscription = self.register_subscription(subscriber)?;
-        let mut tables = self.tables.lock().unwrap();
-        tables
-            .entry(TypeId::of::<D>())
-            .or_insert_with(|| Box::new(TableSubscriptions::<D::Key>::default()))
-            .downcast_mut::<TableSubscriptions<D::Key>>()
-            .unwrap()
-            .subscriptions_all
-            .insert(subscription);
-        Ok(subscription)
+        self.register_subscription(subscriber, |subscription| {
+            self.tables
+                .lock()
+                .unwrap()
+                .entry(TypeId::of::<D>())
+                .or_insert_with(|| Box::new(TableSubscriptions::<D::Key>::default()))
+                .downcast_mut::<D::Key>()
+                .subscriptions_all
+                .insert(subscription);
+        })
     }
 
     /// Remove all subscriptions from a specific table (single-key and whole-table subscriptions).
@@ -461,11 +492,34 @@ impl<Notif: Clone + 'static> Subscriptions<Notif> {
             return;
         };
 
-        let subs = subs.downcast_mut::<TableSubscriptions<D::Key>>().unwrap();
+        let subs = subs.downcast_mut::<D::Key>();
         subs.subscriptions_all.retain(|s| s != &subscription);
         subs.subscriptions
             .iter_mut()
             .for_each(|(_, s)| s.retain(|s| s != &subscription));
+    }
+
+    /// Forget a subscriber and remove all subscriptions belonging to it.
+    ///
+    /// Does nothing if `subscriber` is not registered.
+    pub(crate) fn remove_subscriber(&self, subscriber: Subscriber) {
+        // Take all locks before starting so that changes to subscriptions and subscribers are atomic.
+        let mut subscribers = self.subscribers.lock().unwrap();
+        let mut all = self.all.lock().unwrap();
+        let mut singletons = self.singletons.lock().unwrap();
+        let mut tables = self.tables.lock().unwrap();
+
+        subscribers.remove(&subscriber);
+        all.retain(|s| s.1 != subscriber);
+        for subs in singletons.values_mut() {
+            subs.retain(|s| s.1 != subscriber);
+        }
+        for table in tables.values_mut() {
+            table.remove_subscriber(subscriber);
+        }
+
+        // Hold the lock on `subscribers` until we're done.
+        drop(subscribers);
     }
 }
 
@@ -482,8 +536,7 @@ pub(crate) fn send_current<D: TableDesc>(
     };
     let value = D::clone_value_for_notification(value);
     let notification = D::make_notification(Event::KeyUpsert(key, value));
-    subs.notifier
-        .notify(Notifications::<_>::single(notification, subscription));
+    subs.notify(Notifications::<_>::single(notification, subscription));
 }
 
 /// Send a notification for the current value of a singleton to `subscription`.
@@ -496,12 +549,10 @@ pub(crate) fn send_current_singleton<S: Singleton>(
         return;
     };
     let notification = S::make_notification(SingletonEvent::Upsert(value));
-    subs.notifier
-        .notify(Notifications::<_>::single(notification, subscription));
+    subs.notify(Notifications::<_>::single(notification, subscription));
 }
 
 /// Internal storage of subscription metadata specific to a single table with key of type `K`.
-#[derive(Debug)]
 pub(crate) struct TableSubscriptions<K: Hash + Eq> {
     /// Subscribed to one key.
     subscriptions: HashMap<K, HashSet<Subscription>>,
@@ -514,6 +565,57 @@ impl<K: Hash + Eq> Default for TableSubscriptions<K> {
         Self {
             subscriptions: Default::default(),
             subscriptions_all: Default::default(),
+        }
+    }
+}
+
+// Not derived because table keys are not necessarily `Debug`.
+impl<K: Hash + Eq> fmt::Debug for TableSubscriptions<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TableSubscriptions")
+            .field("watched_keys", &self.subscriptions.len())
+            .field("subscriptions_all", &self.subscriptions_all)
+            .finish()
+    }
+}
+
+/// Type-erased access to a table's [`TableSubscriptions`].
+///
+/// A table's subscriptions are generic over its key type, but they are all stored together in
+/// `Subscriptions::tables` and some operations must be applied to every table without knowing any
+/// of their key types. Such operations go here; everything else downcasts to the concrete type.
+trait AnyTableSubscriptions: Any + Send + fmt::Debug {
+    /// Remove all of this table's subscriptions which belong to `subscriber`.
+    fn remove_subscriber(&mut self, subscriber: Subscriber);
+}
+
+impl dyn AnyTableSubscriptions {
+    /// The subscriptions as those of a table with key type `K`.
+    ///
+    /// Panics if `K` is not the key type of the table these subscriptions belong to. That would be
+    /// a bug: subscriptions are only ever found via the `TypeId` of their table.
+    fn downcast_ref<K: Hash + Eq + 'static>(&self) -> &TableSubscriptions<K> {
+        (self as &dyn Any).downcast_ref().unwrap()
+    }
+
+    /// Mutable version of [`Self::downcast_ref`], with the same panics.
+    fn downcast_mut<K: Hash + Eq + 'static>(&mut self) -> &mut TableSubscriptions<K> {
+        (self as &mut dyn Any).downcast_mut().unwrap()
+    }
+}
+
+impl<K: Clone + Hash + Eq + Send + 'static> AnyTableSubscriptions for TableSubscriptions<K> {
+    fn remove_subscriber(&mut self, subscriber: Subscriber) {
+        self.subscriptions_all.retain(|s| s.1 != subscriber);
+        let mut empty = Vec::new();
+        self.subscriptions.iter_mut().for_each(|(k, s)| {
+            s.retain(|s| s.1 != subscriber);
+            if s.is_empty() {
+                empty.push(k.clone());
+            }
+        });
+        for k in empty {
+            self.subscriptions.remove(&k);
         }
     }
 }
@@ -970,7 +1072,12 @@ mod tests {
     }
 
     fn new_subscriptions() -> Subscriptions<Notification> {
-        Subscriptions::new(NoOpNotifier::<Notification>::new())
+        // Leaked so that the weak reference stays live for the rest of the test: subscribing
+        // requires a notifier which has not been dropped.
+        let notifier = NoOpNotifier::<Notification>::new();
+        let subs = Subscriptions::new(Arc::downgrade(&notifier));
+        std::mem::forget(notifier);
+        subs
     }
 
     #[test]
@@ -986,7 +1093,7 @@ mod tests {
         let subs = new_subscriptions();
         let bogus = Subscriber(NonZeroUsize::new(1).unwrap());
         assert_eq!(
-            subs.register_subscription(bogus),
+            subs.register_subscription(bogus, |_| {}),
             Err(Error::UnknownSubscriber)
         );
     }
@@ -995,8 +1102,22 @@ mod tests {
     fn register_subscription_carries_its_subscriber() {
         let subs = new_subscriptions();
         let subscriber = subs.register_subscriber(OWNER);
-        let subscription = subs.register_subscription(subscriber).unwrap();
-        assert_eq!(subscription.1, subscriber);
+        let subscription = subs.register_subscription(subscriber, |_| {}).unwrap();
+        assert_eq!(subscription.subscriber(), subscriber);
+    }
+
+    #[test]
+    fn register_subscription_holds_the_subscribers_lock() {
+        let subs = new_subscriptions();
+        let subscriber = subs.register_subscriber(OWNER);
+
+        subs.register_subscription(subscriber, |_| {
+            // Recording the subscription must happen under the `subscribers` lock, otherwise a
+            // concurrent `remove_subscriber` could sweep between the check and the insert, leaving
+            // a subscription belonging to a subscriber the store has forgotten.
+            assert!(subs.subscribers.try_lock().is_err());
+        })
+        .unwrap();
     }
 
     #[test]
@@ -1148,6 +1269,101 @@ mod tests {
     }
 
     #[test]
+    fn removed_subscriber_receives_nothing() {
+        let subs = new_subscriptions();
+        let gone = subs.register_subscriber(OWNER);
+        let kept = subs.register_subscriber(OWNER);
+
+        // Every kind of subscription, for both subscribers.
+        let gone_subs = [
+            subs.create_global_subscription(gone).unwrap(),
+            subs.create_singleton_subscription::<Count>(gone).unwrap(),
+            subs.create_table_subscription_all::<Items>(gone).unwrap(),
+            subs.create_table_subscription::<Items>(1, gone).unwrap(),
+        ];
+        let kept_subs = [
+            subs.create_global_subscription(kept).unwrap(),
+            subs.create_singleton_subscription::<Count>(kept).unwrap(),
+            subs.create_table_subscription_all::<Items>(kept).unwrap(),
+            subs.create_table_subscription::<Items>(1, kept).unwrap(),
+        ];
+
+        subs.remove_subscriber(gone);
+
+        let mut notifs = Notifications::default();
+        subs.collect_events::<Items>(&mut notifs, events(&[(1, upsert("a"))]));
+        subs.collect_singleton_events::<Count>(&mut notifs, &SinValue::U64(5));
+
+        let map: HashMap<Subscription, Vec<Notification>> = notifs.into();
+        for s in gone_subs {
+            assert!(!map.contains_key(&s));
+        }
+        // Removing one subscriber must leave every other subscriber's subscriptions alone.
+        for s in kept_subs {
+            assert!(!map[&s].is_empty());
+        }
+    }
+
+    #[test]
+    fn removed_subscriber_cannot_subscribe_again() {
+        let subs = new_subscriptions();
+        let subscriber = subs.register_subscriber(OWNER);
+        subs.remove_subscriber(subscriber);
+
+        assert_eq!(
+            subs.create_global_subscription(subscriber),
+            Err(Error::UnknownSubscriber)
+        );
+        assert_eq!(
+            subs.create_singleton_subscription::<Count>(subscriber),
+            Err(Error::UnknownSubscriber)
+        );
+        assert_eq!(
+            subs.create_table_subscription_all::<Items>(subscriber),
+            Err(Error::UnknownSubscriber)
+        );
+        assert_eq!(
+            subs.create_table_subscription::<Items>(1, subscriber),
+            Err(Error::UnknownSubscriber)
+        );
+    }
+
+    #[test]
+    fn removing_an_unknown_subscriber_is_a_no_op() {
+        let subs = new_subscriptions();
+        let subscriber = subs.register_subscriber(OWNER);
+        let sub = subs
+            .create_table_subscription_all::<Items>(subscriber)
+            .unwrap();
+
+        // A subscriber which was never registered, and one which has already been removed.
+        subs.remove_subscriber(Subscriber(NonZeroUsize::new(99).unwrap()));
+        let removed = subs.register_subscriber(OWNER);
+        subs.remove_subscriber(removed);
+        subs.remove_subscriber(removed);
+
+        let mut notifs = Notifications::default();
+        subs.collect_events::<Items>(&mut notifs, events(&[(1, upsert("a"))]));
+        let map: HashMap<Subscription, Vec<Notification>> = notifs.into();
+        assert!(!map[&sub].is_empty());
+    }
+
+    #[test]
+    fn has_subscribers_false_after_removing_subscriber() {
+        let subs = new_subscriptions();
+        let subscriber = subs.register_subscriber(OWNER);
+        subs.create_global_subscription(subscriber).unwrap();
+        subs.create_singleton_subscription::<Count>(subscriber)
+            .unwrap();
+        subs.create_table_subscription_all::<Items>(subscriber)
+            .unwrap();
+        subs.remove_subscriber(subscriber);
+
+        assert!(!subs.has_subscribers::<Items>());
+        assert!(!subs.has_singleton_subscribers::<Count>());
+    }
+
+    #[test]
     fn has_subscribers_false_when_no_subscriptions() {
         let subs = new_subscriptions();
         assert!(!subs.has_subscribers::<Items>());
@@ -1275,17 +1491,26 @@ mod tests {
     }
 
     #[test]
-    fn on_commit_forwards_to_notifier() {
+    fn notify_forwards_to_notifier() {
         let (notifier, rec) = RecordingNotifier::new();
-        let subs = Subscriptions::new(notifier);
-        subs.on_commit(Notifications::default());
+        let subs = Subscriptions::new(Arc::downgrade(&notifier));
+        let subscription = make_subscription(1);
+
+        let mut notifications = Notifications::default();
+        notifications.append_notifications(subscription, &[Notification::Items(Event::TableClear)]);
+        subs.notify(notifications);
+
         assert_eq!(rec.total_calls(), 1);
+        assert_eq!(
+            ItemsKind::from(&rec.notifications_for(subscription)[0]),
+            ItemsKind::TableClear
+        );
     }
 
     #[test]
     fn e2e_single_key_subscription() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
 
         // Pre-populate before subscribing so the table is non-empty (a first insert into an empty
@@ -1315,7 +1540,7 @@ mod tests {
     #[test]
     fn e2e_whole_table_subscription() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
         rec.reset();
@@ -1339,7 +1564,7 @@ mod tests {
     #[test]
     fn e2e_global_subscription_sees_all_tables() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.subscribe_global(subscriber).unwrap();
         rec.reset();
@@ -1359,7 +1584,7 @@ mod tests {
     #[test]
     fn e2e_global_subscription_sees_singletons() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.subscribe_global(subscriber).unwrap();
         rec.reset();
@@ -1379,7 +1604,7 @@ mod tests {
     #[test]
     fn e2e_first_insert_into_empty_table_is_table_upsert() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
         rec.reset();
@@ -1405,7 +1630,7 @@ mod tests {
     #[test]
     fn e2e_singleton_subscription() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.subscribe::<Count>(subscriber).unwrap();
         rec.reset();
@@ -1423,7 +1648,7 @@ mod tests {
     #[test]
     fn e2e_arc_singleton_subscription() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.subscribe::<Shared>(subscriber).unwrap();
         rec.reset();
@@ -1446,7 +1671,7 @@ mod tests {
     #[test]
     fn e2e_notifications_grouped_by_subscription() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber_a = store.register_subscriber(OWNER);
         let subscriber_b = store.register_subscriber(OWNER);
 
@@ -1479,7 +1704,7 @@ mod tests {
     #[test]
     fn e2e_unsubscribe_stops_notifications() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
 
@@ -1493,7 +1718,7 @@ mod tests {
     #[test]
     fn e2e_unsubscribe_global_stops_notifications() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let gone = store.subscribe_global(subscriber).unwrap();
         let kept = store.subscribe_global(subscriber).unwrap();
@@ -1510,6 +1735,56 @@ mod tests {
         assert_eq!(kept.len(), 2);
         assert_eq!(ItemsKind::from(&kept[0]), ItemsKind::TableUpsert(vec![1]));
         assert_eq!(CountKind::from(&kept[1]), CountKind::Upsert(7));
+    }
+
+    #[test]
+    fn e2e_remove_subscriber_stops_notifications() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let gone = store.register_subscriber(OWNER);
+        let kept = store.register_subscriber(OWNER);
+
+        let table_sub = store.table::<Items>(OWNER).subscribe(gone).unwrap();
+        let singleton_sub = store.subscribe::<Count>(gone).unwrap();
+        let global_sub = store.subscribe_global(gone).unwrap();
+        let kept_sub = store.table::<Items>(OWNER).subscribe(kept).unwrap();
+
+        store.remove_subscriber(gone);
+        rec.reset();
+
+        store.table::<Items>(OWNER).insert(1, "a".to_owned());
+        store.insert::<Count>(OWNER, 7);
+
+        // All of the removed subscriber's subscriptions are dead, whatever they watched...
+        assert!(rec.notifications_for(table_sub).is_empty());
+        assert!(rec.notifications_for(singleton_sub).is_empty());
+        assert!(rec.notifications_for(global_sub).is_empty());
+        // ...but the other subscriber is unaffected.
+        assert_eq!(
+            rec.notifications_for(kept_sub)
+                .iter()
+                .map(ItemsKind::from)
+                .collect::<Vec<_>>(),
+            vec![ItemsKind::TableUpsert(vec![1])]
+        );
+    }
+
+    #[test]
+    fn e2e_removed_subscriber_cannot_subscribe_again() {
+        let (notifier, _rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+
+        store.remove_subscriber(subscriber);
+
+        assert_eq!(
+            store.table::<Items>(OWNER).subscribe(subscriber),
+            Err(Error::UnknownSubscriber)
+        );
+        assert_eq!(
+            store.subscribe::<Count>(subscriber),
+            Err(Error::UnknownSubscriber)
+        );
     }
 
     /// Seed `Items` with `keys` (mapping each key `k` to the value `"v{k}"`) in a committed
@@ -1529,7 +1804,7 @@ mod tests {
     #[test]
     fn e2e_iter_mut_notifies_visited_keys() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
         seed_items(&store, &[1, 2]);
@@ -1552,7 +1827,7 @@ mod tests {
     #[test]
     fn e2e_iter_mut_notifies_key_subscription() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store
             .table::<Items>(OWNER)
@@ -1581,7 +1856,7 @@ mod tests {
     #[test]
     fn e2e_partial_iter_mut_notifies_only_visited_keys() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
         seed_items(&store, &[1, 2]);
@@ -1609,7 +1884,7 @@ mod tests {
     #[test]
     fn e2e_iter_mut_with_remove_in_same_txn() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
         seed_items(&store, &[1, 2, 3]);
@@ -1638,7 +1913,7 @@ mod tests {
     #[test]
     fn e2e_iter_mut_on_empty_table_notifies_nothing() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
         rec.reset();
@@ -1656,7 +1931,7 @@ mod tests {
     #[test]
     fn e2e_rolled_back_transaction_notifies_nothing() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let _sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
         rec.reset();
@@ -1673,7 +1948,7 @@ mod tests {
     #[test]
     fn e2e_mutations_coalesced_within_one_transaction() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
         rec.reset();
@@ -1700,7 +1975,7 @@ mod tests {
     #[test]
     fn e2e_insert_then_remove_in_one_txn_notifies_nothing() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
         // Seed an unrelated key so the table is non-empty and the transaction below is not an
@@ -1723,7 +1998,7 @@ mod tests {
     #[test]
     fn e2e_insert_then_remove_in_one_txn_still_reports_other_keys() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
         seed_items(&store, &[9]);
@@ -1751,7 +2026,7 @@ mod tests {
     #[test]
     fn e2e_insert_then_clear_in_one_txn_notifies_nothing() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
         rec.reset();
@@ -1772,7 +2047,7 @@ mod tests {
     #[test]
     fn e2e_clear_of_populated_table_still_notifies() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
         seed_items(&store, &[1]);
@@ -1800,7 +2075,7 @@ mod tests {
     #[test]
     fn e2e_subscribe_and_notify_singleton_sends_current_value() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         store.insert::<Count>(OWNER, 6);
         store.insert::<Count>(OWNER, 7);
@@ -1821,7 +2096,7 @@ mod tests {
     #[test]
     fn e2e_subscribe_and_notify_singleton_without_value_sends_nothing() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         rec.reset();
 
@@ -1835,7 +2110,7 @@ mod tests {
     #[test]
     fn e2e_subscribe_and_notify_singleton_then_receives_updates() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         store.insert::<Count>(OWNER, 7);
         rec.reset();
@@ -1861,7 +2136,7 @@ mod tests {
     #[test]
     fn e2e_subscribe_and_notify_arc_singleton_sends_current_value() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         store.insert::<Shared>(OWNER, Arc::new("hello".to_owned()));
         rec.reset();
@@ -1879,7 +2154,7 @@ mod tests {
     #[test]
     fn e2e_subscribe_key_and_notify_sends_current_value() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         store.table::<Items>(OWNER).insert(1, "one".to_owned());
         rec.reset();
@@ -1903,7 +2178,7 @@ mod tests {
     #[test]
     fn e2e_subscribe_key_and_notify_missing_key_sends_nothing() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         // The table is non-empty, but does not contain the key being subscribed to.
         store.table::<Items>(OWNER).insert(2, "two".to_owned());
@@ -1932,7 +2207,7 @@ mod tests {
     #[test]
     fn e2e_no_subscribers_commits_inserts_and_removes() {
         let (notifier, _rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
 
         store.table::<Items>(OWNER).insert(1, "a".to_owned());
         store.table::<Items>(OWNER).insert(2, "b".to_owned());
@@ -1946,7 +2221,7 @@ mod tests {
     #[test]
     fn e2e_no_subscribers_commits_mixed_mutations_in_one_txn() {
         let (notifier, _rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         seed_items(&store, &[1, 2, 3]);
 
         let mut txn = store.begin_transaction(OWNER);
@@ -1971,7 +2246,7 @@ mod tests {
     #[test]
     fn e2e_no_subscribers_commits_clear() {
         let (notifier, _rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         seed_items(&store, &[1, 2]);
 
         // Clear and re-insert within one transaction, so the commit takes the "clear everything,
@@ -1994,7 +2269,7 @@ mod tests {
     #[test]
     fn e2e_unwatched_table_commits_while_watched_table_notifies() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         // Only `Items` is watched; `Plain` is committed without collecting notifications.
         let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
@@ -2020,7 +2295,7 @@ mod tests {
     #[test]
     fn e2e_subscribing_after_unwatched_inserts_sees_per_key_upserts() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
 
         // Committed with no subscribers, so no events are collected for it...
@@ -2050,7 +2325,7 @@ mod tests {
     #[test]
     fn e2e_subscribing_after_unwatched_clear_sees_table_upsert() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
 
         seed_items(&store, &[1, 2]);
@@ -2075,7 +2350,7 @@ mod tests {
     #[test]
     fn e2e_no_singleton_subscribers_commits_value() {
         let (notifier, _rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
 
         store.insert::<Count>(OWNER, 7);
         assert_eq!(store.get::<Count>(OWNER), Some(7));
@@ -2087,7 +2362,7 @@ mod tests {
     #[test]
     fn e2e_unwatched_singleton_commits_while_watched_one_notifies() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
         let sub = store.subscribe::<Count>(subscriber).unwrap();
         rec.reset();
@@ -2114,7 +2389,7 @@ mod tests {
     #[test]
     fn e2e_subscribing_after_unwatched_singleton_writes_sees_later_updates() {
         let (notifier, rec) = RecordingNotifier::new();
-        let store = KvStore::with_notifier(notifier);
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
         let subscriber = store.register_subscriber(OWNER);
 
         store.insert::<Count>(OWNER, 7);

--- a/ts_kv_store/src/schema.rs
+++ b/ts_kv_store/src/schema.rs
@@ -206,8 +206,8 @@ impl<K: Hash + Eq, V: Any + Send + Sync> IndexStorage<K, V> for () {
 /// This should be considered a sealed trait and not implemented except by the macros in this module.
 /// Unfortunately it has to be public because of macro visibility hygiene.
 #[doc(hidden)]
-pub trait GeneratedStorage: Default {
-    type Notification: Clone + 'static;
+pub trait GeneratedStorage: Default + Send + Sync {
+    type Notification: Clone + Send + 'static;
     /// Commit a transaction by applying all tables' transaction state to their permanent data.
     ///
     /// This operation must be atomic. I.e., it will only fail without any tables committed, and if it
@@ -516,12 +516,19 @@ macro_rules! store {
             /// The store has a no-op notifier, so subscribers are never notified of changes.
             #[allow(dead_code, clippy::new_without_default)]
             pub fn new() -> Self {
-                Self::with_notifier($crate::NoOpNotifier::new())
+                // The store only holds a weak reference to its notifier, so downgrading a
+                // throwaway no-op notifier leaves the store with a dead weak reference. Upgrading it
+                // always fails, which means no notifications are ever sent.
+                Self::with_notifier(std::sync::Arc::downgrade(&$crate::NoOpNotifier::new()))
             }
 
             /// Create a new, empty KV store as described by the schema macros, which sends
             /// notifications of changes to `notifier`.
-            pub fn with_notifier(notifier: std::sync::Arc<dyn $crate::Notifier<Notification = <TableStorage as $crate::schema::GeneratedStorage>::Notification>>) -> Self {
+            ///
+            /// The store keeps only a weak reference to `notifier`, so the caller is responsible for
+            /// keeping the notifier alive (e.g. via the subscribers it hands out). Once the last
+            /// strong reference is dropped the store stops sending notifications.
+            pub fn with_notifier(notifier: std::sync::Weak<dyn $crate::Notifier<Notification = <TableStorage as $crate::schema::GeneratedStorage>::Notification>>) -> Self {
                 KvStore($crate::KvStore::new_with_storage(std::sync::RwLock::new($crate::storage::Storage::new(notifier))))
             }
         }

--- a/ts_kv_store/src/storage.rs
+++ b/ts_kv_store/src/storage.rs
@@ -3,7 +3,7 @@ use std::{
     borrow::Borrow,
     collections::{HashMap, HashSet},
     hash::Hash,
-    sync::Arc,
+    sync::{Arc, Weak},
 };
 
 use crate::{
@@ -37,7 +37,7 @@ pub struct Storage<TableStorage: schema::GeneratedStorage> {
 impl<TableStorage: schema::GeneratedStorage> Storage<TableStorage> {
     /// Create a new storage with no data.
     #[allow(clippy::new_without_default)]
-    pub fn new(notifier: Arc<dyn Notifier<Notification = TableStorage::Notification>>) -> Self {
+    pub fn new(notifier: Weak<dyn Notifier<Notification = TableStorage::Notification>>) -> Self {
         Storage {
             tables: TableStorage::default(),
             committed: TxnId::FIRST,
@@ -1286,7 +1286,8 @@ mod txn_test {
 
     #[test]
     fn commit_with_mismatched_id_fails() {
-        let mut storage = Storage::<TableStorage>::new(NoOpNotifier::new());
+        let mut storage =
+            Storage::<TableStorage>::new(std::sync::Arc::downgrade(&NoOpNotifier::new()));
         let id = storage.begin_transaction();
         // A commit must target the in-progress transaction.
         assert!(matches!(
@@ -1297,7 +1298,8 @@ mod txn_test {
 
     #[test]
     fn commit_then_recommit_fails() {
-        let mut storage = Storage::<TableStorage>::new(NoOpNotifier::new());
+        let mut storage =
+            Storage::<TableStorage>::new(std::sync::Arc::downgrade(&NoOpNotifier::new()));
         let id = storage.begin_transaction();
         assert!(storage.commit_transaction(id).is_ok());
         // No transaction is pending after a successful commit.
@@ -1309,7 +1311,8 @@ mod txn_test {
 
     #[test]
     fn clear_transaction_rolls_back_and_frees_singleton_entry() {
-        let mut storage = Storage::<TableStorage>::new(NoOpNotifier::new());
+        let mut storage =
+            Storage::<TableStorage>::new(std::sync::Arc::downgrade(&NoOpNotifier::new()));
         let id = storage.begin_transaction();
         storage.insert_singleton::<Count>(42, id);
         // Visible to the in-progress transaction.

--- a/ts_kv_store/src/transactions.rs
+++ b/ts_kv_store/src/transactions.rs
@@ -211,7 +211,7 @@ impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableSt
         let notifications = self.write_lock().commit_transaction(id)?;
         let guard = self.guard.take().unwrap();
         let guard = RwLockWriteGuard::downgrade(guard);
-        guard.subscriptions.on_commit(notifications);
+        guard.subscriptions.notify(notifications);
 
         Ok(())
     }

--- a/ts_kv_store_tokio/Cargo.toml
+++ b/ts_kv_store_tokio/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ts_kv_store_tokio"
+version.workspace = true
+description = "Tokio integration for ts_kv_store notifications"
+categories = ["data-structures", "asynchronous"]
+keywords = ["tailscale", "key-value", "tokio"]
+
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+thiserror.workspace = true
+tokio = { workspace = true, features = ["rt", "sync", "time"] }
+tracing.workspace = true
+ts_kv_store.workspace = true
+
+[dev-dependencies]
+# `test-util` enables paused/virtual time (`#[tokio::test(start_paused = true)]`) for the timing tests.
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/ts_kv_store_tokio/README.md
+++ b/ts_kv_store_tokio/README.md
@@ -1,0 +1,5 @@
+# ts_kv_store_tokio
+
+Tokio integration for [ts_kv_store](../ts_kv_store) notifications.
+
+See docs in [lib.rs](src/lib.rs) for details.

--- a/ts_kv_store_tokio/src/lib.rs
+++ b/ts_kv_store_tokio/src/lib.rs
@@ -1,0 +1,670 @@
+//! # ts_kv_store_tokio
+//!
+//! Tokio integration for [`ts_kv_store`] notifications. Notifications are delivered via Tokio
+//! channels (though this isn't part of the API).
+//!
+//! A KV store is declared in the usual way using the `schema` macros. An instance of the store is
+//! created as part of creating a [`TokioNotifier`]. The notifier can be used to access the store
+//! (using the [`TokioNotifier::store`] method). Users should use the subscribe/unsubscribe methods
+//! of the notifier, rather than the underlying store.
+//!
+//! A [`TokioSubscriber`] is created from a [`TokioNotifier`] and combines a subscriber identity
+//! with the receiving end of a channel for receiving notifications (all subscriptions for a single
+//! subscriber are sent via the same channel).
+
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt,
+    sync::{Arc, Mutex, Weak},
+};
+
+use tokio::{
+    sync::{
+        Notify,
+        mpsc::{Receiver, Sender, channel, error::TryRecvError},
+    },
+    task::JoinHandle,
+};
+use ts_kv_store::{
+    GeneratedStorage, KvStore, Notifications, Notifier, Owner, Subscriber, Subscription,
+    schema::{Singleton, TableDesc},
+};
+
+mod notify;
+
+/// The capacity of each subscriber's notification channel.
+#[cfg(not(test))]
+const CHANNEL_CAPACITY: usize = 32;
+#[cfg(test)]
+const CHANNEL_CAPACITY: usize = 2;
+
+/// A [`Notifier`] which forwards notifications to subscribers using Tokio channels.
+///
+/// The generic parameter `Storage` links a notifier instance to a specific store.
+pub struct TokioNotifier<Storage: GeneratedStorage> {
+    store: Arc<KvStore<Storage>>,
+    senders: Mutex<HashMap<Subscriber, SubscriberSender<Storage>>>,
+    /// Notifications waiting to be sent, oldest first.
+    queue: Mutex<VecDeque<QueuedNotifications<Storage>>>,
+    /// Signalled whenever `queue` is added to, to wake `task`.
+    notify: Arc<Notify>,
+    /// Async task which sends queued notifications to subscribers.
+    task: JoinHandle<()>,
+}
+
+/// The notifications from a single transaction, as queued for sending.
+///
+/// This is a [`Notifications`] in its map form.
+type QueuedNotifications<Storage> =
+    HashMap<Subscription, Vec<<Storage as GeneratedStorage>::Notification>>;
+
+impl<Storage: GeneratedStorage + 'static> TokioNotifier<Storage> {
+    /// Create a new `TokioNotifier` and [`KvStore`]. Spawns a task to send notifcations.
+    ///
+    /// The notifier owns the store and the store holds a weak reference back to the notifier.
+    ///
+    /// Spawns the task which sends notifications to subscribers, so this must be called from within
+    /// a Tokio runtime. The task runs until the notifier is dropped, waking whenever there are
+    /// notifications to send and periodically while any are waiting to be retried.
+    pub fn new() -> Arc<TokioNotifier<Storage>> {
+        let notify = Arc::new(Notify::new());
+
+        Arc::new_cyclic(|weak: &Weak<TokioNotifier<Storage>>| {
+            let task = tokio::spawn(notify::notify_loop(weak.clone(), notify.clone()));
+
+            TokioNotifier {
+                store: Arc::new(KvStore::from_notifier(weak.clone())),
+                senders: Default::default(),
+                queue: Default::default(),
+                notify,
+                task,
+            }
+        })
+    }
+
+    /// The [`KvStore`] this notifier was created for.
+    pub fn store(&self) -> &Arc<KvStore<Storage>> {
+        &self.store
+    }
+
+    /// Create a new subscriber to this notifier.
+    pub fn create_subscriber(self: &Arc<Self>, owner: Owner) -> TokioSubscriber<Storage> {
+        let id = self.store.register_subscriber(owner);
+        let (sender, receiver) = channel(CHANNEL_CAPACITY);
+
+        self.senders
+            .lock()
+            .unwrap()
+            .insert(id, SubscriberSender::new(sender));
+
+        TokioSubscriber {
+            id,
+            receiver,
+            notifier: self.clone(),
+            owner,
+        }
+    }
+
+    fn remove_subscriber(&self, subscriber: Subscriber) {
+        self.senders.lock().unwrap().remove(&subscriber);
+        self.store.remove_subscriber(subscriber);
+    }
+}
+
+impl<Storage: GeneratedStorage> fmt::Debug for TokioNotifier<Storage> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("TokioNotifier").finish()
+    }
+}
+
+impl<Storage: GeneratedStorage + 'static> Notifier for TokioNotifier<Storage> {
+    type Notification = Storage::Notification;
+
+    fn notify(&self, notifications: Notifications<Self::Notification>) {
+        self.queue.lock().unwrap().push_back(notifications.into());
+        self.notify.notify_one();
+    }
+}
+
+impl<Storage: GeneratedStorage> Drop for TokioNotifier<Storage> {
+    fn drop(&mut self) {
+        // Stop the sending task. Without this, the task would wait forever.
+        self.task.abort();
+    }
+}
+
+/// A subscriber to a [`KvStore`]'s notifications, via [`TokioNotifier`]. Identifies a subscriber
+/// and receives notifications.
+///
+/// Dropping a subscriber removes it and all its subscriptions from the store.
+pub struct TokioSubscriber<Storage: GeneratedStorage + 'static> {
+    /// KvStore's id for this subscriber.
+    id: Subscriber,
+    /// Reference to our 'parent' notifier.
+    notifier: Arc<TokioNotifier<Storage>>,
+    /// Receiver end of a Tokio channel for receiving notifications from the notifier.
+    receiver: Receiver<Storage::Notification>,
+    owner: Owner,
+}
+
+impl<Storage: GeneratedStorage + 'static> TokioSubscriber<Storage> {
+    /// Wait for the next notification.
+    ///
+    /// Returns [`Error::ChannelDisconnected`] if the channel is closed. No further notifications will
+    /// arrive after that.
+    pub async fn recv(&mut self) -> Result<Storage::Notification> {
+        self.receiver.recv().await.ok_or(Error::ChannelDisconnected)
+    }
+
+    /// Receive the next notification without waiting.
+    ///
+    /// Returns [`Error::ChannelEmpty`] if there is no notification to receive, or [`Error::ChannelDisconnected`] if the
+    /// channel is closed (see [`recv`](Self::recv)).
+    pub fn try_recv(&mut self) -> Result<Storage::Notification> {
+        self.receiver.try_recv().map_err(|e| match e {
+            TryRecvError::Empty => Error::ChannelEmpty,
+            TryRecvError::Disconnected => Error::ChannelDisconnected,
+        })
+    }
+
+    /// Subscribe to the whole store.
+    ///
+    /// Returns [`Error::UnknownSubscriber`] if this subscriber is no longer known to the store. That
+    /// will happen if the notifier cannot send notifications to this subscriber.
+    pub fn subscribe_global(&self) -> Result<Subscription> {
+        Ok(self.notifier.store.subscribe_global(self.id)?)
+    }
+
+    /// Subscribe to the singleton key/value pair `S`.
+    ///
+    /// Returns [`Error::UnknownSubscriber`] if this subscriber is no longer known to the store. That
+    /// will happen if the notifier cannot send notifications to this subscriber.
+    pub fn subscribe_singleton<S: Singleton<Storage = Storage>>(&self) -> Result<Subscription> {
+        Ok(self.notifier.store.subscribe::<S>(self.id)?)
+    }
+
+    /// Subscribe to the singleton key/value pair `S` and be sent its current value (if any).
+    ///
+    /// Returns [`Error::UnknownSubscriber`] if this subscriber is no longer known to the store. That
+    /// will happen if the notifier cannot send notifications to this subscriber.
+    pub fn subscribe_singleton_and_notify<S: Singleton<Storage = Storage>>(
+        &self,
+    ) -> Result<Subscription> {
+        Ok(self.notifier.store.subscribe_and_notify::<S>(self.id)?)
+    }
+
+    /// Subscribe to every key in the table `D`.
+    ///
+    /// Returns [`Error::UnknownSubscriber`] if this subscriber is no longer known to the store. That
+    /// will happen if the notifier cannot send notifications to this subscriber.
+    pub fn subscribe_table<D: TableDesc<Storage = Storage>>(&self) -> Result<Subscription>
+    where
+        D::Key: Send,
+    {
+        Ok(self
+            .notifier
+            .store
+            .table::<D>(self.owner)
+            .subscribe(self.id)?)
+    }
+
+    /// Subscribe to a single `key` in the table `D`.
+    ///
+    /// Returns [`Error::UnknownSubscriber`] if this subscriber is no longer known to the store. That
+    /// will happen if the notifier cannot send notifications to this subscriber.
+    pub fn subscribe_key<D: TableDesc<Storage = Storage>>(
+        &self,
+        key: D::Key,
+    ) -> Result<Subscription>
+    where
+        D::Key: Send,
+    {
+        Ok(self
+            .notifier
+            .store
+            .table::<D>(self.owner)
+            .subscribe_key(self.id, key)?)
+    }
+
+    /// Subscribe to a single `key` in the table `D` and be sent its current value (if any).
+    ///
+    /// Returns [`Error::UnknownSubscriber`] if this subscriber is no longer known to the store. That
+    /// will happen if the notifier cannot send notifications to this subscriber.
+    pub fn subscribe_key_and_notify<D: TableDesc<Storage = Storage>>(
+        &self,
+        key: D::Key,
+    ) -> Result<Subscription>
+    where
+        D::Key: Send,
+    {
+        Ok(self
+            .notifier
+            .store
+            .table::<D>(self.owner)
+            .subscribe_key_and_notify(self.id, key)?)
+    }
+
+    /// Remove a subscription to the whole store.
+    pub fn unsubscribe_global(&self, subscription: Subscription) {
+        self.notifier.store.unsubscribe_global(subscription);
+    }
+
+    /// Remove a subscription to the singleton key/value pair `S`.
+    pub fn unsubscribe_singleton<S: Singleton<Storage = Storage>>(
+        &self,
+        subscription: Subscription,
+    ) {
+        self.notifier.store.unsubscribe::<S>(subscription);
+    }
+
+    /// Remove a subscription to the table `D`.
+    pub fn unsubscribe_table<D: TableDesc<Storage = Storage>>(&self, subscription: Subscription) {
+        self.notifier
+            .store
+            .table::<D>(self.owner)
+            .unsubscribe(subscription);
+    }
+}
+
+impl<Storage: GeneratedStorage + 'static> Drop for TokioSubscriber<Storage> {
+    /// Remove the subscriber (and thus all its subscriptions) from the store, drop the notifier's
+    /// sender for it, and close its channel.
+    fn drop(&mut self) {
+        self.notifier.remove_subscriber(self.id);
+    }
+}
+
+/// A subscriber's channel, and how it is doing at receiving notifications.
+struct SubscriberSender<Storage: GeneratedStorage> {
+    sender: Sender<Storage::Notification>,
+    /// `None` if the last send to this subscriber succeeded, otherwise how close we are to giving
+    /// up on it.
+    failing: Option<notify::Failing>,
+}
+
+impl<Storage: GeneratedStorage> SubscriberSender<Storage> {
+    fn new(sender: Sender<Storage::Notification>) -> Self {
+        SubscriberSender {
+            sender,
+            failing: None,
+        }
+    }
+}
+
+/// Errors due to the notifier or the store.
+///
+/// Subsumes [`ts_kv_store::Error`].
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    /// The subscriber is not (or no longer) known to the store.
+    #[error("Unknown subscriber")]
+    UnknownSubscriber,
+    /// An attempt was made to subscribe to the store, but the store has no notifier, so subscriptions
+    /// would not be sent. This is likely because there is a reference to the store but not the notifier,
+    /// so the notifier has been dropped.
+    #[error("Store has no registered notifer")]
+    MissingNotifier,
+    /// A non-blocking [`TokioSubscriber::try_recv`] found no notification waiting.
+    #[error("No notifications in channel")]
+    ChannelEmpty,
+    /// The subscriber's notification channel is closed, so no more notifications will ever arrive.
+    #[error("Notification channel is closed")]
+    ChannelDisconnected,
+}
+
+impl From<ts_kv_store::Error> for Error {
+    fn from(e: ts_kv_store::Error) -> Self {
+        match e {
+            ts_kv_store::Error::UnknownSubscriber => Error::UnknownSubscriber,
+            ts_kv_store::Error::MissingNotifier => Error::MissingNotifier,
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// A `Result` whose error is this crate's [`Error`].
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::time::{sleep, timeout};
+    use ts_kv_store::{Event, SingletonEvent};
+
+    use super::*;
+
+    ts_kv_store::store!(
+        kvs: {
+            Count(u64; OWNER),
+        }
+        tables: {
+            Items(u32 => String; OWNER; notify(Clone)),
+        }
+    );
+
+    const OWNER: &str = "owner";
+
+    fn notifier() -> Arc<TokioNotifier<TableStorage>> {
+        TokioNotifier::new()
+    }
+
+    fn insert_item(notifier: &TokioNotifier<TableStorage>, key: u32, value: &str) {
+        notifier
+            .store()
+            .table::<Items>(OWNER)
+            .insert(key, value.to_owned());
+    }
+
+    /// Extract the `(key, value)` of an `Items` per-key upsert, panicking on any other notification.
+    fn items_key_upsert(n: &Notification) -> (u32, String) {
+        match n {
+            Notification::Items(Event::KeyUpsert(k, v)) => (*k, v.clone()),
+            other => panic!("expected Items/KeyUpsert, got {other:?}"),
+        }
+    }
+
+    /// Extract the (sorted) keys of an `Items` table-level upsert.
+    fn items_table_upsert(n: &Notification) -> Vec<u32> {
+        match n {
+            Notification::Items(Event::TableUpsert(keys)) => {
+                let mut keys = keys.clone();
+                keys.sort();
+                keys
+            }
+            other => panic!("expected Items/TableUpsert, got {other:?}"),
+        }
+    }
+
+    /// Extract the value of a `Count` singleton upsert.
+    fn count_upsert(n: &Notification) -> u64 {
+        match n {
+            Notification::Count(SingletonEvent::Upsert(v)) => *v,
+            other => panic!("expected Count/Upsert, got {other:?}"),
+        }
+    }
+
+    /// Wait for the next notification, panicking if none arrives.
+    async fn recv_one(sub: &mut TokioSubscriber<TableStorage>) -> Notification {
+        timeout(Duration::from_secs(1), sub.recv())
+            .await
+            .expect("timed out waiting for a notification")
+            .expect("channel closed unexpectedly")
+    }
+
+    /// Assert that no notification is delivered. Gives the background task a chance to run first.
+    async fn assert_idle(sub: &mut TokioSubscriber<TableStorage>) {
+        match timeout(Duration::from_millis(50), sub.recv()).await {
+            Err(_) => {} // nothing delivered, as expected
+            Ok(Ok(n)) => panic!("expected no notification, got {n:?}"),
+            Ok(Err(e)) => panic!("channel unexpectedly closed: {e:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn table_subscription_receives_events() {
+        let notifier = notifier();
+        let mut sub = notifier.create_subscriber(OWNER);
+        sub.subscribe_table::<Items>().unwrap();
+
+        // First insert into the empty table is a table-level upsert; the next is a per-key upsert.
+        insert_item(&notifier, 1, "a");
+        insert_item(&notifier, 2, "b");
+
+        assert_eq!(items_table_upsert(&recv_one(&mut sub).await), vec![1]);
+        assert_eq!(
+            items_key_upsert(&recv_one(&mut sub).await),
+            (2, "b".to_owned())
+        );
+    }
+
+    #[tokio::test]
+    async fn key_subscription_filters_other_keys() {
+        let notifier = notifier();
+        insert_item(&notifier, 99, "x"); // seed so later inserts are per-key
+        let mut sub = notifier.create_subscriber(OWNER);
+        sub.subscribe_key::<Items>(1).unwrap();
+
+        insert_item(&notifier, 2, "two"); // a different key: filtered out
+        insert_item(&notifier, 1, "one"); // the subscribed key: delivered
+
+        assert_eq!(
+            items_key_upsert(&recv_one(&mut sub).await),
+            (1, "one".to_owned())
+        );
+        assert_idle(&mut sub).await;
+    }
+
+    #[tokio::test]
+    async fn singleton_subscription_receives_updates() {
+        let notifier = notifier();
+        let mut sub = notifier.create_subscriber(OWNER);
+        sub.subscribe_singleton::<Count>().unwrap();
+
+        notifier.store().insert::<Count>(OWNER, 7);
+
+        assert_eq!(count_upsert(&recv_one(&mut sub).await), 7);
+    }
+
+    #[tokio::test]
+    async fn global_subscription_sees_table_and_singleton() {
+        let notifier = notifier();
+        let mut sub = notifier.create_subscriber(OWNER);
+        sub.subscribe_global().unwrap();
+
+        insert_item(&notifier, 1, "a");
+        notifier.store().insert::<Count>(OWNER, 9);
+
+        assert_eq!(items_table_upsert(&recv_one(&mut sub).await), vec![1]);
+        assert_eq!(count_upsert(&recv_one(&mut sub).await), 9);
+    }
+
+    #[tokio::test]
+    async fn subscribe_singleton_and_notify_sends_current_value() {
+        let notifier = notifier();
+        notifier.store().insert::<Count>(OWNER, 5); // pre-existing value, no subscribers yet
+        let mut sub = notifier.create_subscriber(OWNER);
+        sub.subscribe_singleton_and_notify::<Count>().unwrap();
+
+        assert_eq!(count_upsert(&recv_one(&mut sub).await), 5);
+    }
+
+    #[tokio::test]
+    async fn subscribe_singleton_and_notify_without_value_sends_nothing() {
+        let notifier = notifier();
+        let mut sub = notifier.create_subscriber(OWNER);
+        sub.subscribe_singleton_and_notify::<Count>().unwrap();
+
+        assert_idle(&mut sub).await;
+    }
+
+    #[tokio::test]
+    async fn subscribe_key_and_notify_sends_current_value() {
+        let notifier = notifier();
+        insert_item(&notifier, 1, "one"); // pre-existing value, no subscribers yet
+        let mut sub = notifier.create_subscriber(OWNER);
+        sub.subscribe_key_and_notify::<Items>(1).unwrap();
+
+        assert_eq!(
+            items_key_upsert(&recv_one(&mut sub).await),
+            (1, "one".to_owned())
+        );
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_table_stops_notifications() {
+        let notifier = notifier();
+        let mut sub = notifier.create_subscriber(OWNER);
+        let subscription = sub.subscribe_table::<Items>().unwrap();
+
+        insert_item(&notifier, 1, "a");
+        recv_one(&mut sub).await; // the subscribed update, before we unsubscribe
+
+        sub.unsubscribe_table::<Items>(subscription);
+        insert_item(&notifier, 2, "b");
+        assert_idle(&mut sub).await;
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_global_stops_notifications() {
+        let notifier = notifier();
+        let mut sub = notifier.create_subscriber(OWNER);
+        let subscription = sub.subscribe_global().unwrap();
+
+        notifier.store().insert::<Count>(OWNER, 1);
+        recv_one(&mut sub).await; // the subscribed update, before we unsubscribe
+
+        sub.unsubscribe_global(subscription);
+        notifier.store().insert::<Count>(OWNER, 2);
+        assert_idle(&mut sub).await;
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_singleton_stops_notifications() {
+        let notifier = notifier();
+        let mut sub = notifier.create_subscriber(OWNER);
+        let subscription = sub.subscribe_singleton::<Count>().unwrap();
+
+        notifier.store().insert::<Count>(OWNER, 1);
+        recv_one(&mut sub).await; // the subscribed update, before we unsubscribe
+
+        sub.unsubscribe_singleton::<Count>(subscription);
+        notifier.store().insert::<Count>(OWNER, 2);
+        assert_idle(&mut sub).await;
+    }
+
+    #[tokio::test]
+    async fn two_subscribers_each_receive() {
+        let notifier = notifier();
+        let mut a = notifier.create_subscriber(OWNER);
+        let mut b = notifier.create_subscriber(OWNER);
+        a.subscribe_singleton::<Count>().unwrap();
+        b.subscribe_singleton::<Count>().unwrap();
+
+        notifier.store().insert::<Count>(OWNER, 7);
+
+        assert_eq!(count_upsert(&recv_one(&mut a).await), 7);
+        assert_eq!(count_upsert(&recv_one(&mut b).await), 7);
+    }
+
+    #[tokio::test]
+    async fn dropping_subscriber_removes_it_and_leaves_others_working() {
+        let notifier = notifier();
+        let mut kept = notifier.create_subscriber(OWNER);
+        kept.subscribe_singleton::<Count>().unwrap();
+
+        let gone = notifier.create_subscriber(OWNER);
+        let gone_id = gone.id;
+        gone.subscribe_singleton::<Count>().unwrap();
+        assert!(notifier.senders.lock().unwrap().contains_key(&gone_id));
+
+        drop(gone);
+        // Drop removes the subscriber's sender (and forgets it in the store).
+        assert!(!notifier.senders.lock().unwrap().contains_key(&gone_id));
+
+        notifier.store().insert::<Count>(OWNER, 7);
+        assert_eq!(count_upsert(&recv_one(&mut kept).await), 7);
+    }
+
+    #[tokio::test]
+    async fn try_recv_reports_empty_then_buffered() {
+        let notifier = notifier();
+        let mut sub = notifier.create_subscriber(OWNER);
+        sub.subscribe_singleton::<Count>().unwrap();
+
+        // Nothing published yet.
+        assert_eq!(sub.try_recv().unwrap_err(), Error::ChannelEmpty);
+
+        // Two updates are queued before we await, so the background task delivers both in one round;
+        // `recv_one` proves delivery happened and takes the first, leaving the second buffered.
+        notifier.store().insert::<Count>(OWNER, 1);
+        notifier.store().insert::<Count>(OWNER, 2);
+        assert_eq!(count_upsert(&recv_one(&mut sub).await), 1);
+        assert_eq!(count_upsert(&sub.try_recv().unwrap()), 2);
+        assert_eq!(sub.try_recv().unwrap_err(), Error::ChannelEmpty);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn backpressure_delivers_everything_in_order() {
+        let notifier = notifier();
+        insert_item(&notifier, 0, "v0"); // seed so inserts are per-key with distinct values
+        let mut sub = notifier.create_subscriber(OWNER);
+        sub.subscribe_table::<Items>().unwrap();
+
+        // Many more notifications than the (small, under-test) channel can hold at once, forcing the
+        // full/requeue/retry path. Draining continuously resets the retry counter, so none is dropped.
+        let n = CHANNEL_CAPACITY as u32 * 3;
+        for k in 1..=n {
+            insert_item(&notifier, k, &format!("v{k}"));
+        }
+
+        for k in 1..=n {
+            assert_eq!(
+                items_key_upsert(&recv_one(&mut sub).await),
+                (k, format!("v{k}"))
+            );
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn write_burst_does_not_drop_a_live_subscriber() {
+        let notifier = notifier();
+        insert_item(&notifier, 0, "v0"); // seed so inserts are per-key
+        let mut sub = notifier.create_subscriber(OWNER);
+        sub.subscribe_table::<Items>().unwrap();
+
+        // Fill the channel and keep committing without ever draining it. Yielding (rather than
+        // sleeping) between commits lets the sending task run a round each time without advancing
+        // the clock, so every one of these rounds finds the channel full. There are more of
+        // them than MAX_RETRIES, but they all happen at the same instant, so they must count as a
+        // single failure and leave the subscriber alone.
+        let n = CHANNEL_CAPACITY as u32 + notify::MAX_RETRIES + 5;
+        for k in 1..=n {
+            insert_item(&notifier, k, &format!("v{k}"));
+            tokio::task::yield_now().await;
+        }
+
+        // Still known to the store, i.e. it was not removed.
+        assert!(sub.subscribe_global().is_ok());
+
+        // And still receiving: the notifications buffered before the channel filled are intact.
+        assert_eq!(
+            items_key_upsert(&recv_one(&mut sub).await),
+            (1, "v1".into())
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn slow_subscriber_is_dropped_and_cannot_resubscribe() {
+        let notifier = notifier();
+        insert_item(&notifier, 0, "v0"); // seed so inserts are per-key
+        let mut sub = notifier.create_subscriber(OWNER);
+        sub.subscribe_table::<Items>().unwrap();
+
+        // Never drained: fill the channel and keep it full across every retry round.
+        let n = CHANNEL_CAPACITY as u32 + 1;
+        for k in 1..=n {
+            insert_item(&notifier, k, &format!("v{k}"));
+        }
+
+        // Advance past all the retry rounds; the notifier gives up and removes the subscriber.
+        sleep(notify::RETRY_TIME * (notify::MAX_RETRIES + 2)).await;
+
+        // Regression for the previously-panicking case: subscribing on a given-up subscriber errors.
+        assert_eq!(sub.subscribe_global(), Err(Error::UnknownSubscriber));
+
+        // Its channel is closed: the already-buffered notifications drain, then it reports closure.
+        let mut drained = 0;
+        loop {
+            match sub.try_recv() {
+                Ok(_) => drained += 1,
+                Err(Error::ChannelDisconnected) => break,
+                Err(Error::ChannelEmpty) => {
+                    panic!("channel still open: subscriber was not dropped")
+                }
+                Err(e) => panic!("unexpected error: {e:?}"),
+            }
+        }
+        assert_eq!(drained, CHANNEL_CAPACITY);
+    }
+}

--- a/ts_kv_store_tokio/src/notify.rs
+++ b/ts_kv_store_tokio/src/notify.rs
@@ -1,0 +1,242 @@
+//! Internal logic for sending notifications.
+
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    sync::{Arc, Weak},
+    time::Duration,
+};
+
+use tokio::{
+    sync::{Notify, mpsc::error::TrySendError},
+    time::{Instant, timeout},
+};
+use ts_kv_store::{GeneratedStorage, Subscriber};
+
+use crate::{QueuedNotifications, SubscriberSender, TokioNotifier};
+
+/// How long to wait before re-sending notifications.
+#[cfg(not(test))]
+const RETRY_TIME: Duration = Duration::from_millis(100);
+#[cfg(test)]
+pub const RETRY_TIME: Duration = Duration::from_millis(5);
+
+/// How many times to try re-sending notifications.
+///
+/// Only failures at least [`RETRY_TIME`] apart count towards this, so giving up on a subscriber
+/// takes at least `RETRY_TIME * (MAX_RETRIES - 1)`, however often we retry in the meantime.
+///
+/// This is reset with a successful send. If a receiver is receiving notifications, but handling
+/// them more slowly than they are being generated, the notifiers internal queue can grow without
+/// bound.
+#[cfg(not(test))]
+const MAX_RETRIES: u32 = 10;
+#[cfg(test)]
+pub const MAX_RETRIES: u32 = 3;
+
+/// Wakes up when notified and sends any queued notifications.
+pub(super) async fn notify_loop<Storage: GeneratedStorage + 'static>(
+    notifier: Weak<TokioNotifier<Storage>>,
+    notify: Arc<Notify>,
+) {
+    // Don't start looping until the first time we're notified. This means that we won't try
+    // and upgrade the notifier to a strong reference before the notifier is constructed.
+    notify.notified().await;
+
+    loop {
+        let retry = if let Some(notifier) = notifier.upgrade() {
+            notifier.send_notifications()
+        } else {
+            // The notifier is gone, so there is nothing left to send.
+            return;
+        };
+
+        if retry {
+            // Retry when the timeout expires, or sooner if we are notified.
+            let _ = timeout(RETRY_TIME, notify.notified()).await;
+        } else {
+            notify.notified().await;
+        }
+    }
+}
+
+/// How close we are to removing a subscriber which is not taking its notifications.
+pub(super) struct Failing {
+    /// How many more failures this subscriber gets before we remove it. Counts down from
+    /// `MAX_RETRIES`.
+    retries_left: u32,
+    /// When we last counted a failure. Failures less than `RETRY_TIME` after this one don't count: a
+    /// commit wakes the sending task early, so a writer committing in a tight loop makes us retry
+    /// many times in an instant, and that must not use up the retries of a subscriber which is
+    /// merely waiting to be polled.
+    last_failure: Instant,
+}
+
+impl<Storage: GeneratedStorage + 'static> TokioNotifier<Storage> {
+    /// Send every queued notification to its subscriber's channel, returning whether this round of
+    /// notifications should be retried.
+    ///
+    /// Notifications are discarded if their subscriber's channel is closed or missing, and re-queued
+    /// if it is full. A subscriber which we fail to send anything to for [`MAX_RETRIES`] rounds is
+    /// given up on: its notifications are discarded and it is removed from the notifier and the store.
+    fn send_notifications(&self) -> bool {
+        let round = SendRound::send_all(
+            &mut self.senders.lock().unwrap(),
+            std::mem::take(&mut *self.queue.lock().unwrap()),
+        );
+
+        for subscriber in round.to_remove {
+            self.remove_subscriber(subscriber);
+        }
+
+        let retry = !round.requeue.is_empty();
+        let mut queue = self.queue.lock().unwrap();
+        for queued in round.requeue.into_iter().rev() {
+            queue.push_front(queued);
+        }
+        retry
+    }
+}
+
+/// A notification could not be sent to its subscriber.
+enum SendError<Storage: GeneratedStorage> {
+    /// The channel filled up; the field is the notifications which were not sent.
+    Full(Vec<Storage::Notification>),
+    /// The subscriber has not taken a notification for [`MAX_RETRIES`] rounds or the channel is
+    /// closed.
+    Dead,
+}
+
+impl<Storage: GeneratedStorage> SubscriberSender<Storage> {
+    /// Record a failure to send to this subscriber, giving up on it (by returning
+    /// [`SendError::Dead`]) once it has used up all [`MAX_RETRIES`] of its retries.
+    ///
+    /// Only failures at least [`RETRY_TIME`] apart count, so retrying sooner is free.
+    fn record_failure(&mut self) -> Result<(), SendError<Storage>> {
+        let now = Instant::now();
+        let counts = match &self.failing {
+            Some(failing) => now.duration_since(failing.last_failure) >= RETRY_TIME,
+            // The first failure since the last successful send always counts.
+            None => true,
+        };
+        if !counts {
+            return Ok(());
+        }
+
+        let failing = self.failing.get_or_insert(Failing {
+            retries_left: MAX_RETRIES,
+            last_failure: now,
+        });
+        failing.last_failure = now;
+        failing.retries_left -= 1;
+
+        if failing.retries_left == 0 {
+            tracing::error!("subscriber is not receiving notifications, dropping it");
+            return Err(SendError::Dead);
+        }
+
+        Ok(())
+    }
+}
+
+/// Send one subscription's `notifications` to its subscriber's channel, stopping at the first one
+/// which cannot be sent.
+///
+/// Never awaits, and never blocks on a full channel: a subscriber which is not keeping up is
+/// reported as [`SendError::Full`] so that the caller can retry it later, or as
+/// [`SendError::Dead`] once it has ignored us for [`MAX_RETRIES`] rounds in a row. Retrying sooner
+/// than [`RETRY_TIME`] does not count towards `MAX_RETRIES`.
+fn send_to_subscriber<Storage: GeneratedStorage>(
+    channel: &mut SubscriberSender<Storage>,
+    notifications: Vec<Storage::Notification>,
+) -> Result<(), SendError<Storage>> {
+    let mut notifications = notifications.into_iter();
+    while let Some(notification) = notifications.next() {
+        match channel.sender.try_send(notification) {
+            Ok(()) => channel.failing = None,
+            // Re-queue this notification and everything after it for this subscriber, rather than
+            // sending later notifications out of order. Give up on a subscriber which has not taken
+            // a notification for a while.
+            Err(TrySendError::Full(notification)) => {
+                channel.record_failure()?;
+
+                let mut rest = vec![notification];
+                rest.extend(notifications);
+                return Err(SendError::Full(rest));
+            }
+            Err(TrySendError::Closed(_)) => return Err(SendError::Dead),
+        }
+    }
+
+    Ok(())
+}
+
+/// The bookkeeping for a single round of sending.
+#[derive(Default)]
+struct SendRound<Storage: GeneratedStorage> {
+    /// Subscribers whose remaining notifications are discarded (because the receiver is dead).
+    skip: HashSet<Subscriber>,
+    /// Subscribers whose remaining notifications are re-queued because their channel is full.
+    full: HashSet<Subscriber>,
+    /// Subscribers to remove from the store and notifier.
+    to_remove: Vec<Subscriber>,
+    /// Notifications to be queued for re-sending.
+    requeue: VecDeque<QueuedNotifications<Storage>>,
+}
+
+impl<Storage: GeneratedStorage> SendRound<Storage> {
+    fn send_all(
+        senders: &mut HashMap<Subscriber, SubscriberSender<Storage>>,
+        queue: VecDeque<QueuedNotifications<Storage>>,
+    ) -> Self {
+        let mut round = Self::default();
+        for queued in queue {
+            round.send_transaction(senders, queued);
+        }
+        round
+    }
+
+    /// Send the notifications from a single transaction.
+    fn send_transaction(
+        &mut self,
+        senders: &mut HashMap<Subscriber, SubscriberSender<Storage>>,
+        queued: QueuedNotifications<Storage>,
+    ) {
+        let mut leftover = HashMap::new();
+
+        for (subscription, notifications) in queued {
+            let subscriber = subscription.subscriber();
+            if self.skip.contains(&subscriber) {
+                continue;
+            }
+            if self.full.contains(&subscriber) {
+                leftover.insert(subscription, notifications);
+                continue;
+            }
+
+            let Some(channel) = senders.get_mut(&subscriber) else {
+                // Expected when a subscriber is dropped (or given up on) while it still has
+                // notifications queued.
+                tracing::debug!(?subscriber, "no channel for subscriber, discarding");
+                self.skip.insert(subscriber);
+                self.to_remove.push(subscriber);
+                continue;
+            };
+
+            match send_to_subscriber(channel, notifications) {
+                Ok(()) => {}
+                Err(SendError::Full(rest)) => {
+                    self.full.insert(subscriber);
+                    leftover.insert(subscription, rest);
+                }
+                Err(SendError::Dead) => {
+                    self.to_remove.push(subscriber);
+                    self.skip.insert(subscriber);
+                }
+            }
+        }
+
+        if !leftover.is_empty() {
+            self.requeue.push_back(leftover);
+        }
+    }
+}


### PR DESCRIPTION
Adds the `ts_kv_store_tokio` crate which implements an async notifier for the store using Tokio. There's quite a few changes to the KV store itself, mostly to support subscriptions/notifications in some way, plus a few small bug fixes.

AI decl: I used Claude pretty extensively on this one. I worked iteratively, doing some coding myself, having Claude do some coding, then reviewing and refactoring the generated code, then having Claude review current state of the code. Therefore, I would consider an LLM was used for all of this PR rather than any specific parts, but I've reviewed and iterated on it all, so I'm confident it is not vibe-coded slop.

cc #207