### PR TITLE
runtime, dataplane: track underlay/overlay ids

### DIFF
--- a/ts_dataplane/src/async_tokio.rs
+++ b/ts_dataplane/src/async_tokio.rs
@@ -26,17 +26,17 @@ use crate::{InboundResult, OutboundResult};
 /// Packet batches sent to an overlay.
 pub type ToOverlay = Vec<PacketMut>;
 /// Packet batches received from an overlay.
-pub type FromOverlay = Vec<PacketMut>;
+pub type FromOverlay = (OverlayTransportId, Vec<PacketMut>);
 
 /// Packet batches sent to an underlay.
 pub type ToUnderlay = (DynEndpoint, Vec<PacketMut>);
 /// Packet batches received from an underlay.
-pub type FromUnderlay = (DynEndpoint, Vec<PacketMut>);
+pub type FromUnderlay = (UnderlayTransportId, DynEndpoint, Vec<PacketMut>);
 
 /// A batch of disco packets received from an underlay transport.
-pub type DiscoBatch = (DynEndpoint, Vec<PacketMut>);
+pub type DiscoBatch = (UnderlayTransportId, DynEndpoint, Vec<PacketMut>);
 /// A batch of stun packets received from an underlay transport.
-pub type StunBatch = (DynEndpoint, Vec<PacketMut>);
+pub type StunBatch = (UnderlayTransportId, DynEndpoint, Vec<PacketMut>);
 
 /// Hashset where membership indicates that a peer has had activity recently and we should run
 /// path discovery.
