### PR TITLE
ts_tunnel: fix handshake DoS when initiator receives invalid responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Put changes for the upcoming release here!
   Private keys continue to have serde implementations for serializing to/from disk.
 - **Security** (ts_elixir): don't print fields of the Keystate struct when inspected.
   Previously a GenServer crash would print the keystate in logs.
+- **Security** (ts_tunnel): fix DoS in handshake logic, where an attacker could force
+  handshakes to fail by racing an invalid response to the initiator. (#334)
 - Fixed (ts_keys): Return an error when parsing a key string with invalid hex digits,
   rather than panic.
 - Fixed(ts_tunnel): adjust session rotation logic to match the spec (#286)

--- a/ts_tunnel/src/handshake.rs
+++ b/ts_tunnel/src/handshake.rs
@@ -194,9 +194,10 @@ impl Handshake {
         cookies: &MACReceiver,
         now: Instant,
     ) -> Option<BidiSession> {
-        let (mut sent_handshake, timeout, _) = self.take_initiated()?;
+        let (mut sent_handshake, timeout, mac) = self.take_initiated()?;
 
         if !cookies.verify_macs(packet.as_bytes()) {
+            *self = Handshake::Initiated(sent_handshake, timeout, mac);
             return None;
         };
 
@@ -208,6 +209,7 @@ impl Handshake {
                 Ok(session_keys) => session_keys,
                 Err(handshake) => {
                     sent_handshake.noise = handshake;
+                    *self = Handshake::Initiated(sent_handshake, timeout, mac);
                     return None;
                 }
             };
@@ -286,7 +288,7 @@ mod tests {
         let mut scheduler = Scheduler::default();
         let timeout = scheduler.add(
             ts_time::TimeRange::new_around(Instant::now(), std::time::Duration::from_secs(1000)),
-            crate::Event::HandshakeTimeout(crate::config::PeerId(0)),
+            Event::HandshakeTimeout(crate::config::PeerId(0)),
         );
         let mut a_handshake = Handshake::Initiated(a_handshake, timeout, handshake_mac);
 
@@ -324,5 +326,70 @@ mod tests {
         b_session.encrypt(&mut packets);
         let a_received = a_session.decrypt(packets);
         assert_eq!(a_received, b_plaintext);
+    }
+
+    // Regression test for https://github.com/tailscale/tailscale-rs/issues/334
+    #[test]
+    fn test_invalid_response_ignored() {
+        let (a_static, b_static) = (NodeKeyPair::new(), NodeKeyPair::new());
+        let psk = rand::random();
+
+        // A sends a handshake
+        let a_mac_send = MACSender::new(&b_static.public);
+        let a_mac_recv = MACReceiver::new(&a_static.public);
+        let a_session = SessionId::random(); // A wants to receive at this ID
+        let a_init_time = TAI64N::now();
+        let (a_handshake, init_pkt) =
+            initiate_handshake(&a_static, &b_static.public, a_session, a_init_time);
+
+        let mut init_pkt = PacketMut::from(init_pkt.as_bytes());
+        let handshake_mac = a_mac_send.write_macs(init_pkt.as_mut());
+        let mut scheduler = Scheduler::default();
+        let timeout = scheduler.add(
+            ts_time::TimeRange::new_around(Instant::now(), std::time::Duration::from_secs(1000)),
+            Event::HandshakeTimeout(crate::PeerId(0)),
+        );
+        let mut a_handshake = Handshake::Initiated(a_handshake, timeout, handshake_mac);
+
+        // B receives and responds
+        let init_pkt = HandshakeInitiation::try_mut_from_bytes(init_pkt.as_mut())
+            .expect("init_pkt should be a valid handshake initiation message");
+        let b_mac_send = MACSender::new(&a_static.public);
+        let b_mac_recv = MACReceiver::new(&b_static.public);
+        let b_handshake = ReceivedHandshake::new(init_pkt, &b_static, &b_mac_recv)
+            .expect("peer B should successfully process A's handshake initiation");
+        let b_session = SessionId::random(); // B wants to receive at this ID
+        let (_b_session, mut response_pkt) =
+            b_handshake.respond(b_session, &psk, &b_mac_send, Instant::now());
+
+        // A receives several invalid responses: one with bad MACs, one with a bad Noise handshake
+        assert!(
+            a_handshake
+                .finish(
+                    &mut HandshakeResponse::default(),
+                    &a_static,
+                    &psk,
+                    &a_mac_recv,
+                    Instant::now()
+                )
+                .is_none()
+        );
+        let mut corrupt_pkt = response_pkt.clone();
+        let corrupt_pkt = HandshakeResponse::try_mut_from_bytes(corrupt_pkt.as_mut()).unwrap();
+        corrupt_pkt.noise[3] += 1;
+        assert!(
+            a_handshake
+                .finish(corrupt_pkt, &a_static, &psk, &a_mac_recv, Instant::now())
+                .is_none()
+        );
+
+        // Finally, A receives the correct response and establishes the session.
+        let response_pkt = HandshakeResponse::try_mut_from_bytes(response_pkt.as_mut())
+            .expect("response_pkt should be a valid handshake response message");
+        assert!(
+            a_handshake
+                .finish(response_pkt, &a_static, &psk, &a_mac_recv, Instant::now())
+                .is_some()
+        );
     }
 }


### PR DESCRIPTION
After taking the initiated handshake, upon failure to finalize the handshake state must be rolled back to allow for a future packet to finalize.

Fixes #334

Change-Id: Ibb421cbf8f18bbf83c8fc94498ee08ae6a6a6964