### PR TITLE
.github/actions/setup-rust: stop caching /bin

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -71,3 +71,4 @@ runs:
         key: ${{ inputs.builder-triple }}-${{ inputs.toolchain-version }}
         cache-workspace-crates: true
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        cache-bin: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,10 +150,10 @@ jobs:
         name: binstall
         uses: cargo-bins/cargo-binstall@dc19f1e48450eefe5a29b8da6c6b00a87d730b37 #v1.18.1
       - name: Install cargo-deny
-        run: command -v cargo-deny || cargo binstall --no-confirm cargo-deny
+        run: command -v cargo-deny || cargo binstall --no-confirm --force cargo-deny
       - &cargo_ws
         name: Install cargo-workspaces
-        run: command -v cargo-workspaces || cargo binstall --no-confirm cargo-workspaces
+        run: command -v cargo-workspaces || cargo binstall --no-confirm --force cargo-workspaces
       - name: Check for unused dependencies (cargo machete)
         uses: bnjbvr/cargo-machete@main
         with:


### PR DESCRIPTION
rust-cache prunes bin/ on save by default. This disables it.

<!--
Please read [CONTRIBUTING.md](/CONTRIBUTING.md) before submitting a PR.

If this is a significant or breaking change, please add the details to [CHANGELOG.md](/CHANGELOG.md) as part of the PR.

Please link to any relevant issues, e.g., `closes #123`.

If you have used any AI tools to produce this PR, please let us know.
-->
