### PR TITLE
KV store: track mutations precisely to avoid false positive notifications

### DIFF
--- a/ts_kv_store/src/index.rs
+++ b/ts_kv_store/src/index.rs
@@ -127,7 +127,7 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
         BaseKey<D>: Clone,
-        BaseValue<D>: Clone,
+        BaseValue<D>: Clone + PartialEq,
         IndexValue<D>: Eq + Hash,
     {
         let mut txn = self.store.begin_transaction(self.owner);
@@ -191,7 +191,7 @@ impl<'store, D: IndexDesc> KvTableIndex<'store, D> {
             &mut dyn Iterator<Item = (&D::Key, &'a BaseKey<D>, &'a mut BaseValue<D>)>,
         ) -> T,
         IndexValue<D>: Eq + Hash + Clone,
-        BaseValue<D>: Clone,
+        BaseValue<D>: Clone + PartialEq,
     {
         let mut txn = self.store.begin_transaction(self.owner);
         let mut txn_table = KvTableTransactionalIndex::<D> { txn: &mut txn };
@@ -318,7 +318,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
         BaseKey<D>: Clone,
-        BaseValue<D>: Clone,
+        BaseValue<D>: Clone + PartialEq,
         IndexValue<D>: Eq + Hash,
     {
         <&mut Self as IndexedOpsMut<_>>::with_mut::<Q, T>(self, key, f, self.txn.owner)
@@ -367,7 +367,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (&D::Key, &BaseKey<D>, &mut BaseValue<D>)>
     where
         IndexValue<D>: Eq + Hash + Clone,
-        BaseValue<D>: Clone,
+        BaseValue<D>: Clone + PartialEq,
     {
         let owner = self.txn.owner;
         IndexedOpsMut::iter_mut(self, owner)
@@ -376,7 +376,7 @@ impl<'guard, 'txn, D: IndexDesc> KvTableTransactionalIndex<'guard, 'txn, D> {
     /// Iterate all the values in a table.
     pub fn iter_base_mut(&mut self) -> impl Iterator<Item = (&BaseKey<D>, &mut BaseValue<D>)>
     where
-        BaseValue<D>: Clone,
+        BaseValue<D>: Clone + PartialEq,
     {
         let owner = self.txn.owner;
         IndexedOpsMut::values_mut(self, owner)
@@ -947,6 +947,59 @@ mod test {
         assert_eq!(index.get("Zara").unwrap(), (1, row("Zara")));
         // Bob was visited but not modified; its index entry must be intact.
         assert_eq!(index.get("Bob").unwrap(), (2, row("Bob")));
+    }
+
+    #[test]
+    fn index_with_mut_without_change_keeps_index_intact() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store.table::<Users>(OWNER).insert(2, row("Bob"));
+
+        store
+            .table_by::<index::Users::name>(OWNER)
+            .with_mut("Alice", |_, v| v.name.len())
+            .unwrap();
+
+        let index = store.table_by::<index::Users::name>(OWNER);
+        assert_eq!(index.len(), 2);
+        assert_eq!(index.get("Alice").unwrap(), (1, row("Alice")));
+        assert_eq!(index.get("Bob").unwrap(), (2, row("Bob")));
+        assert_eq!(store.table::<Users>(OWNER).get(&1), Some(row("Alice")));
+    }
+
+    #[test]
+    fn index_with_iter_mut_without_mutation_keeps_index_intact() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store.table::<Users>(OWNER).insert(2, row("Bob"));
+
+        // Every row is de-indexed as it is yielded and re-indexed when the iterator is dropped,
+        // even though none of them changed.
+        let visited = store
+            .table_by::<index::Users::name>(OWNER)
+            .with_iter_mut(|i| i.count());
+        assert_eq!(visited, 2);
+
+        let index = store.table_by::<index::Users::name>(OWNER);
+        assert_eq!(index.len(), 2);
+        assert_eq!(index.get("Alice").unwrap(), (1, row("Alice")));
+        assert_eq!(index.get("Bob").unwrap(), (2, row("Bob")));
+    }
+
+    #[test]
+    fn index_table_used_directly_supports_with_mut() {
+        let store = KvStore::new();
+        store.table::<Users>(OWNER).insert(1, row("Alice"));
+        store.table::<Users>(OWNER).insert(2, row("Bob"));
+
+        let index_table = store.table::<index::Users::name>(OWNER);
+        assert_eq!(index_table.get("Alice"), Some(1));
+        // Repointing the index entry at the other base row.
+        assert_eq!(
+            index_table.with_mut("Alice", |k| std::mem::replace(k, 2)),
+            Ok(1)
+        );
+        assert_eq!(index_table.get("Alice"), Some(2));
     }
 
     #[test]

--- a/ts_kv_store/src/iter.rs
+++ b/ts_kv_store/src/iter.rs
@@ -102,6 +102,8 @@ impl<'guard, Guard, D: TableDesc, Kind> Drop for TableIterator<'guard, Guard, D,
 
 /// An iterator giving mutable access to values.
 pub struct TableIteratorMut<'guard, Guard: StorageGuardMut<D::Storage> + 'guard, D: TableDesc, Kind>
+where
+    D::Value: PartialEq,
 {
     /// Guard on the KV store's storage (all of it).
     guard: Guard,
@@ -118,7 +120,7 @@ pub struct TableIteratorMut<'guard, Guard: StorageGuardMut<D::Storage> + 'guard,
 impl<'guard, Guard: StorageGuardMut<D::Storage> + 'guard, D: TableDesc, Kind>
     TableIteratorMut<'guard, Guard, D, Kind>
 where
-    D::Value: Clone,
+    D::Value: Clone + PartialEq,
 {
     /// Create an iterator over the table described by `D`.
     pub(crate) fn new(guard: Guard, owner: Owner) -> Self
@@ -152,6 +154,8 @@ where
 
 impl<'guard, Guard: StorageGuardMut<D::Storage>, D: TableDesc, Kind> Drop
     for TableIteratorMut<'guard, Guard, D, Kind>
+where
+    D::Value: PartialEq,
 {
     fn drop(&mut self) {
         let storage = self.guard.storage();
@@ -170,7 +174,7 @@ impl<'guard, Guard: StorageGuardMut<D::Storage>, D: TableDesc, Kind> Drop
 impl<'guard, Guard: StorageGuardMut<D::Storage>, D: TableDesc> Iterator
     for TableIteratorMut<'guard, Guard, D, KeysAndValues>
 where
-    D::Value: Clone,
+    D::Value: Clone + PartialEq,
 {
     type Item = (&'guard D::Key, &'guard mut D::Value);
 
@@ -182,7 +186,7 @@ where
 impl<'guard, Guard: StorageGuardMut<D::Storage>, D: TableDesc> Iterator
     for TableIteratorMut<'guard, Guard, D, Values>
 where
-    D::Value: Clone,
+    D::Value: Clone + PartialEq,
 {
     type Item = &'guard mut D::Value;
 
@@ -350,7 +354,7 @@ impl<'guard, Guard: StorageGuardMut<D::Storage>, D: IndexDesc> Iterator
     for IndexIteratorMut<'guard, Guard, D>
 where
     D::Value: Clone + Hash + Eq,
-    <<D as IndexDesc>::BaseTable as TableDesc>::Value: Clone,
+    <<D as IndexDesc>::BaseTable as TableDesc>::Value: Clone + PartialEq,
 {
     type Item = (
         &'guard D::Key,

--- a/ts_kv_store/src/operations.rs
+++ b/ts_kv_store/src/operations.rs
@@ -425,7 +425,7 @@ pub(crate) trait TabularOpsMut<TableStorage: schema::GeneratedStorage>:
     where
         <Self::TableDesc as TableDesc>::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq + ToOwned<Owned = <Self::TableDesc as TableDesc>::Key>,
-        <Self::TableDesc as TableDesc>::Value: Clone,
+        <Self::TableDesc as TableDesc>::Value: Clone + PartialEq,
     {
         let mut storage = self.write_lock();
         let storage = storage.storage();
@@ -463,7 +463,7 @@ pub(crate) trait TabularOpsMut<TableStorage: schema::GeneratedStorage>:
     where
         Self::WriteLock: 'guard,
         Self::TableDesc: 'guard,
-        <<Self as TabularOpsMut<TableStorage>>::TableDesc as TableDesc>::Value: Clone,
+        <<Self as TabularOpsMut<TableStorage>>::TableDesc as TableDesc>::Value: Clone + PartialEq,
     {
         let guard = self.write_lock();
         TableIteratorMut::<'guard, Self::WriteLock, Self::TableDesc, iter::KeysAndValues>::new(
@@ -478,7 +478,7 @@ pub(crate) trait TabularOpsMut<TableStorage: schema::GeneratedStorage>:
     where
         Self::WriteLock: 'guard,
         Self::TableDesc: 'guard,
-        <<Self as TabularOpsMut<TableStorage>>::TableDesc as TableDesc>::Value: Clone,
+        <<Self as TabularOpsMut<TableStorage>>::TableDesc as TableDesc>::Value: Clone + PartialEq,
     {
         let guard = self.write_lock();
         TableIteratorMut::<'guard, Self::WriteLock, Self::TableDesc, iter::Values>::new(
@@ -531,7 +531,7 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
         Q: ?Sized + Hash + Eq,
         BaseKey<Self::IndexDesc>: Clone,
         IndexValue<Self::IndexDesc>: Hash + Eq,
-        BaseValue<Self::IndexDesc>: Clone,
+        BaseValue<Self::IndexDesc>: Clone + PartialEq,
     {
         let mut storage = self.write_lock();
         let storage = storage.storage();
@@ -591,7 +591,7 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
         Self::IndexDesc: 'guard,
         IndexValue<Self::IndexDesc>: Hash + Eq,
         BaseKey<Self::IndexDesc>: Clone,
-        BaseValue<Self::IndexDesc>: Clone,
+        BaseValue<Self::IndexDesc>: Clone + PartialEq,
     {
         let guard = self.write_lock();
         IndexIteratorMut::<'guard, Self::WriteLock, Self::IndexDesc>::new(guard, owner)
@@ -608,7 +608,7 @@ pub(crate) trait IndexedOpsMut<TableStorage: schema::GeneratedStorage>:
     >
     where
         Self::WriteLock: 'guard,
-        BaseValue<Self::IndexDesc>: Clone,
+        BaseValue<Self::IndexDesc>: Clone + PartialEq,
     {
         let guard = self.write_lock();
         TableIteratorMut::<

--- a/ts_kv_store/src/pub_sub.rs
+++ b/ts_kv_store/src/pub_sub.rs
@@ -813,6 +813,13 @@ mod tests {
     use super::*;
     use crate::{Error, storage::SinValue, store};
 
+    /// A value type with an indexed field, for exercising mutation through an index.
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct Row {
+        pub name: String,
+        pub count: u32,
+    }
+
     store!(
         kvs: {
             Count(u64; OWNER),
@@ -821,6 +828,7 @@ mod tests {
         tables: {
             Items(u32 => String; OWNER; notify(Clone)),
             Plain(u32 => String; OWNER),
+            Rows(u32 => Row; OWNER; index(name: String); notify(Clone)),
         }
     );
 
@@ -918,6 +926,40 @@ mod tests {
                     ItemsKind::TableRemove(ks)
                 }
                 Event::TableClear => ItemsKind::TableClear,
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    /// A comparable projection of a `Rows` notification.
+    #[derive(Debug, PartialEq)]
+    enum RowsKind {
+        KeyUpsert(u32, Row),
+        KeyRemove(u32),
+        TableUpsert(Vec<u32>),
+        TableRemove(Vec<u32>),
+        TableClear,
+    }
+
+    impl From<&Notification> for RowsKind {
+        fn from(n: &Notification) -> RowsKind {
+            let Notification::Rows(e) = n else {
+                panic!();
+            };
+            match e {
+                Event::KeyUpsert(k, v) => RowsKind::KeyUpsert(*k, v.clone()),
+                Event::KeyRemove(k) => RowsKind::KeyRemove(*k),
+                Event::TableUpsert(ks) => {
+                    let mut ks = ks.clone();
+                    ks.sort();
+                    RowsKind::TableUpsert(ks)
+                }
+                Event::TableRemove(ks) => {
+                    let mut ks = ks.clone();
+                    ks.sort();
+                    RowsKind::TableRemove(ks)
+                }
+                Event::TableClear => RowsKind::TableClear,
                 _ => unreachable!(),
             }
         }
@@ -2405,5 +2447,406 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![CountKind::Upsert(8)]
         );
+    }
+
+    /// Seed `Rows` with `(key, name)` pairs (each row's `count` starts at 0) in a committed
+    /// transaction. Names must be distinct, since `name` is an index key.
+    fn seed_rows(store: &KvStore, rows: &[(u32, &str)]) {
+        let mut txn = store.begin_transaction(OWNER);
+        {
+            let mut t = txn.table::<Rows>();
+            for (k, name) in rows {
+                t.insert(
+                    *k,
+                    Row {
+                        name: (*name).to_owned(),
+                        count: 0,
+                    },
+                );
+            }
+        }
+        txn.commit().unwrap();
+    }
+
+    #[test]
+    fn e2e_with_mut_without_change_notifies_nothing() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
+        seed_items(&store, &[1, 2]);
+        rec.reset();
+
+        // The closure only reads through its mutable reference.
+        assert_eq!(store.table::<Items>(OWNER).with_mut(&1, |v| v.len()), Ok(2));
+
+        assert!(rec.notifications_for(sub).is_empty());
+        // A transaction with nothing to report doesn't reach the notifier at all.
+        assert_eq!(rec.total_calls(), 0);
+        assert_eq!(store.table::<Items>(OWNER).get(&1), Some("v1".to_owned()));
+    }
+
+    #[test]
+    fn e2e_with_mut_writing_same_value_notifies_nothing() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
+        seed_items(&store, &[1]);
+        rec.reset();
+
+        // Written to, but with a value equal to the one already there.
+        store
+            .table::<Items>(OWNER)
+            .with_mut(&1, |v| *v = "v1".to_owned())
+            .unwrap();
+
+        assert!(rec.notifications_for(sub).is_empty());
+        assert_eq!(rec.total_calls(), 0);
+    }
+
+    #[test]
+    fn e2e_with_mut_changing_value_still_notifies() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
+        seed_items(&store, &[1]);
+        rec.reset();
+
+        store
+            .table::<Items>(OWNER)
+            .with_mut(&1, |v| v.push('!'))
+            .unwrap();
+
+        assert_eq!(
+            rec.notifications_for(sub)
+                .iter()
+                .map(ItemsKind::from)
+                .collect::<Vec<_>>(),
+            vec![ItemsKind::KeyUpsert(1, "v1!".to_owned())]
+        );
+    }
+
+    #[test]
+    fn e2e_mutate_and_revert_in_one_txn_notifies_nothing() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
+        seed_items(&store, &[1]);
+        rec.reset();
+
+        // Only the net effect of a transaction is notifiable, so a change which is undone before
+        // the commit is not reported.
+        let mut txn = store.begin_transaction(OWNER);
+        {
+            let mut t = txn.table::<Items>();
+            t.with_mut(&1, |v| v.push('!'));
+            t.with_mut(&1, |v| {
+                v.pop();
+            });
+        }
+        txn.commit().unwrap();
+
+        assert!(rec.notifications_for(sub).is_empty());
+        assert_eq!(store.table::<Items>(OWNER).get(&1), Some("v1".to_owned()));
+    }
+
+    #[test]
+    fn e2e_iter_mut_without_mutation_notifies_nothing() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
+        seed_items(&store, &[1, 2, 3]);
+        rec.reset();
+
+        let mut txn = store.begin_transaction(OWNER);
+        {
+            let mut t = txn.table::<Items>();
+            // Every row is visited (and so de-indexed and re-indexed), but none is changed.
+            assert_eq!(t.iter_mut().count(), 3);
+        }
+        txn.commit().unwrap();
+
+        assert!(rec.notifications_for(sub).is_empty());
+        assert_eq!(rec.total_calls(), 0);
+    }
+
+    #[test]
+    fn e2e_iter_mut_notifies_only_mutated_keys() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
+        seed_items(&store, &[1, 2, 3]);
+        rec.reset();
+
+        let mut txn = store.begin_transaction(OWNER);
+        {
+            let mut t = txn.table::<Items>();
+            for (k, v) in t.iter_mut() {
+                if *k == 2 {
+                    v.push('!');
+                }
+            }
+        }
+        txn.commit().unwrap();
+
+        // The iterator handed out a `&mut` for all three rows, but only key 2 changed.
+        assert_eq!(
+            rec.notifications_for(sub)
+                .iter()
+                .map(ItemsKind::from)
+                .collect::<Vec<_>>(),
+            vec![ItemsKind::KeyUpsert(2, "v2!".to_owned())]
+        );
+    }
+
+    #[test]
+    fn e2e_values_mut_without_mutation_notifies_nothing() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
+        seed_items(&store, &[1, 2]);
+        rec.reset();
+
+        let mut txn = store.begin_transaction(OWNER);
+        {
+            let mut t = txn.table::<Items>();
+            let total: usize = t.values_mut().map(|v| v.len()).sum();
+            assert_eq!(total, 4);
+        }
+        txn.commit().unwrap();
+
+        assert!(rec.notifications_for(sub).is_empty());
+        assert_eq!(rec.total_calls(), 0);
+    }
+
+    #[test]
+    fn e2e_no_op_mutation_does_not_mask_other_keys() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
+        seed_items(&store, &[1, 2]);
+        rec.reset();
+
+        let mut txn = store.begin_transaction(OWNER);
+        {
+            let mut t = txn.table::<Items>();
+            t.with_mut(&1, |v| v.len());
+            t.with_mut(&2, |v| v.push('!'));
+        }
+        txn.commit().unwrap();
+
+        // Filtering key 1 out must leave key 2's upsert alone (and, since only one key remains,
+        // must still report it as a single-key event).
+        assert_eq!(
+            rec.notifications_for(sub)
+                .iter()
+                .map(ItemsKind::from)
+                .collect::<Vec<_>>(),
+            vec![ItemsKind::KeyUpsert(2, "v2!".to_owned())]
+        );
+    }
+
+    #[test]
+    fn e2e_no_op_mutation_with_remove_notifies_only_remove() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
+        seed_items(&store, &[1, 2]);
+        rec.reset();
+
+        let mut txn = store.begin_transaction(OWNER);
+        {
+            let mut t = txn.table::<Items>();
+            t.with_mut(&1, |v| v.len());
+            t.remove(&2);
+        }
+        txn.commit().unwrap();
+
+        assert_eq!(
+            rec.notifications_for(sub)
+                .iter()
+                .map(ItemsKind::from)
+                .collect::<Vec<_>>(),
+            vec![ItemsKind::KeyRemove(2)]
+        );
+    }
+
+    #[test]
+    fn e2e_no_op_mutation_of_removed_key_notifies_only_remove() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
+        seed_items(&store, &[1, 2]);
+        rec.reset();
+
+        // The same key is mutated and then removed; the removal wins.
+        let mut txn = store.begin_transaction(OWNER);
+        {
+            let mut t = txn.table::<Items>();
+            t.with_mut(&1, |v| v.push('!'));
+            t.remove(&1);
+        }
+        txn.commit().unwrap();
+
+        assert_eq!(
+            rec.notifications_for(sub)
+                .iter()
+                .map(ItemsKind::from)
+                .collect::<Vec<_>>(),
+            vec![ItemsKind::KeyRemove(1)]
+        );
+    }
+
+    #[test]
+    fn e2e_no_op_mutation_of_watched_key_notifies_nothing() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store
+            .table::<Items>(OWNER)
+            .subscribe_key(subscriber, 1)
+            .unwrap();
+        seed_items(&store, &[1, 2]);
+        rec.reset();
+
+        let mut txn = store.begin_transaction(OWNER);
+        {
+            let mut t = txn.table::<Items>();
+            t.with_mut(&1, |v| v.len());
+            t.with_mut(&2, |v| v.push('!'));
+        }
+        txn.commit().unwrap();
+
+        // The watched key didn't change, and the key which did change isn't watched.
+        assert!(rec.notifications_for(sub).is_empty());
+    }
+
+    #[test]
+    fn e2e_insert_of_identical_value_still_notifies() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
+        seed_items(&store, &[1]);
+        rec.reset();
+
+        // Precision applies to mutation through a `&mut`, not to writes: an insert is always
+        // reported, even if it writes the value which was already there.
+        store.table::<Items>(OWNER).insert(1, "v1".to_owned());
+
+        assert_eq!(
+            rec.notifications_for(sub)
+                .iter()
+                .map(ItemsKind::from)
+                .collect::<Vec<_>>(),
+            vec![ItemsKind::KeyUpsert(1, "v1".to_owned())]
+        );
+    }
+
+    #[test]
+    fn e2e_no_op_mutation_after_clear_still_notifies() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.table::<Items>(OWNER).subscribe(subscriber).unwrap();
+        seed_items(&store, &[1]);
+        rec.reset();
+
+        let mut txn = store.begin_transaction(OWNER);
+        {
+            let mut t = txn.table::<Items>();
+            t.clear();
+            t.insert(2, "b".to_owned());
+            t.with_mut(&2, |v| v.len());
+        }
+        txn.commit().unwrap();
+
+        // Clearing the table replaces its contents wholesale, so every surviving key is reported
+        // regardless of what the mutable-reference tracking recorded.
+        assert_eq!(
+            rec.notifications_for(sub)
+                .iter()
+                .map(ItemsKind::from)
+                .collect::<Vec<_>>(),
+            vec![ItemsKind::TableClear, ItemsKind::TableUpsert(vec![2])]
+        );
+    }
+
+    #[test]
+    fn e2e_index_with_mut_without_change_notifies_nothing() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.table::<Rows>(OWNER).subscribe(subscriber).unwrap();
+        seed_rows(&store, &[(1, "a"), (2, "b")]);
+        rec.reset();
+
+        assert_eq!(
+            store
+                .table_by::<index::Rows::name>(OWNER)
+                .with_mut("a", |k, v| (*k, v.count)),
+            Ok((1, 0))
+        );
+
+        assert!(rec.notifications_for(sub).is_empty());
+        assert_eq!(rec.total_calls(), 0);
+    }
+
+    #[test]
+    fn e2e_index_with_mut_changing_value_notifies_base_table() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.table::<Rows>(OWNER).subscribe(subscriber).unwrap();
+        seed_rows(&store, &[(1, "a"), (2, "b")]);
+        rec.reset();
+
+        store
+            .table_by::<index::Rows::name>(OWNER)
+            .with_mut("a", |_, v| v.count += 1)
+            .unwrap();
+
+        assert_eq!(
+            rec.notifications_for(sub)
+                .iter()
+                .map(RowsKind::from)
+                .collect::<Vec<_>>(),
+            vec![RowsKind::KeyUpsert(
+                1,
+                Row {
+                    name: "a".to_owned(),
+                    count: 1,
+                }
+            )]
+        );
+    }
+
+    #[test]
+    fn e2e_index_iter_mut_without_mutation_notifies_nothing() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.table::<Rows>(OWNER).subscribe(subscriber).unwrap();
+        seed_rows(&store, &[(1, "a"), (2, "b")]);
+        rec.reset();
+
+        // Iterating an index takes its mutable references via a different path (`Table::get_mut`)
+        // to the one `iter_mut` on a plain table uses.
+        let visited = store
+            .table_by::<index::Rows::name>(OWNER)
+            .with_iter_mut(|it| it.count());
+        assert_eq!(visited, 2);
+
+        assert!(rec.notifications_for(sub).is_empty());
+        assert_eq!(rec.total_calls(), 0);
     }
 }

--- a/ts_kv_store/src/raw.rs
+++ b/ts_kv_store/src/raw.rs
@@ -369,7 +369,7 @@ impl<D: schema::TableDesc> KvTable<'_, D> {
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
-        D::Value: Clone,
+        D::Value: Clone + PartialEq,
     {
         let mut txn = self.store.begin_transaction(self.owner);
         let mut txn_table = KvTableTransactional::<D> { txn: &mut txn };
@@ -413,7 +413,7 @@ impl<D: schema::TableDesc> KvTable<'_, D> {
     pub fn with_iter_mut<F, T>(&self, mut f: F) -> T
     where
         F: for<'a> FnMut(&mut dyn Iterator<Item = (&'a D::Key, &'a mut D::Value)>) -> T,
-        D::Value: Clone,
+        D::Value: Clone + PartialEq,
     {
         let mut txn = self.store.begin_transaction(self.owner);
         let mut txn_table = KvTableTransactional::<D> { txn: &mut txn };

--- a/ts_kv_store/src/schema.rs
+++ b/ts_kv_store/src/schema.rs
@@ -114,6 +114,10 @@ pub trait TableDesc: Sized + 'static {
     ) -> <Self::Storage as GeneratedStorage>::Notification;
     /// Create a value for a notification, possibly by cloning `value`.
     fn clone_value_for_notification(value: &Self::Value) -> Self::NotificationValue;
+
+    /// Compare two references to this table's value type, returns `true` if the value type impls
+    /// `PartialEq` and the values are equal. **Panics** if `Self::Value` does not impl `PartialEq`.
+    fn value_eq(a: &Self::Value, b: &Self::Value) -> bool;
 }
 
 /// Similar to `TableDesc::get_table_mut`, but allows for getting two different tables at one time.
@@ -352,6 +356,8 @@ macro_rules! store {
                 fn clone_value_for_notification(_value: &Self::Value) -> Self::NotificationValue {
                     $crate::table_notification_clone_value!(_value $(; notify($notif))?)
                 }
+
+                $crate::value_eq!(Self::Value);
             }
 
             $(
@@ -375,12 +381,15 @@ macro_rules! store {
                         unreachable!();
                     }
                     fn clone_value_for_notification(_value: &Self::Value) -> Self::NotificationValue {}
+
+                    $crate::value_eq!(Self::Value);
                 }
 
                 impl $crate::schema::IndexDesc for index::$name::$field {
                     type BaseTable = $name;
                 }
             )*
+
         )*)?
 
         /// Macro-generated storage for all tabular data.
