### PR TITLE
kvstore: remove SinValue and add with_mut for singletons

### DIFF
--- a/ts_kv_store/src/lib.rs
+++ b/ts_kv_store/src/lib.rs
@@ -131,10 +131,8 @@
 //! for documentation.
 //!
 //! The implementation of storage for tabular data is one HashMap per table, and otherwise
-//! straightforward. For singleton data, we store values (as a `SinValue`) in fields with the name
-//! of the singleton. Values can be stored in different ways (inline, via an `Arc`, etc.) each of
-//! which is a variant of `SinValue`. The store transparently converts keys and values to their
-//! declared types.
+//! straightforward. For singleton data, we store values in an `Option` in fields with the name of
+//! the singleton.
 //!
 //! The implementation of the storage operations (`get`, `insert`, etc.) is somewhat shared between
 //! the various types which support them (`KvStore`, the table types, the transaction types, index
@@ -157,7 +155,7 @@
 //! outside of the main storage in a per-table delete mask.
 //!
 //! Singletons work slightly differently: they still use a `VersionedValue`, but use a tombstone value
-//! for deletes (`SinValue::None`) rather than a delete mask.
+//! for deletes (`None`) rather than a delete mask.
 //!
 //! To commit a transaction, the delete masks are applied to their corresponding tables, the committed
 //! transaction id in the store is set to the committed transaction's, and the pending transaction

