### PR TITLE
dataplane: track peers with outgoing traffic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5448,6 +5448,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/ts_dataplane/src/async_tokio.rs
+++ b/ts_dataplane/src/async_tokio.rs
@@ -1,8 +1,13 @@
 //! The packet processing dataplane, as a tokio task.
 
-use std::{collections::HashMap, convert::Infallible, ops::DerefMut, sync::atomic::AtomicU32};
+use std::{
+    collections::{HashMap, HashSet},
+    convert::Infallible,
+    ops::DerefMut,
+    sync::{Arc, atomic::AtomicU32},
+};
 
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::{Mutex, mpsc, watch};
 use ts_packet::PacketMut;
 use ts_transport::{OverlayTransportId, PeerId, UnderlayTransportId};
 use ts_tunnel::NodeKeyPair;
@@ -32,6 +37,10 @@ pub type FromUnderlay = Vec<PacketMut>;
 pub type DiscoBatch = Vec<PacketMut>;
 /// A batch of stun packets received from an underlay transport.
 pub type StunBatch = Vec<PacketMut>;
+
+/// Hashset where membership indicates that a peer has had activity recently and we should run
+/// path discovery.
+pub type ActivePeers = Arc<HashSet<PeerId>>;
 
 /// Shorthand for a sender channel.
 pub type Tx<T> = mpsc::UnboundedSender<T>;
@@ -68,6 +77,9 @@ struct CoreState {
     disco_out: Tx<DiscoBatch>,
     /// Send handle for stun packets received from underlays.
     stun_out: Tx<StunBatch>,
+
+    /// Send handle for peer activity changes.
+    peer_activity_out: watch::Sender<ActivePeers>,
 }
 
 /// State that must be held during async polling.
@@ -85,13 +97,22 @@ impl DataPlane {
     /// otherwise all it can do is drop packets.
     ///
     /// The second and third elements of the return tuple are output queues for disco and
-    /// STUN messages, respectively.
-    pub fn new(my_key: NodeKeyPair) -> (Self, Rx<DiscoBatch>, Rx<StunBatch>) {
+    /// STUN messages, respectively. The fourth element represents the set of peers with recent
+    /// outgoing traffic, as tracked by the dataplane.
+    pub fn new(
+        my_key: NodeKeyPair,
+    ) -> (
+        Self,
+        Rx<DiscoBatch>,
+        Rx<StunBatch>,
+        watch::Receiver<ActivePeers>,
+    ) {
         let (overlay_up, overlay_down) = mpsc::unbounded_channel();
         let (underlay_down, underlay_up) = mpsc::unbounded_channel();
 
         let (disco_tx, disco_rx) = mpsc::unbounded_channel();
         let (stun_tx, stun_rx) = mpsc::unbounded_channel();
+        let (peer_tx, peer_rx) = watch::channel(Default::default());
 
         let sync = crate::DataPlane::new(my_key);
 
@@ -108,6 +129,7 @@ impl DataPlane {
                 sync,
                 stun_out: stun_tx,
                 disco_out: disco_tx,
+                peer_activity_out: peer_tx,
                 overlay_transports: Default::default(),
                 underlay_transports: Default::default(),
             }),
@@ -118,7 +140,7 @@ impl DataPlane {
             }),
         };
 
-        (dp, disco_rx, stun_rx)
+        (dp, disco_rx, stun_rx, peer_rx)
     }
 
     /// Allocate a new underlay transport.