@@ -607,6 +616,39 @@ macro_rules! on_insert_each {
             } else {
                 $self.$field.set_poisoned($txn_id);
             }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! value_eq {
+    ($t:ty) => {
+        fn value_eq(a: &$t, b: &$t) -> bool {
+            // Use the 'autoref specialization' trick (https://github.com/dtolnay/case-studies/tree/master/autoref-specialization)
+            // to compare values if possible and panic if not. Panicking is safe here because
+            // this method is only called for possibly mutated values, and values can only be
+            // mutated if they impl `PartialEq`.
+            #[allow(dead_code)]
+            trait HasEq {
+                fn veq(&self, other: &Self) -> bool;
+            }
+            #[allow(dead_code)]
+            trait MaybeEq {
+                fn veq(&self, other: Self) -> bool;
+            }
+            impl<T: core::cmp::PartialEq> HasEq for T {
+                fn veq(&self, other: &Self) -> bool {
+                    self == other
+                }
+            }
+            impl<T> MaybeEq for &T {
+                fn veq(&self, _other: Self) -> bool {
+                    unreachable!();
+                }
+            }
+
+            a.veq(b)
         }
     };
 }

--- a/ts_kv_store/src/storage.rs
+++ b/ts_kv_store/src/storage.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::{
     Error, Notifier, Owner, Result,
     pub_sub::{Notifications, Subscriptions, WatchedEvent},
-    schema::{self, IndexStorage},
+    schema::{self, IndexStorage, TableDesc},
     transactions::TxnId,
 };
 
