### PR TITLE
.github/workflows: run windows-gnu on the nightly cron only

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - v*
   pull_request:
+  schedule:
+    # Nightly run; execute daily at 06:37 AM UTC on main (default branch).
+    - cron: "37 6 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -22,6 +25,9 @@ jobs:
 
     strategy:
       matrix:
+        is_pr_or_push:
+          - ${{github.event_name == 'pull_request' || github.event_name == 'push'}}
+
         rust_toolchain:
           - version: 1.95.0
             label: latest
@@ -36,6 +42,11 @@ jobs:
           # macos uses clang, not working yet
           # - triple: aarch64-apple-darwin
           #        runner: macos-26
+
+        exclude:
+          - is_pr_or_push: true
+            build:
+              triple: x86_64-pc-windows-gnu
 
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,11 @@ on:
     branches:
       - main
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
   schedule:
     # Nightly run; execute daily at 06:37 AM UTC on main (default branch).
-    - cron: '37 6 * * *'
+    - cron: "37 6 * * *"
 
   workflow_dispatch:
     inputs:
@@ -40,7 +40,6 @@ env:
 
   prev_rust: &prev_rust 1.94.1
   latest_rust: &latest_rust 1.95.0
-
 
 defaults:
   run:
@@ -74,6 +73,10 @@ jobs:
           - is_pr_or_push: true
             target:
               triple: aarch64-apple-darwin
+          # Same for `*-windows-gnu`
+          - is_pr_or_push: true
+            target:
+              triple: x86_64-pc-windows-gnu
     # The name needs to remain stable for the "Require status checks to pass" feature of our branch
     # protection rules to work, thus the "toolchain.label" field in the matrix. Unfortunately the
     # status check matching on job name doesn't support regexes, just an exact job name match.


### PR DESCRIPTION
On windows, only `-msvc` runs on PRs. Moves `-gnu` to nightly. `c.yml` now also has a nightly schedule.

Removes `test (rust {prev,latest}, x86_64-pc-windows-gnu)` and `build (rust latest, windows-8vcpu)` from PRs.

TODO: update branch protection before submitting this.