@@ -253,17 +253,17 @@ impl DataPlane {
 
             tokio::select! {
                 overlay_pkts = overlay_down.recv() => {
-                    let overlay_pkts = overlay_pkts.unwrap();
+                    let (overlay_id, overlay_pkts) = overlay_pkts.unwrap();
                     tracing::trace!(n_overlay_pkts = overlay_pkts.len());
 
-                    SelectResult::OverlayDown(overlay_pkts)
+                    SelectResult::OverlayDown((overlay_id, overlay_pkts))
                 }
 
                 underlay_pkts = underlay_up.recv() => {
-                    let (ep, underlay_pkts) = underlay_pkts.unwrap();
-                    tracing::trace!(from_ep = %ep.ty(), n_underlay_pkts = underlay_pkts.len());
+                    let (id, ep, underlay_pkts) = underlay_pkts.unwrap();
+                    tracing::trace!(underlay_id = ?id, from_ep = %ep.ty(), n_underlay_pkts = underlay_pkts.len());
 
-                    SelectResult::UnderlayUp((ep, underlay_pkts))
+                    SelectResult::UnderlayUp((id, ep, underlay_pkts))
                 }
 
                 _ = self.transports_changed.notified() => {
@@ -289,13 +289,13 @@ impl DataPlane {
         let mut possible_gc = false;
 
         let (to_peers, to_local) = match select_result {
-            SelectResult::OverlayDown(overlay_down) => {
+            SelectResult::OverlayDown((_overlay_id, overlay_down)) => {
                 let OutboundResult { to_peers, loopback } =
                     core.sync.process_outbound(overlay_down);
 
                 (Some(to_peers), Some(loopback))
             }
-            SelectResult::UnderlayUp((ep, pkts)) => {
+            SelectResult::UnderlayUp((underlay_id, ep, pkts)) => {
                 let InboundResult {
                     to_local,
                     to_peers,
@@ -303,11 +303,16 @@ impl DataPlane {
                     stun,
                 } = core.sync.process_inbound(pkts);
 
-                if !disco.is_empty() && core.disco_out.send((ep.clone(), disco)).is_err() {
+                if !disco.is_empty()
+                    && core
+                        .disco_out
+                        .send((underlay_id, ep.clone(), disco))
+                        .is_err()
+                {
                     tracing::warn!("disco packets dropped: no receiver");
                 }
 
-                if !stun.is_empty() && core.stun_out.send((ep, stun)).is_err() {
+                if !stun.is_empty() && core.stun_out.send((underlay_id, ep, stun)).is_err() {
                     tracing::warn!("stun packets dropped: no receiver");
                 }
 

--- a/ts_runtime/src/dataplane.rs
+++ b/ts_runtime/src/dataplane.rs
@@ -63,7 +63,9 @@ impl DataplaneActor {
 pub type DiscoPacket = yoke::Yoke<&'static Packet<Plaintext>, ts_packet::Packet>;
 
 #[derive(Clone)]
+#[expect(dead_code)]
 pub struct IncomingDiscoMsg {
+    pub transport: UnderlayTransportId,
     pub sender: DynEndpoint,
     pub packet: DiscoPacket,
 }
@@ -85,6 +87,7 @@ struct DiscoInternal(DiscoBatch);
 #[derive(Debug, Clone)]
 #[expect(dead_code)]
 pub struct IncomingStunMsg {
+    pub transport: UnderlayTransportId,
     pub sender: DynEndpoint,
     pub pkt: ts_packet::Packet,
 }
@@ -147,7 +150,7 @@ impl Message<StreamMessage<DiscoInternal, (), ()>> for DataplaneActor {
         msg: StreamMessage<DiscoInternal, (), ()>,
         _ctx: &mut Context<Self, Self::Reply>,
     ) {
-        let (ep, bufs) = match msg {
+        let (transport_id, ep, bufs) = match msg {
             StreamMessage::Next(pkt) => pkt.0,
             _ => return,
         };
@@ -176,6 +179,7 @@ impl Message<StreamMessage<DiscoInternal, (), ()>> for DataplaneActor {
             .unwrap();
 
             let pkt = IncomingDiscoMsg {
+                transport: transport_id,
                 sender: ep.clone(),
                 packet: pkt,
             };
@@ -195,7 +199,7 @@ impl Message<StreamMessage<StunInternal, (), ()>> for DataplaneActor {
         msg: StreamMessage<StunInternal, (), ()>,
         _ctx: &mut Context<Self, Self::Reply>,
     ) {
-        let (ep, pkts) = match msg {
+        let (transport_id, ep, pkts) = match msg {
             StreamMessage::Next(pkt) => pkt.0,
             _ => return,
         };
@@ -203,6 +207,7 @@ impl Message<StreamMessage<StunInternal, (), ()>> for DataplaneActor {
         for pkt in pkts {
             self.env
                 .publish_noretain(IncomingStunMsg {
+                    transport: transport_id,
                     pkt: pkt.freeze(),
                     sender: ep.clone(),
                 })

--- a/ts_runtime/src/lib.rs
+++ b/ts_runtime/src/lib.rs
@@ -108,6 +108,7 @@ impl kameo::Actor for Runtime {
             (
                 env.clone(),
                 Default::default(),
+                netstack_id,
                 netstack_up,
                 Arc::new(Mutex::new(netstack_down)),
             ),

--- a/ts_runtime/src/multiderp/uniderp.rs
+++ b/ts_runtime/src/multiderp/uniderp.rs
@@ -97,6 +97,7 @@ impl kameo::Actor for Uniderp {
         let runner = Runner {
             region_id: args.region_id,
             region: args.region,
+            transport_id,
             peer_db: Arc::new(RwLock::new(None)),
             home_derp_rx,
             to_dataplane,
@@ -219,6 +220,7 @@ impl Message<DerpLatencyMeasurement> for Uniderp {
 struct Runner {
     region_id: RegionId,
     region: DerpRegion,
+    transport_id: UnderlayTransportId,
     home_derp_rx: watch::Receiver<bool>,
     to_dataplane: Tx<FromUnderlay>,
     from_dataplane: Arc<Mutex<Rx<ToUnderlay>>>,
@@ -277,7 +279,7 @@ impl Runner {
         Ok(transport)
     }
 
-    #[tracing::instrument(skip_all, level = "trace")]
+    #[tracing::instrument(skip_all, fields(transport_id = ?self.transport_id), level = "trace")]
     async fn run_transport(
         &mut self,
         transport: impl UnderlayTransport<Error = ts_derp::Error>,
@@ -301,7 +303,7 @@ impl Runner {
 
                         tracing::trace!(parent: &span, ?ep, len = pkts.len(), "packets from derp server");
 
-                        let Ok(()) = self.to_dataplane.send((ep, pkts)) else {
+                        let Ok(()) = self.to_dataplane.send((self.transport_id, ep, pkts)) else {
                             tracing::error!(parent: &span, "underlay receive channel closed");
                             break;
                         };

--- a/ts_runtime/src/netstack_actor.rs
+++ b/ts_runtime/src/netstack_actor.rs
@@ -11,6 +11,7 @@ use netstack::{
 use tokio::sync::Mutex;
 use ts_dataplane::async_tokio::{FromOverlay, Rx, ToOverlay, Tx};
 use ts_packet::PacketMut;
+use ts_transport::OverlayTransportId;
 
 use crate::{Error, env::Env, task::Task};
 
@@ -22,13 +23,14 @@ impl kameo::Actor for NetstackActor {
     type Args = (
         Env,
         netstack::netcore::Config,
+        OverlayTransportId,
         Tx<FromOverlay>,
         Arc<Mutex<Rx<ToOverlay>>>,
     );
     type Error = Error;
 
     async fn on_start(
-        (env, config, netstack_up, netstack_down): Self::Args,
+        (env, config, id, netstack_up, netstack_down): Self::Args,
         slf: ActorRef<Self>,
     ) -> Result<Self, Self::Error> {
         env.subscribe::<Arc<ts_control::StateUpdate>>(&slf).await?;
@@ -49,7 +51,7 @@ impl kameo::Actor for NetstackActor {
 
         Task::spawn_link(&slf, async move {
             while let Some(buf) = netstack_down_rx.recv_async().await {
-                if netstack_up.send(vec![buf.to_vec().into()]).is_err() {
+                if netstack_up.send((id, vec![buf.to_vec().into()])).is_err() {
                     break;
                 }
             }


### PR DESCRIPTION
Include the underlay/overlay transport id in packets coming from underlays/overlays respectively, since they're each intentionally grouped into a single channel in this direction. This is needed to disambiguate where a packet actually came from in order to produce a return path for disco