@@ -294,6 +294,17 @@ impl<T> VersionedValue<T> {
         }
     }
 
+    fn was_mutated<D: TableDesc<Value = T>>(&self) -> bool {
+        if self.slot_a.is_none() || self.slot_b.is_none() {
+            return false;
+        }
+
+        !D::value_eq(
+            &self.slot_a.as_ref().unwrap().1,
+            &self.slot_b.as_ref().unwrap().1,
+        )
+    }
+
     pub(crate) fn get(&self, id: TxnId) -> Option<&T> {
         // This could be expressed more simply with a match, but that doesn't work for `get_mut` because
         // of mutable borrows. Since the functions do the same thing, I use the more complex code
@@ -539,9 +550,7 @@ pub struct Table<D: schema::TableDesc, I> {
     data: HashMap<D::Key, VersionedValue<D::Value>>,
     /// A mask of deleted rows in the table. Should be checked before reading from `data`.
     delete_mask: DeleteMask<D::Key, D::Value>,
-    /// A list of keys modified (includes inserts, but not deletes) by the given transaction.
-    ///
-    /// Can be an over-approximation, but not an under-approximation.
+    /// Keys modified (includes inserts, but not deletes) by the given transaction.
     modified: Option<TxnMutations<D::Key>>,
     /// A flag indicating if the table has become inconsistent.
     ///
@@ -598,7 +607,7 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
             "Found mismatched modified set to GC"
         );
 
-        for k in &modified.keys {
+        for k in modified.keys.iter().chain(&modified.ref_keys) {
             if let Some(value) = self.data.get_mut(k) {
                 value.gc_txn(txn_id);
 
@@ -650,9 +659,16 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
         txn_id: TxnId,
         collect_notifications: bool,
     ) -> HashMap<D::Key, WatchedEvent<D::NotificationValue>> {
-        let modified = self.modified.take().map(|m| {
+        let modified = self.modified.take().and_then(|mut m| {
             assert_eq!(m.txn_id, txn_id);
-            m.keys
+            // The modified set is only used for notifications, so don't pay for filtering the
+            // mutable refs if there is nobody to notify.
+            if !collect_notifications {
+                return None;
+            }
+            self.filter_mutated_refs(&mut m.ref_keys);
+            m.keys.extend(m.ref_keys);
+            Some(m.keys)
         });
 
         match std::mem::take(&mut self.delete_mask) {
@@ -743,6 +759,28 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
         }
     }
 
+    /// Takes a set of keys which may have been mutated and removes any keys where the values are unchanged
+    /// in the most recent transaction.
+    fn filter_mutated_refs(&self, refs: &mut HashSet<D::Key>) {
+        match &self.delete_mask {
+            DeleteMask::None => {}
+            DeleteMask::All(..) => {
+                refs.clear();
+                return;
+            }
+            DeleteMask::Some(_, removed_keys) => {
+                refs.retain(|k| !removed_keys.contains(k));
+            }
+        }
+
+        refs.retain(|k| {
+            self.data
+                .get(k)
+                .map(|vv| vv.was_mutated::<D>())
+                .unwrap_or(false)
+        });
+    }
+
     pub(crate) fn len(&self, txn_id: TxnId) -> usize {
         match &self.delete_mask {
             DeleteMask::None => self.iter_data(txn_id).count(),
@@ -787,8 +825,12 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
         key: &D::Key,
         txn_id: TxnId,
         max_committed_id: TxnId,
-    ) {
-        record_mutation(&mut self.modified, key, txn_id, max_committed_id);
+    ) where
+        // Required because committing a recorded key compares values using `D::value_eq`, which
+        // panics for value types without `PartialEq`.
+        D::Value: PartialEq,
+    {
+        record_mut_ref(&mut self.modified, key, txn_id, max_committed_id);
     }
 
     /// Get a mutable iterator over the table. Does not keep indexes up to date, nor record mutations.
@@ -840,10 +882,10 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
-        D::Value: Clone,
+        D::Value: Clone + PartialEq,
     {
         let value = get_from_table_mut::<D, Q>(&mut self.delete_mask, &mut self.data, key, txn_id)?;
-        record_mutation(&mut self.modified, key, txn_id, max_committed_id);
+        record_mut_ref(&mut self.modified, key, txn_id, max_committed_id);
         self.indexes.on_remove(value, txn_id, max_committed_id);
 
         Some(value)
@@ -859,10 +901,12 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
-        D::Value: Clone,
+        D::Value: Clone + PartialEq,
     {
         let value = get_from_table_mut::<D, Q>(&mut self.delete_mask, &mut self.data, key, txn_id)?;
-        record_mutation(&mut self.modified, key, txn_id, max_committed_id);
+        // Recorded before calling `f` so that if `f` panics, the (already cloned) value is still
+        // rolled back by `gc_txn`.
+        record_mut_ref(&mut self.modified, key, txn_id, max_committed_id);
         self.indexes.on_remove(value, txn_id, max_committed_id);
         let result = f(value);
         self.indexes.on_insert(key, value, txn_id, max_committed_id);
@@ -982,6 +1026,30 @@ where
 struct TxnMutations<K> {
     txn_id: TxnId,
     keys: HashSet<K>,
+    // Keys where we've returned a mutable reference to that key to the user. We don't know for sure
+    // if the corresponding value was modified, so we'll check at commit time for notifications.
+    // For indexing, we'll just assume they've been modified. For rollback, we need to rollback
+    // whether or not the value was mutated because we will have cloned the value in any case.
+    ref_keys: HashSet<K>,
+}
+
+fn with_mutations<K>(
+    modified: &mut Option<TxnMutations<K>>,
+    txn_id: TxnId,
+    max_committed_id: TxnId,
+    f: impl FnOnce(&mut TxnMutations<K>),
+) {
+    if txn_id == max_committed_id {
+        return;
+    }
+
+    let modified = modified.get_or_insert_with(|| TxnMutations {
+        txn_id,
+        keys: HashSet::new(),
+        ref_keys: HashSet::new(),
+    });
+    assert_eq!(modified.txn_id, txn_id);
+    f(modified);
 }
 
 fn record_mutation<K, Q>(
@@ -993,16 +1061,23 @@ fn record_mutation<K, Q>(
     K: Borrow<Q> + Hash + Eq,
     Q: ?Sized + Hash + Eq + ToOwned<Owned = K>,
 {
-    if txn_id == max_committed_id {
-        return;
-    }
-
-    let modified = modified.get_or_insert_with(|| TxnMutations {
-        txn_id,
-        keys: HashSet::new(),
+    with_mutations(modified, txn_id, max_committed_id, |m| {
+        m.keys.insert(key.to_owned());
     });
-    assert_eq!(modified.txn_id, txn_id);
-    modified.keys.insert(key.to_owned());
+}
+
+fn record_mut_ref<K, Q>(
+    modified: &mut Option<TxnMutations<K>>,
+    key: &Q,
+    txn_id: TxnId,
+    max_committed_id: TxnId,
+) where
+    K: Borrow<Q> + Hash + Eq,
+    Q: ?Sized + Hash + Eq + ToOwned<Owned = K>,
+{
+    with_mutations(modified, txn_id, max_committed_id, |m| {
+        m.ref_keys.insert(key.to_owned());
+    });
 }
 
 /// Iterate the key-value pairs in a table.
@@ -1059,7 +1134,7 @@ pub(crate) struct TableIteratorMut<'a, D: schema::TableDesc, I> {
 impl<'a, D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Iterator
     for TableIteratorMut<'a, D, I>
 where
-    D::Value: Clone,
+    D::Value: Clone + PartialEq,
 {
     type Item = (&'a D::Key, &'a mut D::Value);
 

--- a/ts_kv_store/src/transactions.rs
+++ b/ts_kv_store/src/transactions.rs
@@ -377,7 +377,7 @@ impl<'guard, D: TableDesc> KvTableTransactional<'guard, '_, D> {
     where
         D::Key: Borrow<Q>,
         Q: ?Sized + Hash + Eq + ToOwned<Owned = D::Key>,
-        D::Value: Clone,
+        D::Value: Clone + PartialEq,
     {
         <&mut Self as TabularOpsMut<_>>::with_mut(self, key, f, self.txn.owner)
     }
@@ -409,7 +409,7 @@ impl<'guard, D: TableDesc> KvTableTransactional<'guard, '_, D> {
     /// Iterate all the key/value pairs in a table.
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (&D::Key, &mut D::Value)>
     where
-        D::Value: Clone,
+        D::Value: Clone + PartialEq,
     {
         let owner = self.txn.owner;
         TabularOpsMut::iter_mut(self, owner)
@@ -418,7 +418,7 @@ impl<'guard, D: TableDesc> KvTableTransactional<'guard, '_, D> {
     /// Iterate all the values in a table.
     pub fn values_mut(&mut self) -> impl Iterator<Item = &mut D::Value>
     where
-        D::Value: Clone,
+        D::Value: Clone + PartialEq,
     {
         let owner = self.txn.owner;
         TabularOpsMut::values_mut(self, owner)
@@ -1071,6 +1071,59 @@ mod test {
     }
 
     #[test]
+    fn txn_no_op_with_mut_commit_leaves_value_unchanged() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "a".to_owned());
+
+        let mut txn = store.begin_transaction(OWNER);
+        assert_eq!(txn.table::<Items>().with_mut(&"k", |v| v.len()), Some(1));
+        txn.commit().unwrap();
+
+        assert_eq!(store.table::<Items>(OWNER).get("k"), Some("a".to_owned()));
+    }
+
+    #[test]
+    fn txn_no_op_with_mut_then_rollback_preserves_value() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "a".to_owned());
+
+        // Take a mutable reference to the row but change nothing, then roll back.
+        {
+            let mut txn = store.begin_transaction(OWNER);
+            txn.table::<Items>().with_mut(&"k", |_| {});
+        }
+        assert_eq!(store.table::<Items>(OWNER).get("k"), Some("a".to_owned()));
+
+        // A second rolled-back transaction, this one writing to the same row.
+        {
+            let mut txn = store.begin_transaction(OWNER);
+            txn.table::<Items>().insert("k", "b".to_owned());
+        }
+
+        // Neither transaction committed, so the row must still hold its committed value.
+        assert_eq!(store.table::<Items>(OWNER).get("k"), Some("a".to_owned()));
+    }
+
+    #[test]
+    fn txn_no_op_iter_mut_then_rollback_preserves_value() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "a".to_owned());
+
+        {
+            let mut txn = store.begin_transaction(OWNER);
+            assert_eq!(txn.table::<Items>().iter_mut().count(), 1);
+        }
+        assert_eq!(store.table::<Items>(OWNER).get("k"), Some("a".to_owned()));
+
+        {
+            let mut txn = store.begin_transaction(OWNER);
+            txn.table::<Items>().insert("k", "b".to_owned());
+        }
+
+        assert_eq!(store.table::<Items>(OWNER).get("k"), Some("a".to_owned()));
+    }
+
+    #[test]
     fn txn_table_iter_keys_cloned_empty() {
         let store = KvStore::new();
         let mut txn = store.begin_transaction(OWNER);
@@ -1593,6 +1646,27 @@ mod test {
 
         // The panicked transaction must have rolled back to the pre-transaction value.
         assert_eq!(store.get::<Count>(OWNER), Some(1));
+    }
+
+    #[test]
+    fn panic_in_with_mut_rolls_back() {
+        let store = KvStore::new();
+        store.table::<Items>(OWNER).insert("k", "a".to_owned());
+
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut txn = store.begin_transaction(OWNER);
+            txn.table::<Items>().with_mut(&"k", |v| {
+                *v = "b".to_owned();
+                panic!();
+            });
+        }))
+        .unwrap_err();
+
+        // The mutation must be rolled back, both for the store itself and for the next
+        // transaction (which is handed the same transaction id as the panicked one).
+        assert_eq!(store.table::<Items>(OWNER).get("k"), Some("a".to_owned()));
+        let mut txn = store.begin_transaction(OWNER);
+        assert_eq!(txn.table::<Items>().get(&"k"), Some("a".to_owned()));
     }
 
     #[test]


### PR DESCRIPTION
cc #207

Just like the commit title says. Also requires that for mutating operations, the value type implements `PartialEq`.

AI decl: I used Claude to generate tests and have reviewed the generated code.