--- a/ts_kv_store/src/operations.rs
+++ b/ts_kv_store/src/operations.rs
@@ -11,7 +11,7 @@
 use std::{
     borrow::Borrow,
     hash::Hash,
-    sync::{Arc, RwLockReadGuard, RwLockWriteGuard},
+    sync::{RwLockReadGuard, RwLockWriteGuard},
 };
 
 use crate::{
@@ -86,16 +86,6 @@ pub(crate) trait SingletonOps<TableStorage: schema::GeneratedStorage>:
         let storage = storage.storage();
         let txn_id = storage.txn_id();
         storage.get_singleton_value::<D>(txn_id).cloned()
-    }
-
-    fn get_arc<D: schema::ArcSingleton<Storage = TableStorage>>(
-        self,
-        _owner: Owner,
-    ) -> Option<Arc<D::Value>> {
-        let storage = self.read_lock();
-        let storage = storage.storage();
-        let txn_id = storage.txn_id();
-        storage.get_singleton_arc::<D>(txn_id)
     }
 
     fn with<D: schema::Singleton<Storage = TableStorage>, T>(
@@ -359,11 +349,7 @@ pub(crate) trait OpsMut<TableStorage: schema::GeneratedStorage>: Sized {
 pub(crate) trait SingletonOpsMut<TableStorage: schema::GeneratedStorage>:
     OpsMut<TableStorage>
 {
-    fn insert<D: schema::Singleton<Storage = TableStorage>>(
-        self,
-        value: D::ArgValue,
-        owner: Owner,
-    ) {
+    fn insert<D: schema::Singleton<Storage = TableStorage>>(self, value: D::Value, owner: Owner) {
         let mut storage = self.write_lock();
         let storage = storage.storage();
         assert_owner::<D>(owner);
@@ -379,6 +365,22 @@ pub(crate) trait SingletonOpsMut<TableStorage: schema::GeneratedStorage>:
 
         let txn_id = storage.txn_id();
         storage.remove_singleton::<D>(txn_id);
+    }
+
+    fn with_mut<D: schema::Singleton<Storage = TableStorage>, T>(
+        self,
+        f: impl FnOnce(&mut D::Value) -> T,
+        owner: Owner,
+    ) -> Option<T>
+    where
+        D::Value: Clone + PartialEq,
+    {
+        let mut storage = self.write_lock();
+        let storage = storage.storage();
+        assert_owner::<D>(owner);
+
+        let txn_id = storage.txn_id();
+        storage.with_mut_singleton::<D, T>(txn_id, f)
     }
 }
 

--- a/ts_kv_store/src/pub_sub.rs
+++ b/ts_kv_store/src/pub_sub.rs
@@ -27,7 +27,7 @@ use std::{
 use crate::{
     Error, Owner, Result,
     schema::{GeneratedStorage, Singleton, TableDesc},
-    storage::{SinValue, Storage},
+    storage::Storage,
 };
 
 /// Identifies a subscriber.
@@ -344,11 +344,11 @@ impl<Notif: Clone + 'static> Subscriptions<Notif> {
         notifications: &mut Notifications<
             <S::Storage as crate::schema::GeneratedStorage>::Notification,
         >,
-        event: &SinValue,
+        event: &Option<S::NotificationValue>,
     ) {
         let notification = match event {
-            SinValue::None => S::make_notification(SingletonEvent::Remove),
-            v => S::make_notification(SingletonEvent::Upsert(S::from_value_clone(v))),
+            None => S::make_notification(SingletonEvent::Remove),
+            Some(v) => S::make_notification(SingletonEvent::Upsert(v.clone())),
         };
 
         for s in self.all.lock().unwrap().iter() {
@@ -811,7 +811,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::{Error, storage::SinValue, store};
+    use crate::{Error, store};
 
     /// A value type with an indexed field, for exercising mutation through an index.
     #[derive(Clone, Debug, PartialEq)]
@@ -822,8 +822,9 @@ mod tests {
 
     store!(
         kvs: {
-            Count(u64; OWNER),
-            Shared(String as Arc; OWNER),
+            Count(u64; OWNER; notify(Clone)),
+            Shared(Arc<String>; OWNER; notify(Clone)),
+            Quiet(u64; OWNER),
         }
         tables: {
             Items(u32 => String; OWNER; notify(Clone)),
@@ -980,6 +981,27 @@ mod tests {
             match e {
                 SingletonEvent::Upsert(v) => CountKind::Upsert(*v),
                 SingletonEvent::Remove => CountKind::Remove,
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    /// A comparable projection of a `Quiet` singleton notification. `Quiet` does not use
+    /// `notify(Clone)`, so its notifications carry no value.
+    #[derive(Debug, PartialEq)]
+    enum QuietKind {
+        Upsert,
+        Remove,
+    }
+
+    impl From<&Notification> for QuietKind {
+        fn from(n: &Notification) -> QuietKind {
+            let Notification::Quiet(e) = n else {
+                panic!();
+            };
+            match e {
+                SingletonEvent::Upsert(()) => QuietKind::Upsert,
+                SingletonEvent::Remove => QuietKind::Remove,
                 _ => unreachable!(),
             }
         }
@@ -1240,12 +1262,12 @@ mod tests {
             .unwrap();
 
         let mut notifs = Notifications::default();
-        subs.collect_singleton_events::<Count>(&mut notifs, &SinValue::U64(5));
+        subs.collect_singleton_events::<Count>(&mut notifs, &Option::Some(5));
         let map: HashMap<Subscription, Vec<Notification>> = notifs.into();
         assert_eq!(CountKind::from(&map[&sub][0]), CountKind::Upsert(5));
 
         let mut notifs = Notifications::default();
-        subs.collect_singleton_events::<Count>(&mut notifs, &SinValue::None);
+        subs.collect_singleton_events::<Count>(&mut notifs, &Option::None);
         let map: HashMap<Subscription, Vec<Notification>> = notifs.into();
         assert_eq!(CountKind::from(&map[&sub][0]), CountKind::Remove);
     }
@@ -1257,7 +1279,7 @@ mod tests {
         let sub = subs.create_global_subscription(subscriber).unwrap();
 
         let mut notifs = Notifications::default();
-        subs.collect_singleton_events::<Count>(&mut notifs, &SinValue::U64(5));
+        subs.collect_singleton_events::<Count>(&mut notifs, &Option::Some(5));
 
         let map: HashMap<Subscription, Vec<Notification>> = notifs.into();
         assert_eq!(CountKind::from(&map[&sub][0]), CountKind::Upsert(5));
@@ -1272,7 +1294,7 @@ mod tests {
 
         let mut notifs = Notifications::default();
         subs.collect_events::<Items>(&mut notifs, events(&[(1, upsert("a"))]));
-        subs.collect_singleton_events::<Count>(&mut notifs, &SinValue::U64(5));
+        subs.collect_singleton_events::<Count>(&mut notifs, &Option::Some(5));
 
         let map: HashMap<Subscription, Vec<Notification>> = notifs.into();
         assert!(!map.contains_key(&sub));
@@ -1288,7 +1310,7 @@ mod tests {
         subs.remove_singleton_subscription::<Count>(sub);
 
         let mut notifs = Notifications::default();
-        subs.collect_singleton_events::<Count>(&mut notifs, &SinValue::U64(5));
+        subs.collect_singleton_events::<Count>(&mut notifs, &Option::Some(5));
         let map: HashMap<Subscription, Vec<Notification>> = notifs.into();
         assert!(!map.contains_key(&sub));
     }
@@ -1334,7 +1356,7 @@ mod tests {
 
         let mut notifs = Notifications::default();
         subs.collect_events::<Items>(&mut notifs, events(&[(1, upsert("a"))]));
-        subs.collect_singleton_events::<Count>(&mut notifs, &SinValue::U64(5));
+        subs.collect_singleton_events::<Count>(&mut notifs, &Option::Some(5));
 
         let map: HashMap<Subscription, Vec<Notification>> = notifs.into();
         for s in gone_subs {
@@ -1688,6 +1710,26 @@ mod tests {
     }
 
     #[test]
+    fn e2e_valueless_singleton_subscription() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.subscribe::<Quiet>(subscriber).unwrap();
+        rec.reset();
+
+        store.insert::<Quiet>(OWNER, 42);
+        store.remove::<Quiet>(OWNER);
+
+        // Without `notify(Clone)` the value is not sent, but a removal must still arrive as a
+        // removal rather than as an upsert of nothing.
+        let got = rec.notifications_for(sub);
+        assert_eq!(
+            got.iter().map(QuietKind::from).collect::<Vec<_>>(),
+            vec![QuietKind::Upsert, QuietKind::Remove]
+        );
+    }
+
+    #[test]
     fn e2e_arc_singleton_subscription() {
         let (notifier, rec) = RecordingNotifier::new();
         let store = KvStore::with_notifier(Arc::downgrade(&notifier));
@@ -1708,6 +1750,253 @@ mod tests {
             &got[1],
             Notification::Shared(SingletonEvent::Remove)
         ));
+    }
+
+    #[test]
+    fn e2e_singleton_with_mut_notifies_with_new_value() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.subscribe::<Count>(subscriber).unwrap();
+        store.insert::<Count>(OWNER, 0);
+        rec.reset();
+
+        store.with_mut::<Count, _>(OWNER, |v| *v += 1);
+        store.with_mut::<Count, _>(OWNER, |v| *v += 1);
+
+        assert_eq!(
+            rec.notifications_for(sub)
+                .iter()
+                .map(CountKind::from)
+                .collect::<Vec<_>>(),
+            vec![CountKind::Upsert(1), CountKind::Upsert(2)]
+        );
+    }
+
+    #[test]
+    fn e2e_singleton_with_mut_notifies_once_per_call() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        store.subscribe::<Count>(subscriber).unwrap();
+        store.insert::<Count>(OWNER, 0);
+        rec.reset();
+
+        store.with_mut::<Count, _>(OWNER, |v| *v = 1);
+
+        // Each `with_mut` is its own transaction, so it commits (and notifies) exactly once.
+        assert_eq!(rec.total_calls(), 1);
+    }
+
+    #[test]
+    fn e2e_singleton_with_mut_to_same_value_does_not_notify() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.subscribe::<Count>(subscriber).unwrap();
+        store.insert::<Count>(OWNER, 7);
+        rec.reset();
+
+        store.with_mut::<Count, _>(OWNER, |_| ());
+
+        assert!(rec.notifications_for(sub).is_empty());
+    }
+
+    #[test]
+    fn e2e_singleton_insert_then_with_mut_to_same_value_notifies() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.subscribe::<Count>(subscriber).unwrap();
+        store.insert::<Count>(OWNER, 0);
+        rec.reset();
+
+        let mut txn = store.begin_transaction(OWNER);
+        txn.insert::<Count>(7);
+        txn.with_mut::<Count, _>(|v| *v = 7);
+        txn.commit().unwrap();
+
+        assert_eq!(
+            rec.notifications_for(sub)
+                .iter()
+                .map(CountKind::from)
+                .collect::<Vec<_>>(),
+            vec![CountKind::Upsert(7)]
+        );
+    }
+
+    #[test]
+    fn e2e_singleton_with_mut_after_remove_does_not_notify() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.subscribe::<Count>(subscriber).unwrap();
+        store.insert::<Count>(OWNER, 7);
+        store.remove::<Count>(OWNER);
+        rec.reset();
+
+        assert!(store.with_mut::<Count, _>(OWNER, |_| panic!()).is_none());
+
+        assert!(rec.notifications_for(sub).is_empty());
+    }
+
+    #[test]
+    fn e2e_singleton_with_mut_after_remove_does_not_notify_on_a_committing_txn() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.subscribe::<Count>(subscriber).unwrap();
+        store.insert::<Count>(OWNER, 7);
+        store.remove::<Count>(OWNER);
+        rec.reset();
+
+        // As above, but in a transaction which goes on to commit real work elsewhere.
+        let mut txn = store.begin_transaction(OWNER);
+        assert!(txn.with_mut::<Count, _>(|_| panic!()).is_none());
+        txn.table::<Items>().insert(1, "a".to_owned());
+        txn.commit().unwrap();
+
+        assert!(rec.notifications_for(sub).is_empty());
+    }
+
+    #[test]
+    fn e2e_commit_without_singleton_writes_does_not_renotify() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.subscribe::<Count>(subscriber).unwrap();
+        store.insert::<Count>(OWNER, 1);
+        store.insert::<Count>(OWNER, 2);
+        rec.reset();
+
+        // Both of `Count`'s slots now hold committed values, but a transaction which doesn't touch
+        // `Count` must not re-deliver it.
+        let mut txn = store.begin_transaction(OWNER);
+        txn.table::<Items>().insert(9, "z".to_owned());
+        txn.commit().unwrap();
+
+        assert!(rec.notifications_for(sub).is_empty());
+    }
+
+    #[test]
+    fn e2e_singleton_with_mut_when_absent_does_not_notify() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.subscribe::<Count>(subscriber).unwrap();
+        rec.reset();
+
+        // There is no value to mutate, so nothing changes and there is nothing to notify about.
+        assert!(store.with_mut::<Count, _>(OWNER, |v| *v = 1).is_none());
+
+        assert!(rec.notifications_for(sub).is_empty());
+    }
+
+    #[test]
+    fn e2e_singleton_with_mut_coalesced_within_one_transaction() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.subscribe::<Count>(subscriber).unwrap();
+        store.insert::<Count>(OWNER, 0);
+        rec.reset();
+
+        let mut txn = store.begin_transaction(OWNER);
+        txn.with_mut::<Count, _>(|v| *v += 1);
+        txn.with_mut::<Count, _>(|v| *v += 1);
+        txn.commit().unwrap();
+
+        // Subscribers see the net effect of the transaction, notified once.
+        assert_eq!(rec.total_calls(), 1);
+        assert_eq!(
+            rec.notifications_for(sub)
+                .iter()
+                .map(CountKind::from)
+                .collect::<Vec<_>>(),
+            vec![CountKind::Upsert(2)]
+        );
+    }
+
+    #[test]
+    fn e2e_rolled_back_singleton_with_mut_notifies_nothing() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.subscribe::<Count>(subscriber).unwrap();
+        store.insert::<Count>(OWNER, 1);
+        rec.reset();
+
+        {
+            let mut txn = store.begin_transaction(OWNER);
+            txn.with_mut::<Count, _>(|v| *v += 1);
+            // Dropped without `commit`, so the transaction rolls back and never notifies.
+        }
+
+        assert!(rec.notifications_for(sub).is_empty());
+        assert_eq!(store.get::<Count>(OWNER), Some(1));
+    }
+
+    #[test]
+    fn e2e_arc_singleton_with_mut_notifies() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.subscribe::<Shared>(subscriber).unwrap();
+        store.insert::<Shared>(OWNER, Arc::new("hello".to_owned()));
+        rec.reset();
+
+        store.with_mut::<Shared, _>(OWNER, |v| *v = Arc::new(format!("{v}!")));
+
+        let got = rec.notifications_for(sub);
+        assert_eq!(got.len(), 1);
+        match &got[0] {
+            Notification::Shared(SingletonEvent::Upsert(v)) => assert_eq!(v.as_str(), "hello!"),
+            _ => panic!("expected a Shared upsert"),
+        }
+    }
+
+    #[test]
+    fn e2e_singleton_with_mut_only_notifies_subscribers_of_that_singleton() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let shared_sub = store.subscribe::<Shared>(subscriber).unwrap();
+        store.insert::<Count>(OWNER, 0);
+        rec.reset();
+
+        store.with_mut::<Count, _>(OWNER, |v| *v = 1);
+
+        assert!(rec.notifications_for(shared_sub).is_empty());
+    }
+
+    #[test]
+    fn e2e_no_singleton_subscribers_commits_mutated_value() {
+        let (notifier, _rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+
+        store.insert::<Count>(OWNER, 0);
+        store.with_mut::<Count, _>(OWNER, |v| *v += 7);
+        assert_eq!(store.get::<Count>(OWNER), Some(7));
+    }
+
+    #[test]
+    fn e2e_global_subscription_sees_singleton_with_mut() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        let sub = store.subscribe_global(subscriber).unwrap();
+        store.insert::<Count>(OWNER, 0);
+        rec.reset();
+
+        store.with_mut::<Count, _>(OWNER, |v| *v = 3);
+
+        assert_eq!(
+            rec.notifications_for(sub)
+                .iter()
+                .map(CountKind::from)
+                .collect::<Vec<_>>(),
+            vec![CountKind::Upsert(3)]
+        );
     }
 
     #[test]
@@ -2136,6 +2425,41 @@ mod tests {
     }
 
     #[test]
+    fn e2e_subscribe_and_notify_valueless_singleton_sends_presence() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        store.insert::<Quiet>(OWNER, 7);
+        rec.reset();
+
+        let sub = store.subscribe_and_notify::<Quiet>(subscriber).unwrap();
+
+        assert_eq!(
+            rec.notifications_for(sub)
+                .iter()
+                .map(QuietKind::from)
+                .collect::<Vec<_>>(),
+            vec![QuietKind::Upsert]
+        );
+    }
+
+    #[test]
+    fn e2e_subscribe_and_notify_valueless_singleton_without_value_sends_nothing() {
+        let (notifier, rec) = RecordingNotifier::new();
+        let store = KvStore::with_notifier(Arc::downgrade(&notifier));
+        let subscriber = store.register_subscriber(OWNER);
+        store.insert::<Quiet>(OWNER, 7);
+        store.remove::<Quiet>(OWNER);
+        rec.reset();
+
+        let sub = store.subscribe_and_notify::<Quiet>(subscriber).unwrap();
+
+        // The value has been removed, so there is nothing to report.
+        assert!(rec.notifications_for(sub).is_empty());
+        assert_eq!(rec.total_calls(), 0);
+    }
+
+    #[test]
     fn e2e_subscribe_and_notify_singleton_without_value_sends_nothing() {
         let (notifier, rec) = RecordingNotifier::new();
         let store = KvStore::with_notifier(Arc::downgrade(&notifier));
@@ -2415,7 +2739,7 @@ mod tests {
         txn.commit().unwrap();
 
         assert_eq!(
-            store.get_arc::<Shared>(OWNER).as_deref(),
+            store.get::<Shared>(OWNER).as_deref(),
             Some(&"hello".to_owned())
         );
         // Only `Count` is watched, so only its event is delivered.

--- a/ts_kv_store/src/raw.rs
+++ b/ts_kv_store/src/raw.rs
@@ -1,6 +1,6 @@
 //! KvStore non-transactional API.
 
-use std::{borrow::Borrow, hash::Hash, sync::Arc};
+use std::{borrow::Borrow, hash::Hash};
 
 use crate::{
     Error, KvStore, KvTableTransactional, Owner, Result, StoreWithOwner,
@@ -79,16 +79,6 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
         <&Self as SingletonOps<_>>::get::<D>(self, owner)
     }
 
-    /// Get a single value from the store by cloning an `Arc`.
-    ///
-    /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
-    pub fn get_arc<D: schema::ArcSingleton<Storage = TableStorage>>(
-        &self,
-        owner: Owner,
-    ) -> Option<Arc<D::Value>> {
-        <&Self as SingletonOps<_>>::get_arc::<D>(self, owner)
-    }
-
     /// Get immutable access to a value in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
@@ -100,11 +90,29 @@ impl<TableStorage: schema::GeneratedStorage> KvStore<TableStorage> {
         <&Self as SingletonOps<_>>::with::<D, T>(self, f, owner)
     }
 
+    /// Get mutable access to a value in the store by reference.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn with_mut<D: schema::Singleton<Storage = TableStorage>, T>(
+        &self,
+        owner: Owner,
+        f: impl FnOnce(&mut D::Value) -> T,
+    ) -> Option<T>
+    where
+        D::Value: Clone + PartialEq,
+    {
+        let mut txn = self.begin_transaction(owner);
+        let result = SingletonOpsMut::with_mut::<D, T>(&mut txn, f, owner);
+        // Should never panic since transaction should only fail on index inserts.
+        txn.commit().unwrap();
+        result
+    }
+
     /// Insert a single value into the store.
     pub fn insert<D: schema::Singleton<Storage = TableStorage>>(
         &self,
         owner: Owner,
-        value: D::ArgValue,
+        value: D::Value,
     ) {
         let mut txn = self.begin_transaction(owner);
         SingletonOpsMut::insert::<D>(&mut txn, value, owner);
@@ -213,15 +221,6 @@ impl<'a, TableStorage: schema::GeneratedStorage> StoreWithOwner<'a, TableStorage
         self.store.get::<D>(self.owner)
     }
 
-    /// Get a single value from the store by cloning an `Arc`.
-    ///
-    /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
-    pub fn get_arc<D: schema::ArcSingleton<Storage = TableStorage>>(
-        &self,
-    ) -> Option<Arc<D::Value>> {
-        self.store.get_arc::<D>(self.owner)
-    }
-
     /// Get immutable access to a value in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
@@ -232,8 +231,21 @@ impl<'a, TableStorage: schema::GeneratedStorage> StoreWithOwner<'a, TableStorage
         self.store.with::<D, T>(self.owner, f)
     }
 
