### PR TITLE
runtime: disco actor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6310,6 +6310,7 @@ dependencies = [
 name = "ts_runtime"
 version = "0.4.0"
 dependencies = [
+ "bytes",
  "chrono",
  "futures",
  "futures-util",
@@ -6347,6 +6348,7 @@ dependencies = [
  "ts_tunnel",
  "url",
  "yoke",
+ "zerocopy",
 ]
 
 [[package]]

--- a/ts_dataplane/src/async_tokio.rs
+++ b/ts_dataplane/src/async_tokio.rs
@@ -191,6 +191,24 @@ impl DataPlane {
         (id, self.overlay_up.clone(), rx)
     }
 
+    /// Send packets directly to an underlay transport by id.
+    ///
+    /// This is typically used to bypass the routing layer in order to directly send e.g. disco
+    /// packets.
+    pub async fn send_underlay(
+        &self,
+        underlay_transport_id: UnderlayTransportId,
+        ep: DynEndpoint,
+        buf: Vec<PacketMut>,
+    ) -> bool {
+        let state = self.core_state.lock().await;
+        let Some(transport) = state.underlay_transports.get(&underlay_transport_id) else {
+            return false;
+        };
+
+        transport.send((ep, buf)).is_ok()
+    }
+
     /// Run the data plane forever, moving packets from the input queues to output queues.
     pub async fn run(&self) -> Infallible {
         loop {

--- a/ts_runtime/Cargo.toml
+++ b/ts_runtime/Cargo.toml
@@ -46,6 +46,8 @@ smol_str = "0.3"
 yoke.workspace = true
 url.workspace = true
 rand.workspace = true
+bytes.workspace = true
+zerocopy.workspace = true
 
 [dev-dependencies]
 chrono.workspace = true

--- a/ts_runtime/src/dataplane.rs
+++ b/ts_runtime/src/dataplane.rs
@@ -50,8 +50,6 @@ pub type DiscoPacket = yoke::Yoke<&'static Packet<Plaintext>, ts_packet::Packet>
 
 #[derive(Clone)]
 pub struct IncomingDiscoMsg {
-    // TODO(npry): used as part of direct transport
-    #[expect(dead_code)]
     pub sender: DynEndpoint,
     pub packet: DiscoPacket,
 }

--- a/ts_runtime/src/dataplane.rs
+++ b/ts_runtime/src/dataplane.rs
@@ -13,6 +13,7 @@ use ts_dataplane::async_tokio::{
 };
 use ts_disco_protocol::{Packet, Plaintext};
 use ts_hexdump::{AsHexExt, Case};
+use ts_packet::PacketMut;
 use ts_transport::{DynEndpoint, OverlayTransportId, UnderlayTransportId};
 
 use crate::{
@@ -43,6 +44,19 @@ impl DataplaneActor {
         &self,
     ) -> (UnderlayTransportId, Rx<ToUnderlay>, Tx<FromUnderlay>) {
         self.dataplane.new_underlay_transport().await
+    }
+
+    /// Send a message directly to an underlay transport, bypassing the routing layer.
+    #[message]
+    pub async fn send_underlay(
+        &self,
+        underlay_id: UnderlayTransportId,
+        endpoint: DynEndpoint,
+        bufs: Vec<PacketMut>,
+    ) -> bool {
+        self.dataplane
+            .send_underlay(underlay_id, endpoint, bufs)
+            .await
     }
 }
 

--- a/ts_runtime/src/disco.rs
+++ b/ts_runtime/src/disco.rs
@@ -28,10 +28,7 @@ impl kameo::Actor for Disco {
 
 #[derive(Clone)]
 pub struct SendDisco {
-    // TODO(npry): consumed by transports in future commits
-    #[expect(dead_code)]
     pub buf: Bytes,
-    #[expect(dead_code)]
     pub ep: DynEndpoint,
 }
 

--- a/ts_runtime/src/disco.rs
+++ b/ts_runtime/src/disco.rs
@@ -1,0 +1,151 @@
+use bytes::{Bytes, BytesMut};
+use kameo::{
+    actor::ActorRef,
+    message::{Context, Message},
+};
+use ts_disco_protocol::{MessageType, Ping, Pong};
+use ts_keys::{DiscoKeyPair, DiscoPublicKey};
+use ts_transport::DynEndpoint;
+use zerocopy::{Immutable, IntoBytes, KnownLayout, TryFromBytes};
+
+use crate::{dataplane::IncomingDiscoMsg, env::Env};
+
+pub struct Disco {
+    env: Env,
+}
+
+impl kameo::Actor for Disco {
+    type Args = Env;
+    type Error = crate::Error;
+
+    async fn on_start(env: Env, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
+        env.subscribe::<IncomingDiscoMsg>(&slf).await?;
+        env.register(None, &slf).await?;
+
+        Ok(Self { env })
+    }
+}
+
+#[derive(Clone)]
+pub struct SendDisco {
+    // TODO(npry): consumed by transports in future commits
+    #[expect(dead_code)]
+    pub buf: Bytes,
+    #[expect(dead_code)]
+    pub ep: DynEndpoint,
+}
+
+impl Message<IncomingDiscoMsg> for Disco {
+    type Reply = ();
+
+    #[tracing::instrument(skip_all, fields(ty = ?msg.packet.get().ty(), sender = ?msg.sender))]
+    async fn handle(&mut self, msg: IncomingDiscoMsg, _ctx: &mut Context<Self, Self::Reply>) {
+        let pkt = msg.packet.get();
+
+        match pkt.ty() {
+            Some(MessageType::CallMeMaybe) => {
+                if !msg.sender.is_disco_coordinator() {
+                    tracing::warn!("call me maybe received but from non-derp endpoint");
+                    return;
+                };
+
+                let cmm = pkt.as_msg::<ts_disco_protocol::CallMeMaybe>().unwrap();
+
+                for ep in &cmm.endpoints {
+                    let addr = ep.socket_addr();
+                    let ep = DynEndpoint::udp(ep.socket_addr());
+
+                    let tx_id = rand::random();
+
+                    let buf = Self::mk_pkt::<Ping>(
+                        Ping::size_with_padding(0),
+                        &self.env.keys.disco_keys,
+                        pkt.sender_pubkey(),
+                        |ping| {
+                            ping.node_key = self.env.keys.node_keys.public;
+                            ping.tx_id = tx_id;
+                        },
+                    );
+
+                    tracing::debug!(
+                        %addr,
+                        ?ep,
+                        tx_id = ?format_args!("{:x?}", ts_hexdump::IterFmt::contiguous(&tx_id)),
+                        "sent callmemaybe response ping"
+                    );
+
+                    self.env
+                        .publish_noretain(SendDisco {
+                            buf: buf.clone(),
+                            ep,
+                        })
+                        .await
+                        .unwrap();
+                }
+            }
+            Some(MessageType::Ping) => {
+                let ping = pkt.as_msg::<Ping>().unwrap();
+                tracing::debug!(?ping, "got ping");
+
+                let Some(sender) = msg.sender.as_udp() else {
+                    tracing::warn!(?ping, "ping is from non-udp peer, bail");
+                    return;
+                };
+
+                let buf = Self::mk_pkt::<Pong>(
+                    Pong::size(),
+                    &self.env.keys.disco_keys,
+                    pkt.sender_pubkey(),
+                    |pong| {
+                        pong.tx_id = ping.tx_id;
+                        pong.src = sender.into();
+                    },
+                );
+
+                self.env
+                    .publish_noretain(SendDisco {
+                        buf,
+                        ep: msg.sender,
+                    })
+                    .await
+                    .unwrap();
+            }
+            Some(MessageType::Pong) => {
+                // ignore, handled by path discovery
+            }
+            Some(_ty) => {
+                tracing::trace!("unhandled disco type");
+            }
+            None => {
+                tracing::warn!("unknown disco type");
+            }
+        }
+    }
+}
+
+impl Disco {
+    pub fn mk_pkt<Msg>(
+        payload_size: usize,
+        disco_keys: &DiscoKeyPair,
+        rcpt_key: &DiscoPublicKey,
+        f: impl FnOnce(&mut Msg),
+    ) -> Bytes
+    where
+        Msg: ?Sized
+            + ts_disco_protocol::Message
+            + Immutable
+            + TryFromBytes
+            + IntoBytes
+            + KnownLayout,
+    {
+        let msg_size = ts_disco_protocol::Packet::size_for_message(payload_size);
+        let mut buf = BytesMut::zeroed(msg_size);
+
+        let resp = ts_disco_protocol::Packet::init_from_bytes::<Msg>(&mut buf, f).unwrap();
+
+        resp.encrypt_in_place(&disco_keys.private, rcpt_key, rand::random())
+            .unwrap();
+
+        buf.freeze()
+    }
+}

--- a/ts_runtime/src/lib.rs
+++ b/ts_runtime/src/lib.rs
@@ -16,6 +16,7 @@ use crate::{
 pub mod control_runner;
 mod dataplane;
 mod derp_latency;
+mod disco;
 mod env;
 mod error;
 mod multiderp;
@@ -78,6 +79,8 @@ impl kameo::Actor for Runtime {
         let (netstack_id, netstack_up, netstack_down) = env
             .ask::<DataplaneActor, _>(None, dataplane::NewOverlayTransport, true)
             .await?;
+
+        disco::Disco::supervise(&slf, env.clone()).spawn().await;
 
         Multiderp::supervise(&slf, env.clone()).spawn().await;
 

--- a/ts_runtime/src/multiderp/mod.rs
+++ b/ts_runtime/src/multiderp/mod.rs
@@ -14,9 +14,16 @@ use kameo::{
 use kameo_actors::scheduler::SetTimeout;
 use ts_control::DerpRegion;
 use ts_derp::RegionId;
+use ts_packet::PacketMut;
 use ts_transport::UnderlayTransportId;
 
-use crate::{Env, Error, multiderp::uniderp::Uniderp};
+use crate::{
+    Env, Error,
+    dataplane::{DataplaneActor, SendUnderlay},
+    disco::SendDisco,
+    multiderp::uniderp::Uniderp,
+    peer_tracker::{PeerDb, PeerState},
+};
 
 /// Consumes derp map updates and spawns an actor per region that runs an underlay transport.
 /// Also consumes home derp indications (for this node) to notify the relevant task that it
@@ -29,6 +36,7 @@ pub struct Multiderp {
     region_map: HashMap<RegionId, UnderlayTransportId>,
     env: Env,
     debounce_state: DebounceState,
+    peer_state: Arc<PeerDb>,
 }
 
 impl kameo::Actor for Multiderp {
@@ -37,12 +45,16 @@ impl kameo::Actor for Multiderp {
 
     async fn on_start(env: Self::Args, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
         env.subscribe::<Arc<ts_control::StateUpdate>>(&slf).await?;
+        env.subscribe::<Arc<PeerState>>(&slf).await?;
+        env.subscribe::<SendDisco>(&slf).await?;
+
         env.register(None, &slf).await?;
 
         Ok(Self {
             env,
             region_map: Default::default(),
             debounce_state: Default::default(),
+            peer_state: Default::default(),
         })
     }
 
@@ -187,5 +199,54 @@ impl Message<DebouncedPublish> for Multiderp {
     async fn handle(&mut self, _: DebouncedPublish, _: &mut Context<Self, Self::Reply>) {
         self.do_map_publish().await;
         self.debounce_state.publish_enqueued = false;
+    }
+}
+
+impl Message<Arc<PeerState>> for Multiderp {
+    type Reply = ();
+
+    async fn handle(&mut self, state: Arc<PeerState>, _: &mut Context<Self, Self::Reply>) {
+        self.peer_state = state.peers.clone();
+    }
+}
+
+impl Message<SendDisco> for Multiderp {
+    type Reply = ();
+
+    async fn handle(&mut self, send: SendDisco, _: &mut Context<Self, Self::Reply>) {
+        let Some(nodekey) = send.ep.as_derp() else {
+            return;
+        };
+
+        let Some((_, peer)) = self.peer_state.get(&nodekey) else {
+            tracing::trace!(%nodekey, "no known peer");
+            return;
+        };
+
+        let Some(derp_region) = &peer.derp_region else {
+            tracing::trace!(%nodekey, "peer had no derp region");
+            return;
+        };
+
+        let Some(transport_id) = self.region_map.get(derp_region) else {
+            tracing::trace!(%nodekey, ?derp_region, "derp region had no transport");
+            return;
+        };
+
+        let sent = self
+            .env
+            .ask::<DataplaneActor, _>(
+                None,
+                SendUnderlay {
+                    endpoint: send.ep,
+                    bufs: vec![PacketMut::from(send.buf.to_vec())],
+                    underlay_id: *transport_id,
+                },
+                true,
+            )
+            .await
+            .unwrap();
+
+        tracing::trace!(?sent, %nodekey, ?derp_region, "disco send result");
     }
 }


### PR DESCRIPTION
Actor that consumes incoming disco messages and generates responses to incoming `CallMeMaybe`s and `Ping`s. Multiderp consumes these and forwards them to Uniderps through a slightly convoluted scheme involving direct underlay sends through the dataplane.