@@ -242,6 +264,12 @@ impl DataPlane {
 
         let mut core = self.core_state.lock().await;
 
+        // To avoid cloning the active peer map repeatedly to compare it against the last state,
+        // compare the length before and after processing packets. It can only grow unless a GC ran
+        // (in process_events), so in all other cases no length change means no change at all.
+        let active_peer_count = core.sync.active_peers.len();
+        let mut possible_gc = false;
+
         let (to_peers, to_local) = match select_result {
             SelectResult::OverlayDown(overlay_down) => {
                 let OutboundResult { to_peers, loopback } =
@@ -269,10 +297,34 @@ impl DataPlane {
             }
             SelectResult::Event => {
                 let EventResult { to_peers } = core.sync.process_events();
+                possible_gc = true;
                 (Some(to_peers), None)
             }
             SelectResult::TransportsChanged => (None, None),
         };
+
+        if possible_gc || core.sync.active_peers.len() != active_peer_count {
+            // only consider membership in the map for whether the peer should be considered
+            // active, time-based expiration is only enforced by gc.
+            let new_active_peers = core
+                .sync
+                .active_peers
+                .keys()
+                .copied()
+                .collect::<HashSet<_>>();
+
+            core.peer_activity_out.send_if_modified(|cur| {
+                if &new_active_peers == cur.as_ref() {
+                    tracing::trace!("no active peers change");
+                    return false;
+                }
+
+                tracing::trace!("active peers updated");
+
+                *cur = Arc::new(new_active_peers);
+                true
+            });
+        }
 
         if let Some(to_peers) = to_peers {
             write_to_underlay(&core, to_peers).await;

--- a/ts_dataplane/src/lib.rs
+++ b/ts_dataplane/src/lib.rs
@@ -2,13 +2,17 @@
 
 extern crate ts_disco_protocol as disco;
 
-use std::{collections::HashMap, sync::Arc, time::Instant};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use ts_bart::RoutingTable;
 use ts_overlay_router as or;
 use ts_packet::PacketMut;
 use ts_packetfilter::{FilterExt, IpProto};
-use ts_time::{Handle, Scheduler};
+use ts_time::{Handle, Scheduler, TimeRange};
 use ts_transport::{OverlayTransportId, PeerId, UnderlayTransportId};
 use ts_tunnel::{Endpoint, NodeKeyPair};
 use ts_underlay_router as ur;
@@ -18,10 +22,16 @@ mod packet_ident;
 
 pub use packet_ident::{PacketIdent, PacketType};
 
+/// Duration without traffic after which to remove a peer from the active map.
+const PEER_EXPIRATION: Duration = Duration::from_secs(45);
+
 /// A data plane subsystem that can be the subject of timer events.
 pub enum Subsystem {
     /// The wireguard component.
     Wireguard,
+
+    /// Peer activity garbage collection.
+    PeerGc,
 }
 
 /// Transforms packets to make tailscale happen.
@@ -42,11 +52,19 @@ pub struct DataPlane {
     /// The packet filter.
     pub packet_filter: Arc<dyn ts_packetfilter::Filter + Send + Sync>,
 
+    /// Per-peer timestamps of last outgoing data packets.
+    ///
+    /// Used to determine whether we should be running path discovery for this peer.
+    pub active_peers: HashMap<PeerId, Instant>,
+
     /// Events queued for future processing.
     pub events: Scheduler<Subsystem>,
 
     /// Next event for the wireguard subsystem.
     pub wg_next: Option<Handle<Subsystem>>,
+
+    /// Next event for the peer gc subsystem.
+    pub peer_gc_next: Option<Handle<Subsystem>>,
 }
 
 impl DataPlane {
@@ -60,7 +78,9 @@ impl DataPlane {
             or_in: Default::default(),
             events: Default::default(),
             packet_filter: Arc::new(ts_packetfilter::DropAllFilter),
+            active_peers: Default::default(),
             wg_next: None,
+            peer_gc_next: None,
         }
     }
 
@@ -72,8 +92,13 @@ impl DataPlane {
             loopback,
         } = self.or_out.route(packets);
 
+        let now = Instant::now();
+
         let to_wireguard = to_wireguard
             .into_iter()
+            .inspect(|(id, _)| {
+                self.active_peers.insert(*id, now);
+            })
             .map(|(k, v)| (ts_tunnel::PeerId(k.0), v))
             .collect::<Vec<_>>();
 
@@ -85,13 +110,7 @@ impl DataPlane {
             .ur_out
             .route(encrypted.into_iter().map(|(k, v)| (PeerId(k.0), v)));
 
-        if let Some(next) = self.wireguard.next_event()
-            && let Some(prev) = self
-                .wg_next
-                .replace(self.events.add(next, Subsystem::Wireguard))
-        {
-            prev.cancel();
-        }
+        self.ensure_events(now);
 
         OutboundResult { to_peers, loopback }
     }
@@ -205,20 +224,19 @@ impl DataPlane {
                 v
             });
 
+        let now = Instant::now();
+
         let to_peers = to_peers
             .into_iter()
-            .map(|(k, v)| (ts_transport::PeerId(k.0), v));
+            .map(|(k, v)| (ts_transport::PeerId(k.0), v))
+            .inspect(|(id, _)| {
+                self.active_peers.insert(*id, now);
+            });
 
         let to_local = self.or_in.route(to_local.flatten());
         let to_peers = self.ur_out.route(to_peers);
 
-        if let Some(next) = self.wireguard.next_event()
-            && let Some(prev) = self
-                .wg_next
-                .replace(self.events.add(next, Subsystem::Wireguard))
-        {
-            prev.cancel();
-        }
+        self.ensure_events(now);
 
         InboundResult {
             to_local,
@@ -245,6 +263,8 @@ impl DataPlane {
     pub fn process_events(&mut self) -> EventResult {
         let mut to_peers = HashMap::new();
         let now = Instant::now();
+        let mut should_gc = false;
+
         for event in self.events.dispatch(now) {
             match event {
                 Subsystem::Wireguard => {
@@ -252,13 +272,50 @@ impl DataPlane {
                     to_peers.extend(
                         res.to_peers
                             .into_iter()
-                            .map(|(id, pkts)| (ts_transport::PeerId(id.0), pkts)),
+                            .map(|(id, pkts)| (ts_transport::PeerId(id.0), pkts))
+                            .inspect(|(id, _)| {
+                                self.active_peers.insert(*id, now);
+                            }),
                     );
                 }
+                Subsystem::PeerGc => should_gc = true,
             }
         }
-        let to_peers = self.ur_out.route(to_peers);
 
+        if should_gc {
+            let _span =
+                tracing::trace_span!("peer gc", n_active_peers_pre = self.active_peers.len())
+                    .entered();
+
+            self.active_peers.retain(|id, &mut last_traffic| {
+                let elapsed = now - last_traffic;
+                let keep = elapsed < PEER_EXPIRATION;
+
+                if !keep {
+                    tracing::trace!(peer_id = %id, ?elapsed, "peer expired");
+                }
+
+                keep
+            });
+
+            tracing::trace!(n_active_peers_post = self.active_peers.len());
+
+            // remove so ensure_peer_gc sees there's no pending event and reschedules it
+            self.peer_gc_next = None;
+        }
+
+        let to_peers = self.ur_out.route(to_peers);
+        self.ensure_events(now);
+
+        EventResult { to_peers }
+    }
+
+    fn ensure_events(&mut self, now: Instant) {
+        self.ensure_wg();
+        self.ensure_peer_gc(now);
+    }
+
+    fn ensure_wg(&mut self) {
         if let Some(next) = self.wireguard.next_event()
             && let Some(prev) = self
                 .wg_next
@@ -266,8 +323,21 @@ impl DataPlane {
         {
             prev.cancel();
         }
+    }
 
-        EventResult { to_peers }
+    fn ensure_peer_gc(&mut self, now: Instant) {
+        if self.active_peers.is_empty()
+            && let Some(evt) = self.peer_gc_next.take()
+        {
+            evt.cancel();
+        }
+
+        if !self.active_peers.is_empty() && self.peer_gc_next.is_none() {
+            self.peer_gc_next = Some(self.events.add(
+                TimeRange::new_around(now + Duration::from_secs(10), Duration::from_millis(2500)),
+                Subsystem::PeerGc,
+            ));
+        }
     }
 }
 

--- a/ts_runtime/Cargo.toml
+++ b/ts_runtime/Cargo.toml
@@ -38,7 +38,7 @@ kameo_actors = "0.6"
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
-tokio-stream = { version = "0.1", default-features = false, features = ["time"] }
+tokio-stream = { version = "0.1", default-features = false, features = ["time", "sync"] }
 tracing.workspace = true
 smallvec.workspace = true
 smol_str = "0.3"

--- a/ts_runtime/src/dataplane.rs
+++ b/ts_runtime/src/dataplane.rs
@@ -8,7 +8,9 @@ use kameo::{
     actor::{ActorRef, Spawn},
     message::{Context, Message, StreamMessage},
 };
-use ts_dataplane::async_tokio::{FromOverlay, FromUnderlay, Rx, ToOverlay, ToUnderlay, Tx};
+use ts_dataplane::async_tokio::{
+    ActivePeers, FromOverlay, FromUnderlay, Rx, ToOverlay, ToUnderlay, Tx,
+};
 use ts_disco_protocol::{Packet, Plaintext};
 use ts_packet::PacketMut;
 use ts_transport::{OverlayTransportId, UnderlayTransportId};
@@ -74,7 +76,7 @@ impl kameo::Actor for DataplaneActor {
     type Error = Error;
 
     async fn on_start(env: Self::Args, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
-        let (dataplane, disco, stun) =
+        let (dataplane, disco, stun, active_peers) =
             ts_dataplane::async_tokio::DataPlane::new(env.keys.node_keys.clone());
 
         let dataplane = Arc::new(dataplane);
@@ -91,6 +93,12 @@ impl kameo::Actor for DataplaneActor {
             tokio_stream::wrappers::UnboundedReceiverStream::new(stun)
                 .flat_map(tokio_stream::iter)
                 .map(StunInternal),
+            (),
+            (),
+        );
+
+        slf.attach_stream(
+            tokio_stream::wrappers::WatchStream::new(active_peers),
             (),
             (),
         );
@@ -172,6 +180,33 @@ impl Message<StreamMessage<StunInternal, (), ()>> for DataplaneActor {
             .publish_noretain(IncomingStunMsg(pkt.freeze()))
             .await
             .unwrap();
+    }
+}
+
+impl Message<StreamMessage<ActivePeers, (), ()>> for DataplaneActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: StreamMessage<ActivePeers, (), ()>,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) {
+        let peers = match msg {
+            StreamMessage::Next(pkt) => pkt,
+            StreamMessage::Finished(_) => {
+                // TODO(npry): apply to all stream msg handlers
+                tracing::warn!("active peers stream died, killing dataplane");
+                ctx.stop();
+                return;
+            }
+            StreamMessage::Started(_) => {
+                return;
+            }
+        };
+
+        tracing::debug!(active_peers = ?peers, "new active_peers");
+
+        self.env.publish(peers).await.unwrap();
     }
 }
 


### PR DESCRIPTION
Maintain a HashSet of peers to which we have recently sent underlay traffic. This will decide the set of peers for which we do path discovery.