+    /// Get mutable access to a value in the store by reference.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn with_mut<D: schema::Singleton<Storage = TableStorage>, T>(
+        &self,
+        f: impl FnOnce(&mut D::Value) -> T,
+    ) -> Option<T>
+    where
+        D::Value: Clone + PartialEq,
+    {
+        self.store.with_mut::<D, T>(self.owner, f)
+    }
+
     /// Insert a single value into the store.
-    pub fn insert<D: schema::Singleton<Storage = TableStorage>>(&self, value: D::ArgValue) {
+    pub fn insert<D: schema::Singleton<Storage = TableStorage>>(&self, value: D::Value) {
         self.store.insert::<D>(self.owner, value)
     }
 
@@ -436,8 +448,9 @@ mod test {
     store!(
         kvs: {
             Count(u64; OWNER),
-            Shared(String as Arc; OWNER),
-            Label(u64 as Ref; OWNER),
+            Shared(Arc<String>; OWNER),
+            Label(&'static u64; OWNER),
+            Boxed(Box<String>; OWNER),
         }
         tables: {
             Items(&'static str => String; OWNER),
@@ -474,30 +487,7 @@ mod test {
         static STATIC_LABEL: u64 = 99;
         let store = KvStore::new();
         store.insert::<Label>(OWNER, &STATIC_LABEL);
-        assert_eq!(store.get::<Label>(OWNER), Some(99));
-    }
-
-    #[test]
-    fn get_arc_returns_none_when_absent() {
-        let store = KvStore::new();
-        assert!(store.get_arc::<Shared>(OWNER).is_none());
-    }
-
-    #[test]
-    fn get_arc_returns_arc_after_insert() {
-        let store = KvStore::new();
-        store.insert::<Shared>(OWNER, Arc::new("hello".to_owned()));
-        let arc = store.get_arc::<Shared>(OWNER).unwrap();
-        assert_eq!(*arc, "hello");
-    }
-
-    #[test]
-    fn get_arc_shares_allocation() {
-        let store = KvStore::new();
-        store.insert::<Shared>(OWNER, Arc::new("hello".to_owned()));
-        let arc1 = store.get_arc::<Shared>(OWNER).unwrap();
-        let arc2 = store.get_arc::<Shared>(OWNER).unwrap();
-        assert!(Arc::ptr_eq(&arc1, &arc2));
+        assert_eq!(store.get::<Label>(OWNER), Some(&99));
     }
 
     #[test]
@@ -516,6 +506,124 @@ mod test {
         let store = KvStore::new();
         store.insert::<Count>(OWNER, 5);
         assert_eq!(store.with::<Count, _>(OWNER, |v| v * 2), Some(10));
+    }
+
+    #[test]
+    fn get_arc_singleton_shares_allocation() {
+        let store = KvStore::new();
+        let arc = Arc::new("hello".to_owned());
+        store.insert::<Shared>(OWNER, arc.clone());
+        let got = store.get::<Shared>(OWNER).unwrap();
+        assert_eq!(*got, "hello");
+        // `get` clones the `Arc` rather than the pointee.
+        assert!(Arc::ptr_eq(&arc, &got));
+    }
+
+    #[test]
+    fn with_mut_returns_none_and_does_not_call_f_when_absent() {
+        let store = KvStore::new();
+        let mut called = false;
+        let result = store.with_mut::<Count, ()>(OWNER, |_| {
+            called = true;
+        });
+        assert!(result.is_none());
+        assert!(!called);
+    }
+
+    #[test]
+    fn with_mut_does_not_insert_when_absent() {
+        let store = KvStore::new();
+        store.with_mut::<Count, _>(OWNER, |v| *v = 7);
+        assert!(store.get::<Count>(OWNER).is_none());
+    }
+
+    #[test]
+    fn with_mut_passes_current_value() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 5);
+        let mut seen = None;
+        store.with_mut::<Count, _>(OWNER, |v| seen = Some(*v));
+        assert_eq!(seen, Some(5));
+    }
+
+    #[test]
+    fn with_mut_returns_result_of_f() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 5);
+        assert_eq!(store.with_mut::<Count, _>(OWNER, |v| *v * 2), Some(10));
+    }
+
+    #[test]
+    fn with_mut_mutates_existing_value() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 5);
+        store.with_mut::<Count, _>(OWNER, |v| *v *= 2);
+        assert_eq!(store.get::<Count>(OWNER), Some(10));
+    }
+
+    #[test]
+    fn with_mut_sees_previous_with_mut() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 0);
+        store.with_mut::<Count, _>(OWNER, |v| *v += 1);
+        store.with_mut::<Count, _>(OWNER, |v| *v += 1);
+        store.with_mut::<Count, _>(OWNER, |v| *v += 1);
+        assert_eq!(store.get::<Count>(OWNER), Some(3));
+    }
+
+    #[test]
+    fn with_mut_returns_none_after_remove() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 5);
+        store.remove::<Count>(OWNER);
+        let mut called = false;
+        let result = store.with_mut::<Count, ()>(OWNER, |_| called = true);
+        assert!(result.is_none());
+        assert!(!called);
+        assert!(store.get::<Count>(OWNER).is_none());
+    }
+
+    #[test]
+    fn with_mut_box_singleton() {
+        let store = KvStore::new();
+        store.insert::<Boxed>(OWNER, Box::new("hello".to_owned()));
+        store.with_mut::<Boxed, _>(OWNER, |v| v.push('!'));
+        assert_eq!(
+            store.get::<Boxed>(OWNER),
+            Some(Box::new("hello!".to_owned()))
+        );
+    }
+
+    #[test]
+    fn with_mut_arc_singleton() {
+        let store = KvStore::new();
+        store.insert::<Shared>(OWNER, Arc::new("hello".to_owned()));
+        store.with_mut::<Shared, _>(OWNER, |v| *v = Arc::new(format!("{v}!")));
+        assert_eq!(
+            store.get::<Shared>(OWNER).as_deref(),
+            Some(&"hello!".to_owned())
+        );
+    }
+
+    #[test]
+    fn with_mut_ref_singleton() {
+        static OLD_LABEL: u64 = 1;
+        static NEW_LABEL: u64 = 2;
+        let store = KvStore::new();
+        store.insert::<Label>(OWNER, &OLD_LABEL);
+        store.with_mut::<Label, _>(OWNER, |v| {
+            assert_eq!(**v, 1);
+            *v = &NEW_LABEL;
+        });
+        assert_eq!(store.get::<Label>(OWNER), Some(&2));
+    }
+
+    #[test]
+    #[cfg_attr(debug_assertions, should_panic(expected = "Ownership violation"))]
+    fn with_mut_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        store.with_mut::<Count, _>(OTHER, |v| *v = 2);
     }
 
     #[test]

