### PR TITLE
runtime/registry: fix downcast in register

### DIFF
--- a/ts_runtime/src/env.rs
+++ b/ts_runtime/src/env.rs
@@ -15,7 +15,7 @@ use crate::{
     Error, ErrorKind,
     error::ResultExt,
     registry,
-    registry::{Forward, Registry},
+    registry::{ErasedWeakRef, Forward, Registry},
     retained_bus::RetainedBus,
 };
 
@@ -78,12 +78,13 @@ impl Env {
     /// registered as the canonical actor of type `A`.
     ///
     /// If the return value is `Ok(Some(_))`, this registration replaced an existing registration
-    /// for the same name.
+    /// for the same name. The actor ref is erased, meaning that you must try to downcast it to a
+    /// `WeakActorRef<B>` for some actor type `B` if you need an `ActorRef` to send messages to.
     pub async fn register<A>(
         &self,
         name: Option<SmolStr>,
         slf: &ActorRef<A>,
-    ) -> Result<Option<WeakActorRef<A>>, Error>
+    ) -> Result<Option<ErasedWeakRef>, Error>
     where
         A: kameo::Actor,
     {

--- a/ts_runtime/src/registry.rs
+++ b/ts_runtime/src/registry.rs
@@ -135,22 +135,20 @@ impl<A> Message<Register<A>> for Registry
 where
     A: kameo::Actor + Any,
 {
-    type Reply = Option<WeakActorRef<A>>;
+    type Reply = Option<ErasedWeakRef>;
 
     async fn handle(
         &mut self,
         msg: Register<A>,
         _ctx: &mut Context<Self, Self::Reply>,
-    ) -> Option<WeakActorRef<A>> {
+    ) -> Option<ErasedWeakRef> {
         if let Some(pending) = self.pending_lookups.remove(&msg.id) {
             for sender in pending {
                 drop(sender.send(Ok(Box::new(Some(msg.aref.clone())))));
             }
         }
 
-        let previous = self.actors.insert(msg.id, Box::new(msg.aref))?;
-
-        *previous.downcast().unwrap()
+        self.actors.insert(msg.id, Box::new(msg.aref))
     }
 }
 


### PR DESCRIPTION
The downcast type for the returned actor was incorrect (it was missing an `Option` wrapping) so it always failed when actors were reregistered. Also, don't panic if an actor of a new type is registered for an existing name, just return `None` when the downcast fails.
