### PR TITLE
.github: add concurrency groups to all workflows

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ on:
           # - staging
           - prod
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_TERM_VERBOSE: true

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,6 +16,10 @@ on:
           - staging
           - prod
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: nix flake check

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,6 +21,10 @@ on:
           - 'pypi'
           - 'testpypi'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
None of the five workflows declared `concurrency`, so every push to a PR left the previous run going to completion. With stacked PRs a restack re runs the full matrix on every branch in the stack, and all of it runs on billed larger runners.

For PRs the group keys on head_ref, so a new push preempts the in-flight run. For pushes to main, tags and the nightly cron head_ref is empty and the group falls back to run_id.

Change-Id: Ie0864094e653c824b77ae1231133cb6e6f075a2b


