### PR TITLE
Implement packet padding for tunneled traffic

### DIFF
--- a/ts_dataplane/src/lib.rs
+++ b/ts_dataplane/src/lib.rs
@@ -84,6 +84,32 @@ impl DataPlane {
         }
     }
 
+    /// Pad `packets` to a 16-byte boundary, as required by `ts_tunnel`.
+    fn pad_packets(packets: &mut Vec<PacketMut>) {
+        const PAD_ALIGN: usize = 16;
+        for p in packets {
+            let m = p.len() % PAD_ALIGN;
+            if m != 0 {
+                p.grow_back(PAD_ALIGN - m);
+            }
+        }
+    }
+
+    /// Remove padding from `packets`.
+    ///
+    /// Packets which do not superficially match the structure of an IPv4 or IPv6 packet are
+    /// removed from `packets`.
+    fn unpad_packets(packets: &mut Vec<PacketMut>) {
+        packets.retain_mut(|packet| {
+            if let Some(sz) = packet.get_ip_len() {
+                packet.resize(sz);
+                true
+            } else {
+                false
+            }
+        });
+    }
+
     /// Processes packets originating from the local device.
     #[tracing::instrument(skip_all, fields(n_packets = packets.len()))]
     pub fn process_outbound(&mut self, packets: Vec<PacketMut>) -> OutboundResult {
@@ -96,10 +122,11 @@ impl DataPlane {
 
         let to_wireguard = to_wireguard
             .into_iter()
-            .inspect(|(id, _)| {
-                self.active_peers.insert(*id, now);
+            .map(|(id, mut packets)| {
+                self.active_peers.insert(id, now);
+                Self::pad_packets(&mut packets);
+                (ts_tunnel::PeerId(id.0), packets)
             })
-            .map(|(k, v)| (ts_tunnel::PeerId(k.0), v))
             .collect::<Vec<_>>();
 
         let ts_tunnel::SendResult {
@@ -144,6 +171,16 @@ impl DataPlane {
 
         let to_local = to_local
             .into_iter()
+            .filter_map(
+                |(peer_id, mut packets)| -> Option<(ts_tunnel::PeerId, Vec<PacketMut>)> {
+                    Self::unpad_packets(&mut packets);
+                    if packets.is_empty() {
+                        None
+                    } else {
+                        Some((peer_id, packets))
+                    }
+                },
+            )
             .map(|(peer_id, mut packets)| -> Vec<PacketMut> {
                 let _span = tracing::trace_span!(
                     "src_filter_inbound",

--- a/ts_netstack_smoltcp_core/src/config.rs
+++ b/ts_netstack_smoltcp_core/src/config.rs
@@ -31,7 +31,7 @@ impl Default for Config {
         Self {
             command_channel_capacity: Some(32),
 
-            mtu: 1500,
+            mtu: 1280,
 
             loopback: false,
 

--- a/ts_packet/src/lib.rs
+++ b/ts_packet/src/lib.rs
@@ -248,6 +248,18 @@ impl PacketMut {
         self.contents.extend_from_slice(slice);
     }
 
+    /// Add zero bytes to, or remove excess bytes from, the end of the packet to make its length
+    /// exactly `len`.
+    pub fn resize(&mut self, len: usize) {
+        self.contents.resize(len, 0);
+    }
+
+    /// Add the given number of zero bytes to the back of this packet. The underlying buffer is
+    /// resized if it does not have enough capacity.
+    pub fn grow_back(&mut self, len: usize) {
+        self.contents.resize(self.contents.len() + len, 0);
+    }
+
     /// Add the given number of zero bytes to the front of this `[PacketMut]`. The underlying
     /// buffer is resized if it does not have enough capacity.
     pub fn grow_front(&mut self, len: usize) {
@@ -503,6 +515,30 @@ impl PacketMut {
             Some(6) => self.ipv6_at(24),
             _ => None,
         }
+    }
+
+    /// Returns the IP datagram length, including both IP header and payload, as reported by the
+    /// IP header's length field.
+    ///
+    /// The returned value may be smaller than [`PacketMut::len`], but will never be greater.
+    ///
+    /// Returns `None` if the packet's structure doesn't match an IPv4 or IPv6 datagram, or the
+    /// length reported by the header is greater than [`PacketMut::len`].
+    pub fn get_ip_len(&self) -> Option<usize> {
+        let len = match self.get_ip_family() {
+            Some(4) => {
+                let len = u16::from_be_bytes(self.get(2..4)?.try_into().unwrap());
+                len as usize
+            }
+            Some(6) => {
+                let len = u16::from_be_bytes(self.get(4..6)?.try_into().unwrap());
+                // v6 length field only includes extension headers and payload, not the fixed base
+                // IP header.
+                len as usize + 40
+            }
+            _ => return None,
+        };
+        if len <= self.len() { Some(len) } else { None }
     }
 }
 

--- a/ts_tunnel/README.md
+++ b/ts_tunnel/README.md
@@ -28,7 +28,7 @@ As stated above, this crate by itself is NOT a complete implementation of WireGu
 
 In particular, this crate operates on packets with no awareness of IP protocols. Packets are opaque byte sequences to
 be encrypted/decrypted/queued/dropped as specified by the session and handshake state machines. This means that this
-crate does not implement aspects of WireGuard that requires awareness of IP addressing. These aspects must be provided
+crate does not implement aspects of WireGuard that requires awareness of IP networking. These aspects must be provided
 by the caller to be a complete implementation of the protocol:
 
 ### Cryptokey routing
@@ -40,6 +40,14 @@ automatically routed to the correct peer based on destination IP.
 This crate does _not_ enforce this unique association. The caller tags packets to be sent with the destination peer ID,
 and received packets are similarly tagged with the originating peer ID. It is up to the caller to select the correct
 peer when sending, and to validate the source IP when receiving.
+
+### Packet padding
+
+A complete WireGuard implementation pads cleartext packets before encryption, to complicate traffic analysis.
+
+This crate does not handle packet padding. It is the caller's responsibility to pad outgoing packets appropriately,
+and to strip any padding from received packets from peers. The padding removal in particular requires parsing received
+IP datagrams to find what the correct packet length should be.
 
 ### Underlay addressing & roaming
 


### PR DESCRIPTION
Fixes #330 

Two commits: one reduces the MTU of packets generated by smoltcp to match the MTU of the Go client. The second implements padding/unpadding in the dataplane, outside of ts_tunnel (because unpadding requires parsing the packet to find the correct size, whereas ts_tunnel wants to be agnostic to the payload).