### PR TITLE
ts_tunnel: clean up session IDs when replacing handshake as responder

### DIFF
--- a/ts_tunnel/src/endpoint.rs
+++ b/ts_tunnel/src/endpoint.rs
@@ -232,6 +232,7 @@ impl Peer {
         }
         self.last_seen_timestamp = Some(handshake.timestamp);
 
+        endpoint.ids.remove_handshake_session(&self.handshake);
         let session_id = endpoint.ids.allocate_session(self.id);
 
         let packet = self.handshake.respond(


### PR DESCRIPTION
Fixes #333

Change-Id: I090f84982d3f2b9556f51257d703b6e56a6a6964

---

I also filed #347 because the code that handles these handshake transitions is still messy and hard to test properly :/ But this at least fixes the unfortunate resource consumption thing.