--- a/ts_kv_store/src/schema.rs
+++ b/ts_kv_store/src/schema.rs
@@ -3,13 +3,12 @@
 use std::{
     any::{Any, TypeId},
     hash::Hash,
-    sync::Arc,
 };
 
 use crate::{
     Owner,
     pub_sub::Subscriptions,
-    storage::{SinValue, Table, VersionedValue},
+    storage::{Table, VersionedValue},
     transactions::TxnId,
 };
 
@@ -22,65 +21,24 @@ pub trait Singleton: Sized + 'static {
 
     /// The type of the value.
     type Value: Any + Send + Sync;
-    /// The type of the notification for this singleton (either `Self::ArgValue` or `()`).
+    /// The type of the notification for this singleton (either `Self::Value` or `()`).
     type NotificationValue: Clone;
-    /// The type used to initialize and access the value. For values stored as `Arc`s this should be
-    /// `Arc<Self::Value>`, for values stored by reference, this should be `&'static Self::Value`, and
-    /// for other types, it should be the same as `Self::Value`.
-    type ArgValue;
     /// The storage for this singleton KV.
     type Storage: GeneratedStorage;
 
-    /// Unwrap a `SinValue` into a typed value.
-    ///
-    /// Panics if `value` is an unexpected variant.
-    fn from_value(value: SinValue) -> Self::ArgValue;
-    /// Unwrap a reference to a `SinValue` into a typed value by cloning, if possible.
-    ///
-    /// Panics if `value` is an unexpected variant.
-    fn from_value_clone(value: &SinValue) -> Self::NotificationValue;
-    /// Unwrap a reference to a `SinValue` into a reference to a typed value.
-    ///
-    /// Panics if `value` is an unexpected variant.
-    fn from_value_ref(value: &SinValue) -> &Self::Value;
-    /// Wrap a typed value into a `SinValue`.
-    fn to_value(value: Self::ArgValue) -> SinValue;
+    /// Get a clone of the value from `storage` if the singleton uses cloning for notification values,
+    /// or `()` if not.
+    fn get_cloned(storage: &Self::Storage, txn_id: TxnId) -> Option<Self::NotificationValue>;
     /// Get a reference to the field storing this singleton in `storage`.
-    fn field_ref(storage: &Self::Storage) -> &VersionedValue<SinValue>;
+    fn get_ref(storage: &Self::Storage) -> &VersionedValue<Option<Self::Value>>;
     /// Get a mutable reference to the field storing this singleton in `storage`.
-    fn field_ref_mut(storage: &mut Self::Storage) -> &mut VersionedValue<SinValue>;
+    fn get_mut(storage: &mut Self::Storage) -> &mut VersionedValue<Option<Self::Value>>;
+    /// Convert an optional reference to this singleton's value to it's notification value.
+    fn notif_value(value: &Option<Self::Value>) -> &Option<Self::NotificationValue>;
     /// Create a notification from an event.
     fn make_notification(
         event: crate::SingletonEvent<Self, Self::NotificationValue>,
     ) -> <Self::Storage as GeneratedStorage>::Notification;
-}
-
-/// A singleton key/value which is store as an `Arc`.
-///
-/// Implementing this trait for non-`Arc` values will cause [`crate::KvStore::get_arc`] to panic (but is
-/// not unsafe).
-///
-/// Prefer to use the macros in this module rather than this trait directly.
-pub trait ArcSingleton: Singleton {
-    /// Unwrap a reference to a `SinValue` into an `Arc` reference to a typed value.
-    ///
-    /// Panics if `value` is an unexpected variant.
-    fn from_value_arc(value: &SinValue) -> Arc<Self::Value> {
-        match value {
-            SinValue::Arc(a) => a.clone().downcast().unwrap(),
-            _ => unreachable!(),
-        }
-    }
-}
-
-/// Mark a singleton value as mutable (i.e., the value in the store is unique).
-///
-/// Prefer to use the macros in this module rather than this trait directly.
-pub trait MutSingleton: Singleton {
-    /// Unwrap a mutable reference to a `SinValue` into a mutable reference to a typed value.
-    ///
-    /// Panics if `value` is an unexpected variant.
-    fn from_value_mut(value: &mut SinValue) -> &mut Self::Value;
 }
 
 /// Describes tabular key/values in the store.
