### PR TITLE
ts_runtime: control runner should wait for DialerActor to register

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ ts_python/python/tailscale/*.so
 *.dll
 *.lib
 tailscale.h
+__pycache__

--- a/ts_runtime/src/control_runner.rs
+++ b/ts_runtime/src/control_runner.rs
@@ -456,7 +456,7 @@ impl Message<StreamMessage<Arc<StateUpdate>, (), ()>> for ControlRunner {
                     UpdateDialPlan {
                         dial_plan: dial_plan.clone(),
                     },
-                    false,
+                    true,
                 )
                 .await
                 .unwrap()


### PR DESCRIPTION
Without this, the following `.unwrap()` panics with an `ActorGone` error.

Also adds `__pycache__` directories to `.gitignore`.
