### PR TITLE
.github/workflows: drop release build on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,11 @@ on:
     branches:
       - main
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
   schedule:
     # Nightly run; execute daily at 06:37 AM UTC on main (default branch).
-    - cron: '37 6 * * *'
+    - cron: "37 6 * * *"
 
   workflow_dispatch:
     inputs:
@@ -40,7 +40,6 @@ env:
 
   prev_rust: &prev_rust 1.94.1
   latest_rust: &latest_rust 1.95.0
-
 
 defaults:
   run:
@@ -123,10 +122,8 @@ jobs:
               $COMMON_FLAGS \
               ${{ case(env.is_windows_gnu == 'true', '--exclude ts_python', '') }}
 
-      # Release builds on Windows specifically take forever: disable them on PRs to speed
-      # the check (the dev build is sufficient to establish that the code compiles)
       - name: Release build (cargo build --release)
-        if: ${{ runner.os != 'Windows' || github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' }}
         run: cargo build $COMMON_FLAGS --release --all-targets
 
       - name: Docs (cargo doc)


### PR DESCRIPTION
They are 60% of the runtime of the CI and will still run on cron.

<!--
Please read [CONTRIBUTING.md](/CONTRIBUTING.md) before submitting a PR.

If this is a significant or breaking change, please add the details to [CHANGELOG.md](/CHANGELOG.md) as part of the PR.

Please link to any relevant issues, e.g., `closes #123`.

If you have used any AI tools to produce this PR, please let us know.
-->