@@ -233,26 +191,19 @@ pub trait GeneratedStorage: Default + Send + Sync {
 /// The syntax is:
 /// ```ignore
 /// store!(
-///   kvs: { Name(ValueKind; owner; notify(None|Clone)?),* }
+///   kvs: { Name(ValueType; owner; notify(None|Clone)?),* }
 ///   tables: { Name(KeyType => ValueType; owner; indexes?; notify(None|Clone)?),* }
 /// )
 /// ```
 /// where `Name` is an identifier to name the table or singleton (in which case it is also the key),
-/// `KeyType` and `ValueType` are types, `ValueKind` is `u64 | ValueType as (Box | Arc | Ref)`.
-/// `owner` is an expression which evaluates to an `Owner`. `Name` is used as a type argument to
-/// KvStore methods to identify the table or singletone.
-///
-/// The storage kinds for singleton values are:
-///
-/// - `u64` a `u64` stored inline.
-/// - `Box` a value with type `Box<ValueType>`.
-/// - `Arc` a value with type `Arc<ValueType>`.
-/// - `Ref` a value with type `&'static ValueType`.
+/// `KeyType` and `ValueType` are types. `owner` is an expression which evaluates to an `Owner`.
+/// `Name` is used as a type argument to KvStore methods to identify the table or singleton.
 ///
 /// # Example:
 ///
 /// ```rust
 /// # use ts_kv_store::store;
+/// # use std::sync::Arc;
 /// # const GRAPH_OWNER: ts_kv_store::Owner = "foo";
 /// # const NODES_OWNER: ts_kv_store::Owner = "bar";
 /// # const EDGES_OWNER: ts_kv_store::Owner = "baz";
@@ -262,7 +213,7 @@ pub trait GeneratedStorage: Default + Send + Sync {
 /// # pub trait Edge {}
 /// store!(
 ///   kvs: {
-///     GraphId(Gid as Arc; GRAPH_OWNER),
+///     GraphId(Arc<Gid>; GRAPH_OWNER),
 ///   }
 ///   tables: {
 ///     Nodes(&'static str => Node; NODES_OWNER),
@@ -308,8 +259,7 @@ pub trait GeneratedStorage: Default + Send + Sync {
 /// ## Notifications
 ///
 /// The `notify(...)` argument is used to control notifications about the table or singleton. Accepted
-/// values are `Clone` and `None`. The default is `None` for tables and `Box` singletons, and `Clone`
-/// for other kinds of singleton.
+/// values are `Clone` and `None`. The default is `None`.
 ///
 /// The `None` behaviour is that only keys are sent in notifications. The `Clone` behaviour is
 /// that values are cloned and included in notifications. This requires that the value type implements
@@ -317,18 +267,51 @@ pub trait GeneratedStorage: Default + Send + Sync {
 #[macro_export]
 macro_rules! store {
     (
-        $(kvs: { $($sname: ident $sbody: tt),* $(,)? })?
+        $(kvs: { $($sname:ident($svalue_ty:ty; $sowner:expr $(; notify($snotif:ident))?)),* $(,)? })?
         $(tables: { $(
-            $name: ident (
-                $key_ty: ty => $value_ty: ty;
-                $owner: expr
-                $(; index($field: ident: $field_ty: ty $(= $get_idx: expr)? $(; $unique:ident)?))*
+            $name:ident (
+                $key_ty:ty => $value_ty:ty;
+                $owner:expr
+                $(; index($field:ident: $field_ty:ty $(= $get_idx:expr)? $(; $unique:ident)?))*
                 $(; notify($notif:ident))?
                 $(;)?
             )
         ),* $(,)? })?
     ) => {
-        $($($crate::singleton!($sname $sbody, TableStorage);)*)?
+        $($(
+            /// Describes a singleton in the KV store.
+            #[allow(non_camel_case_types)]
+            pub struct $sname;
+
+            impl $crate::schema::Singleton for $sname {
+                const OWNER: $crate::Owner = $sowner;
+                type Value = $svalue_ty;
+                type NotificationValue = $crate::notification_value_type!($svalue_ty $(; notify($snotif))?);
+                type Storage = TableStorage;
+
+                fn get_cloned(_storage: &Self::Storage, _txn_id: $crate::transactions::TxnId) -> Option<Self::NotificationValue> {
+                    $crate::get_cloned_notification_value!($sname, _storage, _txn_id $(; notify($snotif))?)
+                }
+
+                fn get_ref(storage: &Self::Storage) -> &$crate::storage::VersionedValue<Option<Self::Value>> {
+                    &storage.$sname
+                }
+
+                fn get_mut(storage: &mut Self::Storage) -> &mut $crate::storage::VersionedValue<Option<Self::Value>>{
+                    &mut storage.$sname
+                }
+
+                fn notif_value(_value: &Option<Self::Value>) -> &Option<Self::NotificationValue> {
+                    $crate::notification_value!(_value $(; notify($snotif))? )
+                }
+
+                fn make_notification(
+                    event: $crate::SingletonEvent<Self, Self::NotificationValue>,
+                ) -> <Self::Storage as $crate::schema::GeneratedStorage>::Notification {
+                    Notification::$sname(event)
+                }
+            }
+        )*)?
         $($(
             /// Describes a table in the KV store.
             #[derive(Default)]
@@ -339,7 +322,7 @@ macro_rules! store {
                 const OWNER: $crate::Owner = $owner;
                 type Key = $key_ty;
                 type Value = $value_ty;
-                type NotificationValue = $crate::table_notification_value_type!($value_ty $(; notify($notif))?);
+                type NotificationValue = $crate::notification_value_type!($value_ty $(; notify($notif))?);
                 type Storage = TableStorage;
                 type Indexes = index::$name::Indexes;
 
@@ -354,7 +337,7 @@ macro_rules! store {
                     Notification::$name(event)
                 }
                 fn clone_value_for_notification(_value: &Self::Value) -> Self::NotificationValue {
-                    $crate::table_notification_clone_value!(_value $(; notify($notif))?)
+                    $crate::notification_clone_value!(_value $(; notify($notif))?)
                 }
 
                 $crate::value_eq!(Self::Value);
@@ -389,15 +372,14 @@ macro_rules! store {
                     type BaseTable = $name;
                 }
             )*
-
         )*)?
 
-        /// Macro-generated storage for all tabular data.
+        /// Macro-generated storage for all data.
         #[derive(Default)]
         #[allow(non_snake_case)]
         pub struct TableStorage {
             $($($name: $crate::storage::Table<$name, index::$name::Indexes>,)*)?
-            $($($sname: $crate::storage::VersionedValue<$crate::storage::SinValue>,)*)?
+            $($($sname: $crate::storage::VersionedValue<Option<$svalue_ty>>,)*)?
         }
 
         /// Macro-generated notification type, there is a variant for each table and singleton with
@@ -435,7 +417,7 @@ macro_rules! store {
                         if _subscriptions.has_singleton_subscribers::<$sname>()
                             && let Some(event) = self.$sname.modified_in_txn(_txn_id)
                         {
-                            _subscriptions.collect_singleton_events::<$sname>(_notifications, event);
+                            _subscriptions.collect_singleton_events::<$sname>(_notifications, <$sname as $crate::schema::Singleton>::notif_value(event));
                         }
                     )*
                 )?
@@ -655,130 +637,7 @@ macro_rules! value_eq {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! singleton {
-    ($name:ident(u64; $owner:expr $(; notify($notif:ident))?), $storage:ident) => {
-        $crate::singleton_types!($name(u64, u64, U64), $owner, $storage, $(notify($notif))?);
-
-        impl $crate::schema::MutSingleton for $name {
-            fn from_value_mut(value: &mut $crate::storage::SinValue) -> &mut Self::Value {
-                match value {
-                    $crate::match_helper_lhs!(U64, v) => $crate::match_helper_rhs_mut!(U64, v),
-                    _ => unreachable!(),
-                }
-            }
-        }
-    };
-    ($name:ident($value_ty:ty as Box; $owner:expr $(; notify($notif:ident))?), $storage:ident) => {
-        $crate::singleton_types!($name($value_ty, $value_ty, Box), $owner, $storage, $(notify($notif))?);
-
-        impl $crate::schema::MutSingleton for $name {
-            fn from_value_mut(value: &mut $crate::storage::SinValue) -> &mut Self::Value {
-                match value {
-                    $crate::match_helper_lhs!(Box, v) => $crate::match_helper_rhs_mut!(Box, v),
-                    _ => unreachable!(),
-                }
-            }
-        }
-    };
-    ($name:ident($value_ty:ty as Arc; $owner:expr $(; notify($notif:ident))?), $storage:ident) => {
-        $crate::singleton_types!(
-            $name($value_ty, std::sync::Arc<$value_ty>, Arc),
-            $owner,
-            $storage,
-            $(notify($notif))?
-        );
-
-        impl $crate::schema::ArcSingleton for $name {}
-    };
-    ($name:ident($value_ty:ty as Ref; $owner:expr $(; notify($notif:ident))?), $storage:ident) => {
-        $crate::singleton_types!($name($value_ty, &'static $value_ty, Ref), $owner, $storage, $(notify($notif))?);
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! singleton_types {
-    ($name:ident($value_ty:ty, $arg_value_ty:ty, $variant:ident), $owner:expr, $storage:ident, $(notify($notif:ident))?) => {
-        /// Describes a singleton in the KV store.
-        #[allow(non_camel_case_types)]
-        pub struct $name;
-
-        impl $crate::schema::Singleton for $name {
-            const OWNER: $crate::Owner = $owner;
-            type Value = $value_ty;
-            type NotificationValue = $crate::singleton_notification_value_type!($name, $variant, $($notif)?);
-            type ArgValue = $arg_value_ty;
-            type Storage = $storage;
-
-            fn from_value(value: $crate::storage::SinValue) -> Self::ArgValue {
-                match value {
-                    $crate::match_helper_lhs!($variant, v) => {
-                        $crate::match_helper_rhs!($variant, v)
-                    }
-                    _ => unreachable!(),
-                }
-            }
-
-            fn from_value_clone(value: &$crate::storage::SinValue) -> Self::NotificationValue {
-                match value {
-                    $crate::match_helper_lhs!($variant, _v) => {
-                        $crate::match_helper_rhs_clone!($variant, _v, $value_ty, $($notif)?)
-                    }
-                    _ => unreachable!(),
-                }
-            }
-
-            fn from_value_ref(value: &$crate::storage::SinValue) -> &Self::Value {
-                match value {
-                    $crate::match_helper_lhs!($variant, v) => {
-                        $crate::match_helper_rhs_ref!($variant, v)
-                    }
-                    _ => unreachable!(),
-                }
-            }
-
-            fn to_value(value: Self::ArgValue) -> $crate::storage::SinValue {
-                $crate::init_helper!($variant, value)
-            }
-
-            fn field_ref(
-                storage: &Self::Storage,
-            ) -> &$crate::storage::VersionedValue<$crate::storage::SinValue> {
-                &storage.$name
-            }
-
-            fn field_ref_mut(
-                storage: &mut Self::Storage,
-            ) -> &mut $crate::storage::VersionedValue<$crate::storage::SinValue> {
-                &mut storage.$name
-            }
-
-            fn make_notification(
-                event: $crate::SingletonEvent<Self, Self::NotificationValue>,
-            ) -> <Self::Storage as $crate::schema::GeneratedStorage>::Notification {
-                Notification::$name(event)
-            }
-        }
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! singleton_notification_value_type {
-    ($sname:ident,Box, $(None)?) => {
-        ()
-    };
-    ($sname:ident, $variant:ident, $(Clone)?) => {
-        <$sname as $crate::schema::Singleton>::ArgValue
-    };
-    ($sname:ident, $variant:ident,None) => {
-        ()
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! table_notification_value_type {
+macro_rules! notification_value_type {
     ($value_ty:ty; notify(Clone)) => {
         $value_ty
     };
@@ -789,7 +648,7 @@ macro_rules! table_notification_value_type {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! table_notification_clone_value {
+macro_rules! notification_clone_value {
     ($value:ident; notify(Clone)) => {
         $value.clone()
     };
@@ -797,100 +656,25 @@ macro_rules! table_notification_clone_value {
         ()
     };
 }
-
 #[doc(hidden)]
 #[macro_export]
-macro_rules! init_helper {
-    (U64, $value:ident) => {
-        $crate::storage::SinValue::U64($value)
-    };
-    (Box, $value:ident) => {
-        $crate::storage::SinValue::Box(
-            std::boxed::Box::new($value) as Box<dyn std::any::Any + Send + Sync>
-        )
-    };
-    (Arc, $value:ident) => {
-        $crate::storage::SinValue::Arc(
-            $value.clone() as std::sync::Arc<dyn std::any::Any + Send + Sync>
-        )
-    };
-    (Ref, $value:ident) => {
-        $crate::storage::SinValue::Ref($value as &'static (dyn std::any::Any + Send + Sync))
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! match_helper_lhs {
-    (U64, $value:ident) => {
-        $crate::storage::SinValue::U64($value)
-    };
-    ($variant:ident, $value:ident) => {
-        $crate::storage::SinValue::$variant($value)
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! match_helper_rhs {
-    (U64, $value:ident) => {
+macro_rules! notification_value {
+    ($value:ident; notify(Clone)) => {
         $value
     };
-    (Box, $value:ident) => {
-        *$value.downcast().unwrap()
-    };
-    (Arc, $value:ident) => {
-        $value.downcast().unwrap()
-    };
-    (Ref, $value:ident) => {
-        $value.downcast_ref().unwrap()
+    ($value:ident $(; notify(None))?) => {
+        if $value.is_some() { &Some(()) } else { &None }
     };
 }
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! match_helper_rhs_ref {
-    (U64, $value:ident) => {
-        $value
+macro_rules! get_cloned_notification_value {
+    ($name:ident, $storage:ident, $txn_id:ident; notify(Clone)) => {
+        $storage.$name.get($txn_id)?.as_ref().map(|v| v.clone())
     };
-    ($variant:ident, $value:ident) => {
-        $value.downcast_ref().unwrap()
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! match_helper_rhs_mut {
-    (U64, $value:ident) => {
-        $value
-    };
-    ($variant:ident, $value:ident) => {
-        $value.downcast_mut().unwrap()
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! match_helper_rhs_clone {
-    ($variant:ident, $value:ident, $value_ty:ty,None) => {
-        ()
-    };
-    (U64, $value:ident, $value_ty:ty, $(Clone)?) => {
-        *$value
-    };
-    (Box, $value:ident, $value_ty:ty,Clone) => {
-        $value.downcast_ref::<$value_ty>().unwrap().clone()
-    };
-    (Box, $value:ident, $value_ty:ty) => {
-        ()
-    };
-    (Arc, $value:ident, $value_ty:ty, $(Clone)?) => {
-        std::sync::Arc::clone($value)
-            .downcast::<$value_ty>()
-            .unwrap()
-    };
-    (Ref, $value:ident, $value_ty:ty, $(Clone)?) => {
-        $value.downcast_ref::<$value_ty>().unwrap()
+    ($name:ident, $storage:ident, $txn_id:ident $(; notify(None))?) => {
+        $storage.$name.get($txn_id)?.as_ref().map(|_| ())
     };
 }
 
@@ -898,27 +682,20 @@ macro_rules! match_helper_rhs_clone {
 mod test {
     use std::sync::Arc;
 
-    use super::*;
-
     #[test]
     fn single() {
         store!(
             kvs: {
-                Foo(u64 as Box; "owner"; notify(Clone)),
-                Bar(u64 as Arc; "owner"; notify(None)),
-                Baz(u64 as Ref; "owner"),
+                Foo(Box<u64>; "owner"; notify(Clone)),
+                Bar(Arc<u64>; "owner"; notify(None)),
+                Baz(&'static u64; "owner"),
                 Qux(u64; "owner"),
             }
         );
 
-        assert_eq!(&42, Foo::from_value_ref(&Foo::to_value(42)));
-        assert_eq!(&42, Bar::from_value_ref(&Bar::to_value(Arc::new(42))));
-        assert_eq!(&42, Baz::from_value_ref(&Baz::to_value(&42)));
-        assert_eq!(&42, Qux::from_value_ref(&Qux::to_value(42)));
-
         let store = KvStore::new();
-        store.insert::<Foo>("owner", 42);
-        assert_eq!(store.get::<Foo>("owner").unwrap(), 42);
+        store.insert::<Foo>("owner", Box::new(42));
+        assert_eq!(store.get::<Foo>("owner").unwrap(), Box::new(42));
     }
 
     #[test]

--- a/ts_kv_store/src/storage.rs
+++ b/ts_kv_store/src/storage.rs
@@ -552,6 +552,11 @@ pub struct Table<D: schema::TableDesc, I> {
     delete_mask: DeleteMask<D::Key, D::Value>,
     /// Keys modified (includes inserts, but not deletes) by the given transaction.
     modified: Option<TxnMutations<D::Key>>,
+    /// True if the table was empty at the start of the current transaction.
+    ///
+    /// This is maintained by updating it when a transaction is committed. No action is required on
+    /// roll-back because `cleared` is not changed during a transaction.
+    cleared: bool,
     /// A flag indicating if the table has become inconsistent.
     ///
     /// Currently this is used for indexes if multiple primary keys are stored for a single index key.
@@ -566,6 +571,7 @@ impl<D: schema::TableDesc, I: Default> Default for Table<D, I> {
             data: HashMap::new(),
             delete_mask: DeleteMask::None,
             modified: None,
+            cleared: true,
             poisoned: VersionedValue::new(false, TxnId::FIRST),
             indexes: I::default(),
         }
@@ -671,10 +677,11 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
             Some(m.keys)
         });
 
-        match std::mem::take(&mut self.delete_mask) {
+        let result = match std::mem::take(&mut self.delete_mask) {
             DeleteMask::All(dm_id, data) if dm_id == txn_id => {
                 if !collect_notifications {
                     self.data = data;
+                    self.cleared = self.data.is_empty();
                     return HashMap::new();
                 }
 
@@ -701,6 +708,7 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
                     removed.iter().for_each(|k| {
                         self.data.remove(k);
                     });
+                    self.cleared = self.data.is_empty();
                     return HashMap::new();
                 }
 
@@ -729,15 +737,14 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
             }
             DeleteMask::None => {
                 if !collect_notifications {
+                    self.cleared = self.data.is_empty();
                     return HashMap::new();
                 }
                 let Some(modified) = modified else {
                     return HashMap::new();
                 };
 
-                // TODO(nrc) O(size of table), should do this more efficiently, i.e., track as we mutate.
-                let was_empty = !self.data.values().any(|v| v.has_prior_value(txn_id));
-                if was_empty {
+                if self.cleared {
                     modified
                         .into_iter()
                         .map(|k| (k, WatchedEvent::KeyOnlyUpsert))
@@ -756,7 +763,11 @@ impl<D: schema::TableDesc, I: IndexStorage<D::Key, D::Value>> Table<D, I> {
                 }
             }
             _ => unreachable!(),
-        }
+        };
+
+        self.cleared = self.data.is_empty();
+
+        result
     }
 
     /// Takes a set of keys which may have been mutated and removes any keys where the values are unchanged

--- a/ts_kv_store/src/storage.rs
+++ b/ts_kv_store/src/storage.rs
@@ -1,9 +1,8 @@
 use std::{
-    any::Any,
     borrow::Borrow,
     collections::{HashMap, HashSet},
     hash::Hash,
-    sync::{Arc, Weak},
+    sync::Weak,
 };
 
 use crate::{
@@ -66,17 +65,17 @@ impl<TableStorage: schema::GeneratedStorage> Storage<TableStorage> {
 
     pub(crate) fn insert_singleton<D: schema::Singleton<Storage = TableStorage>>(
         &mut self,
-        value: D::ArgValue,
+        value: D::Value,
         txn_id: TxnId,
     ) {
-        D::field_ref_mut(&mut self.tables).set(D::to_value(value), txn_id);
+        D::get_mut(&mut self.tables).set(Some(value), txn_id);
     }
 
     pub(crate) fn remove_singleton<D: schema::Singleton<Storage = TableStorage>>(
         &mut self,
         txn_id: TxnId,
     ) {
-        D::field_ref_mut(&mut self.tables).set(SinValue::None, txn_id);
+        D::get_mut(&mut self.tables).set(None, txn_id);
     }
 
     /// Retrieve a singleton value from the store using the given type-key.
@@ -84,24 +83,48 @@ impl<TableStorage: schema::GeneratedStorage> Storage<TableStorage> {
         &self,
         txn_id: TxnId,
     ) -> Option<&D::Value> {
-        map_singleton_value(D::field_ref(&self.tables), txn_id, |v| D::from_value_ref(v))
+        D::get_ref(&self.tables).get(txn_id)?.as_ref()
+    }
+
+    /// Pass a mutable reference to a singleton value to `f`.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the singleton.
+    pub(crate) fn with_mut_singleton<D: schema::Singleton<Storage = TableStorage>, T>(
+        &mut self,
+        txn_id: TxnId,
+        f: impl FnOnce(&mut D::Value) -> T,
+    ) -> Option<T>
+    where
+        D::Value: Clone + PartialEq,
+    {
+        let singleton = D::get_mut(&mut self.tables);
+
+        // Check for a value before cloning: a removed singleton is stored as a `None` in an occupied
+        // slot, and cloning that into the free slot would look like a mutation and cause a spurious
+        // `Remove` notification.
+        singleton.get(txn_id)?.as_ref()?;
+
+        // If this transaction has already written to the singleton, then it counts as mutated however
+        // `f` behaves, and the clone we'd roll back isn't ours to roll back.
+        let previously_written = singleton.modified_in_txn(txn_id).is_some();
+
+        let value = singleton.internal_clone(txn_id)?.as_mut()?;
+        let old_value = (!previously_written).then(|| value.clone());
+        let result = f(value);
+
+        if old_value.is_some_and(|old_value| *value == old_value) {
+            // `f` left the value alone, so discard the clone.
+            singleton.gc_txn(txn_id);
+        }
+
+        Some(result)
     }
 
     pub(crate) fn get_singleton_notification_value<D: schema::Singleton<Storage = TableStorage>>(
         &self,
         txn_id: TxnId,
     ) -> Option<D::NotificationValue> {
-        map_singleton_value(D::field_ref(&self.tables), txn_id, |v| {
-            D::from_value_clone(v)
-        })
-    }
-
-    /// Retrieve a singleton value from the store using the given type-key.
-    pub(crate) fn get_singleton_arc<D: schema::ArcSingleton<Storage = TableStorage>>(
-        &self,
-        txn_id: TxnId,
-    ) -> Option<Arc<D::Value>> {
-        map_singleton_value(D::field_ref(&self.tables), txn_id, |v| D::from_value_arc(v))
+        D::get_cloned(&self.tables, txn_id)
     }
 
     /// Begin a new transaction. Returns the transactions unique id.
@@ -159,35 +182,6 @@ impl<TableStorage: schema::GeneratedStorage> Storage<TableStorage> {
     }
 }
 
-/// Internal storage for singleton values.
-#[doc(hidden)]
-#[derive(Default)]
-pub enum SinValue {
-    /// Tombstone value.
-    #[default]
-    None,
-    // TODO add other special cases
-    /// A single, inline `u64`.
-    U64(u64),
-    /// A boxed value.
-    Box(Box<dyn Any + Send + Sync>),
-    /// A shared reference in the store.
-    Arc(Arc<dyn Any + Send + Sync>),
-    /// A static reference in the store.
-    Ref(&'static (dyn Any + Send + Sync)),
-}
-
-fn map_singleton_value<'a, T>(
-    value: &'a VersionedValue<SinValue>,
-    id: TxnId,
-    f: impl FnOnce(&'a SinValue) -> T,
-) -> Option<T> {
-    match &value.get(id)? {
-        SinValue::None => None,
-        v => Some(f(v)),
-    }
-}
-
 /// An MVCC value with only two versions (versioned by [`TxnId`]).
 #[doc(hidden)]
 #[derive(Debug)]
@@ -226,6 +220,7 @@ impl<T> VersionedValue<T> {
         }
     }
 
+    /// The value written by `txn_id`, if this transaction wrote to either slot.
     pub fn modified_in_txn(&self, txn_id: TxnId) -> Option<&T> {
         if let Some((id, v)) = &self.slot_a
             && *id == txn_id
@@ -305,7 +300,7 @@ impl<T> VersionedValue<T> {
         )
     }
 
-    pub(crate) fn get(&self, id: TxnId) -> Option<&T> {
+    pub fn get(&self, id: TxnId) -> Option<&T> {
         // This could be expressed more simply with a match, but that doesn't work for `get_mut` because
         // of mutable borrows. Since the functions do the same thing, I use the more complex code
         // here too.
@@ -1236,8 +1231,6 @@ mod test {
         assert_eq!(v.get(TxnId::new(3)), Some(&20));
     }
 
-    // take
-
     #[test]
     fn take_returns_none_when_empty() {
         let mut v: VersionedValue<u32> = VersionedValue::default();
@@ -1296,7 +1289,46 @@ mod test {
         assert!(v.slot_a.is_some());
     }
 
-    // set
+    #[test]
+    fn internal_clone_returns_none_when_empty() {
+        let mut v: VersionedValue<u32> = VersionedValue::default();
+        assert!(v.internal_clone(TxnId::new(2)).is_none());
+    }
+
+    #[test]
+    fn internal_clone_copies_committed_value_into_free_slot() {
+        let mut v = VersionedValue {
+            slot_a: Some((TxnId::new(2), 10u32)),
+            slot_b: None,
+        };
+        *v.internal_clone(TxnId::new(4)).unwrap() = 99;
+        // The committed value is left intact so that the transaction can be rolled back.
+        assert_eq!(v.slot_a, Some((TxnId::new(2), 10)));
+        assert_eq!(v.slot_b, Some((TxnId::new(4), 99)));
+    }
+
+    #[test]
+    fn internal_clone_reuses_slot_from_same_txn() {
+        let mut v = VersionedValue {
+            slot_a: Some((TxnId::new(2), 10u32)),
+            slot_b: Some((TxnId::new(4), 99u32)),
+        };
+        *v.internal_clone(TxnId::new(4)).unwrap() += 1;
+        assert_eq!(v.slot_a, Some((TxnId::new(2), 10)));
+        assert_eq!(v.slot_b, Some((TxnId::new(4), 100)));
+    }
+
+    #[test]
+    fn internal_clone_overwrites_older_of_two_committed_slots() {
+        let mut v = VersionedValue {
+            slot_a: Some((TxnId::new(3), 10u32)),
+            slot_b: Some((TxnId::new(2), 20u32)),
+        };
+        // The most recently committed value is the one cloned, and the older one is overwritten.
+        *v.internal_clone(TxnId::new(5)).unwrap() = 99;
+        assert_eq!(v.slot_a, Some((TxnId::new(3), 10)));
+        assert_eq!(v.slot_b, Some((TxnId::new(5), 99)));
+    }
 
     #[test]
     fn set_into_empty_writes_to_slot_a() {
@@ -1410,5 +1442,84 @@ mod txn_test {
         assert!(storage.current_txn().is_none());
         let now = storage.txn_id();
         assert!(storage.get_singleton_value::<Count>(now).is_none());
+    }
+
+    #[test]
+    fn with_mut_singleton_on_a_removed_value_records_no_mutation() {
+        use crate::schema::Singleton;
+
+        let mut storage =
+            Storage::<TableStorage>::new(std::sync::Arc::downgrade(&NoOpNotifier::new()));
+        let id = storage.begin_transaction();
+        storage.insert_singleton::<Count>(42, id);
+        storage.commit_transaction(id).unwrap();
+        let id = storage.begin_transaction();
+        storage.remove_singleton::<Count>(id);
+        storage.commit_transaction(id).unwrap();
+
+        let id = storage.begin_transaction();
+        assert!(
+            storage
+                .with_mut_singleton::<Count, _>(id, |v| *v = 7)
+                .is_none()
+        );
+
+        // A removed singleton is a `None` in an occupied slot. Cloning it into the free slot would
+        // be indistinguishable from a real mutation at commit time.
+        assert!(
+            Count::get_ref(&storage.tables)
+                .modified_in_txn(id)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn with_mut_singleton_without_a_change_records_no_mutation() {
+        use crate::schema::Singleton;
+
+        let mut storage =
+            Storage::<TableStorage>::new(std::sync::Arc::downgrade(&NoOpNotifier::new()));
+        let id = storage.begin_transaction();
+        storage.insert_singleton::<Count>(42, id);
+        storage.commit_transaction(id).unwrap();
+
+        let id = storage.begin_transaction();
+        assert_eq!(
+            storage.with_mut_singleton::<Count, _>(id, |v| *v = 42),
+            Some(())
+        );
+
+        assert!(
+            Count::get_ref(&storage.tables)
+                .modified_in_txn(id)
+                .is_none()
+        );
+        // Rolling back the clone must not lose the value.
+        assert_eq!(storage.get_singleton_value::<Count>(id), Some(&42));
+    }
+
+    #[test]
+    fn with_mut_singleton_keeps_a_mutation_from_earlier_in_the_txn() {
+        use crate::schema::Singleton;
+
+        let mut storage =
+            Storage::<TableStorage>::new(std::sync::Arc::downgrade(&NoOpNotifier::new()));
+        let id = storage.begin_transaction();
+        storage.insert_singleton::<Count>(42, id);
+        storage.commit_transaction(id).unwrap();
+
+        let id = storage.begin_transaction();
+        storage.insert_singleton::<Count>(7, id);
+        assert_eq!(
+            storage.with_mut_singleton::<Count, _>(id, |v| *v = 7),
+            Some(())
+        );
+
+        // The insert is this transaction's own write, so a `with_mut` which changes nothing must
+        // not roll it back.
+        assert_eq!(
+            Count::get_ref(&storage.tables).modified_in_txn(id),
+            Some(&Some(7))
+        );
     }
 }

--- a/ts_kv_store/src/transactions.rs
+++ b/ts_kv_store/src/transactions.rs
@@ -7,7 +7,7 @@ use std::{
     cell::UnsafeCell,
     hash::Hash,
     num::NonZeroU64,
-    sync::{Arc, RwLockReadGuard, RwLockWriteGuard},
+    sync::{RwLockReadGuard, RwLockWriteGuard},
 };
 
 use crate::{
@@ -263,15 +263,6 @@ impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableSt
         <&Self as SingletonOps<_>>::get::<D>(self, self.owner)
     }
 
-    /// Get a single value from the store by cloning an `Arc`.
-    ///
-    /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
-    pub fn get_arc<D: schema::ArcSingleton<Storage = TableStorage>>(
-        &self,
-    ) -> Option<Arc<D::Value>> {
-        <&Self as SingletonOps<_>>::get_arc::<D>(self, self.owner)
-    }
-
     /// Get immutable access to a value in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
@@ -282,8 +273,21 @@ impl<'guard, TableStorage: schema::GeneratedStorage> Transaction<'guard, TableSt
         <&Self as SingletonOps<_>>::with::<D, T>(self, f, self.owner)
     }
 
+    /// Get mutable access to a value in the store by reference.
+    ///
+    /// Returns `None` (and does not call `f`) if there is no value for the specified key.
+    pub fn with_mut<D: schema::Singleton<Storage = TableStorage>, T>(
+        &mut self,
+        f: impl FnOnce(&mut D::Value) -> T,
+    ) -> Option<T>
+    where
+        D::Value: Clone + PartialEq,
+    {
+        <&mut Self as SingletonOpsMut<_>>::with_mut::<D, T>(self, f, self.owner)
+    }
+
     /// Insert a single value into the store.
-    pub fn insert<D: schema::Singleton<Storage = TableStorage>>(&mut self, value: D::ArgValue) {
+    pub fn insert<D: schema::Singleton<Storage = TableStorage>>(&mut self, value: D::Value) {
         <&mut Self as SingletonOpsMut<_>>::insert::<D>(self, value, self.owner)
     }
 
@@ -523,15 +527,6 @@ impl<'guard, TableStorage: schema::GeneratedStorage> RoTransaction<'guard, Table
         <&Self as SingletonOps<_>>::get::<D>(self, self.owner)
     }
 
-    /// Get a single value from the store by cloning an `Arc`.
-    ///
-    /// Returns `None` if there is no value for the specified key. Panics if the value is not an `Arc`.
-    pub fn get_arc<D: schema::ArcSingleton<Storage = TableStorage>>(
-        &self,
-    ) -> Option<Arc<D::Value>> {
-        <&Self as SingletonOps<_>>::get_arc::<D>(self, self.owner)
-    }
-
     /// Get immutable access to a value in the store by reference.
     ///
     /// Returns `None` (and does not call `f`) if there is no value for the specified key.
@@ -614,7 +609,7 @@ mod test {
     use crate::store;
 
     store!(
-        kvs: { Count(u64; OWNER), Shared(String as Arc; OWNER) }
+        kvs: { Count(u64; OWNER), Shared(Arc<String>; OWNER) }
         tables: { Items(&'static str => String; OWNER), Counters(u32 => u64; OWNER) }
     );
 
@@ -721,32 +716,6 @@ mod test {
     }
 
     #[test]
-    fn txn_get_arc_returns_none_when_absent() {
-        let store = KvStore::new();
-        let txn = store.begin_transaction(OWNER);
-        assert!(txn.get_arc::<Shared>().is_none());
-    }
-
-    #[test]
-    fn txn_get_arc_returns_arc_after_insert() {
-        let store = KvStore::new();
-        store.insert::<Shared>(OWNER, Arc::new("hello".to_owned()));
-        let txn = store.begin_transaction(OWNER);
-        let arc = txn.get_arc::<Shared>().unwrap();
-        assert_eq!(*arc, "hello");
-    }
-
-    #[test]
-    fn txn_get_arc_shares_allocation() {
-        let store = KvStore::new();
-        store.insert::<Shared>(OWNER, Arc::new("hello".to_owned()));
-        let txn = store.begin_transaction(OWNER);
-        let arc1 = txn.get_arc::<Shared>().unwrap();
-        let arc2 = txn.get_arc::<Shared>().unwrap();
-        assert!(Arc::ptr_eq(&arc1, &arc2));
-    }
-
-    #[test]
     fn txn_with_returns_none_and_does_not_call_f_when_absent() {
         let store = KvStore::new();
         let txn = store.begin_transaction(OWNER);
@@ -772,6 +741,66 @@ mod test {
         let mut txn = store.begin_transaction(OWNER);
         txn.insert::<Count>(1);
         txn.remove::<Count>();
+        assert!(txn.get::<Count>().is_none());
+    }
+
+    #[test]
+    fn txn_with_mut_returns_none_and_does_not_call_f_when_absent() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        let mut called = false;
+        let result = txn.with_mut::<Count, ()>(|_| called = true);
+        assert!(result.is_none());
+        assert!(!called);
+    }
+
+    #[test]
+    fn txn_with_mut_does_not_insert_when_absent() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.with_mut::<Count, _>(|v| *v = 7);
+        assert!(txn.get::<Count>().is_none());
+    }
+
+    #[test]
+    fn txn_with_mut_mutates_value_inserted_before_txn() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 5);
+        let mut txn = store.begin_transaction(OWNER);
+        txn.with_mut::<Count, _>(|v| *v *= 2);
+        assert_eq!(txn.get::<Count>(), Some(10));
+    }
+
+    #[test]
+    fn txn_with_mut_mutates_value_inserted_in_same_txn() {
+        let store = KvStore::new();
+        let mut txn = store.begin_transaction(OWNER);
+        txn.insert::<Count>(5);
+        txn.with_mut::<Count, _>(|v| *v *= 2);
+        assert_eq!(txn.get::<Count>(), Some(10));
+    }
+
+    #[test]
+    fn txn_with_mut_sees_previous_with_mut_in_same_txn() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 0);
+        let mut txn = store.begin_transaction(OWNER);
+        txn.with_mut::<Count, _>(|v| *v += 1);
+        txn.with_mut::<Count, _>(|v| *v += 1);
+        txn.with_mut::<Count, _>(|v| *v += 1);
+        assert_eq!(txn.get::<Count>(), Some(3));
+    }
+
+    #[test]
+    fn txn_with_mut_returns_none_after_remove_in_same_txn() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 5);
+        let mut txn = store.begin_transaction(OWNER);
+        txn.remove::<Count>();
+        let mut called = false;
+        let result = txn.with_mut::<Count, ()>(|_| called = true);
+        assert!(result.is_none());
+        assert!(!called);
         assert!(txn.get::<Count>().is_none());
     }
 
@@ -803,6 +832,16 @@ mod test {
         store.insert::<Count>(OWNER, 1);
         let mut txn = store.begin_transaction(OTHER);
         txn.insert::<Count>(5);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Ownership violation")]
+    fn txn_with_mut_wrong_owner_panics() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        let mut txn = store.begin_transaction(OTHER);
+        txn.with_mut::<Count, _>(|v| *v = 5);
     }
 
     #[test]
@@ -1209,22 +1248,6 @@ mod test {
     }
 
     #[test]
-    fn ro_txn_get_arc_returns_none_when_absent() {
-        let store = KvStore::new();
-        let txn = store.begin_ro_transaction(OWNER);
-        assert!(txn.get_arc::<Shared>().is_none());
-    }
-
-    #[test]
-    fn ro_txn_get_arc_returns_arc() {
-        let store = KvStore::new();
-        store.insert::<Shared>(OWNER, Arc::new("hello".to_owned()));
-        let txn = store.begin_ro_transaction(OWNER);
-        let arc = txn.get_arc::<Shared>().unwrap();
-        assert_eq!(*arc, "hello");
-    }
-
-    #[test]
     fn ro_txn_with_returns_none_and_does_not_call_f_when_absent() {
         let store = KvStore::new();
         let txn = store.begin_ro_transaction(OWNER);
@@ -1452,6 +1475,82 @@ mod test {
         txn.commit().unwrap();
 
         assert_eq!(store.get::<Count>(OWNER), None);
+    }
+
+    #[test]
+    fn txn_singleton_with_mut_then_commit_visible() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 7);
+
+        let mut txn = store.begin_transaction(OWNER);
+        txn.with_mut::<Count, _>(|v| *v += 1);
+        txn.commit().unwrap();
+
+        assert_eq!(store.get::<Count>(OWNER), Some(8));
+    }
+
+    #[test]
+    fn txn_singleton_with_mut_commits_atomically_with_other_writes() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 0);
+
+        let mut txn = store.begin_transaction(OWNER);
+        txn.with_mut::<Count, _>(|v| *v = 1);
+        txn.table::<Items>().insert("k", "v".to_owned());
+        txn.commit().unwrap();
+
+        assert_eq!(store.get::<Count>(OWNER), Some(1));
+        assert_eq!(store.table::<Items>(OWNER).get("k"), Some("v".to_owned()));
+    }
+
+    #[test]
+    fn txn_singleton_with_mut_of_insert_in_same_txn_rolled_back_on_drop() {
+        let store = KvStore::new();
+        {
+            let mut txn = store.begin_transaction(OWNER);
+            txn.insert::<Count>(41);
+            txn.with_mut::<Count, _>(|v| *v += 1);
+            // dropped here without commit
+        }
+        assert_eq!(store.get::<Count>(OWNER), None);
+    }
+
+    #[test]
+    fn txn_singleton_with_mut_over_existing_rolled_back_on_drop() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        {
+            let mut txn = store.begin_transaction(OWNER);
+            txn.with_mut::<Count, _>(|v| *v += 1);
+        }
+        assert_eq!(store.get::<Count>(OWNER), Some(1));
+    }
+
+    #[test]
+    fn txn_singleton_with_mut_explicitly_rolled_back() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+
+        let mut txn = store.begin_transaction(OWNER);
+        txn.with_mut::<Count, _>(|v| *v += 1);
+        txn.rollback();
+
+        assert_eq!(store.get::<Count>(OWNER), Some(1));
+    }
+
+    #[test]
+    fn txn_singleton_with_mut_after_rollback_sees_pre_txn_value() {
+        let store = KvStore::new();
+        store.insert::<Count>(OWNER, 1);
+        {
+            let mut txn = store.begin_transaction(OWNER);
+            txn.with_mut::<Count, _>(|v| *v += 1);
+        }
+
+        let mut txn = store.begin_transaction(OWNER);
+        let mut seen = None;
+        txn.with_mut::<Count, _>(|v| seen = Some(*v));
+        assert_eq!(seen, Some(1));
     }
 
     #[test]

--- a/ts_kv_store_tokio/src/lib.rs
+++ b/ts_kv_store_tokio/src/lib.rs
@@ -336,7 +336,7 @@ mod tests {
 
     ts_kv_store::store!(
         kvs: {
-            Count(u64; OWNER),
+            Count(u64; OWNER; notify(Clone)),
         }
         tables: {
             Items(u32 => String; OWNER; notify(Clone)),


### PR DESCRIPTION
Closes #354

Currently based on #358

This should really be two commits, but because I didn't notice the refactoring until too late, they're smooshed together.

The big refactoring here is that I've removed the `SinValue` concept. That simplifies a bunch of code and changes the schema declarations to be closer to tables and more ergonomic (in particular removing the storage kind concept).

The new feature is the ability to mutate singletons using `with_mut` (similar to table KVs). The core of that is pretty simple, but there are some fiddly bits dealing with mutation tracking.

AI decl: I used Claude to generate tests and to fix some bugs in the mutation tracking. I've reviewed and refactored all changes.