### PR TITLE
.github/workflows: pin action bnjbvr/cargo-machete to v0.9.2 commit sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         name: Install cargo-workspaces
         run: command -v cargo-workspaces || cargo binstall --no-confirm --force cargo-workspaces
       - name: Check for unused dependencies (cargo machete)
-        uses: bnjbvr/cargo-machete@main
+        uses: bnjbvr/cargo-machete@ac30a525c0a8d163a92d727b3ff079ee3f6ecb08 # v0.9.2
         with:
           args: "--with-metadata"
       - name: Dependency audit (cargo deny)


### PR DESCRIPTION
Pin an unpinned ci dependency bnjbvr/cargo-machete to v0.9.2. Previously this action would track the main branch and use latest changes published there resulting in the potential for builds of the same source to drift as that dependency updated. Pinning makes the relationship explicit and prevents that.

Because the current dependency is pinned to `main` this change will revert the version of this action back by a number of commits. This seems preferred over fixing the action to a floating version like the current main commit.

Fixes #328

Change-Id: I36965a466d945a04cea96843b26b04296a6a6964