### PR TITLE
runtime: initial support for direct udp connections

### DIFF
--- a/ts_dataplane/src/async_tokio.rs
+++ b/ts_dataplane/src/async_tokio.rs
@@ -261,7 +261,7 @@ impl DataPlane {
 
                 underlay_pkts = underlay_up.recv() => {
                     let (id, ep, underlay_pkts) = underlay_pkts.unwrap();
-                    tracing::trace!(underlay_id = ?id, from_ep = %ep.ty(), n_underlay_pkts = underlay_pkts.len());
+                    tracing::trace!(underlay_id = ?id, from_ep = ?ep, n_underlay_pkts = underlay_pkts.len());
 
                     SelectResult::UnderlayUp((id, ep, underlay_pkts))
                 }
@@ -373,7 +373,7 @@ impl DataPlane {
 async fn write_to_overlay(slf: &CoreState, packets: HashMap<OverlayTransportId, Vec<PacketMut>>) {
     for (id, packets) in packets {
         if let Some(queue) = slf.overlay_transports.get(&id) {
-            tracing::trace!(overlay_id = ?id, n_packets = packets.len());
+            tracing::trace!(overlay_id = ?id, n_packets = packets.len(), "overlay packets");
             queue.send(packets).unwrap();
         }
     }
@@ -381,7 +381,7 @@ async fn write_to_overlay(slf: &CoreState, packets: HashMap<OverlayTransportId, 
 
 async fn write_to_underlay(slf: &CoreState, packets: ts_underlay_router::outbound::Result) {
     for ((tid, endpoint), packets) in packets {
-        tracing::trace!(underlay_id = ?tid, ?endpoint, n_packets = packets.len());
+        tracing::trace!(underlay_id = ?tid, ?endpoint, n_packets = packets.len(), "underlay data packets");
 
         if let Some(queue) = slf.underlay_transports.get(&tid) {
             queue.send((endpoint, packets)).unwrap();

--- a/ts_runtime/Cargo.toml
+++ b/ts_runtime/Cargo.toml
@@ -47,6 +47,7 @@ yoke.workspace = true
 url.workspace = true
 rand.workspace = true
 bytes.workspace = true
+itertools.workspace = true
 zerocopy.workspace = true
 
 [dev-dependencies]

--- a/ts_runtime/src/control_runner.rs
+++ b/ts_runtime/src/control_runner.rs
@@ -1,8 +1,5 @@
 use core::net::{Ipv4Addr, Ipv6Addr};
-use std::{
-    net::{IpAddr, SocketAddr},
-    sync::Arc,
-};
+use std::sync::Arc;
 
 use futures::StreamExt;
 use kameo::{
@@ -13,30 +10,16 @@ use kameo::{
     supervision::RestartPolicy,
 };
 use ts_control::{
-    ControlDialer, DialPlan, Endpoint, EndpointType, Error as ControlError, Node,
-    RegistrationError, StateUpdate,
+    ControlDialer, DialPlan, Endpoint, Error as ControlError, Node, RegistrationError, StateUpdate,
     client::{HttpConn, handle_ping, send_map_request},
 };
 
 use crate::{
     Task,
     derp_latency::{DerpLatencyMeasurement, DerpLatencyMeasurer},
+    direct,
     env::Env,
-    netmon,
-    stunner::StunAddress,
 };
-
-/// Temporary debugging configuration to report the stun- and netmon-discovered endpoints to control
-/// with a dummy port. This does not result in direct UDP connectivity because there is no socket
-/// hooked up anywhere, it just creates endpoint entries in control.
-const SEND_DUMMY_ENDPOINTS: bool = false;
-
-// placeholder: we will actually get this from the direct udp actor, which will consume
-// these netmon::State messages to just directly give us an endpoint list to report.
-// for testing, just use this dummy port. it won't result in a functional configuration
-// because there's no udp socket listening, but should surface the endpoints in control
-// and induce disco traffic from peers.
-const DUMMY_PORT: u16 = 51823;
 
 /// Actor responsible for maintaining the connection to control.
 ///
@@ -47,10 +30,7 @@ pub struct ControlRunner {
 
     derp_latency_measurement: Option<DerpLatencyMeasurement>,
 
-    /// Endpoints not derived from public IPv4 STUN.
-    local_endpoints: Vec<Endpoint>,
-    /// Endpoint derived from public IPv4 STUN request.
-    stun_endpoint: Option<Endpoint>,
+    endpoints: Vec<Endpoint>,
 
     self_node: Option<Node>,
     pending_node_requests: Vec<PendingNodeRequest>,
@@ -164,8 +144,7 @@ impl kameo::Actor for ControlRunner {
         .await;
 
         params.env.subscribe::<DerpLatencyMeasurement>(&slf).await?;
-        params.env.subscribe::<Arc<netmon::State>>(&slf).await?;
-        params.env.subscribe::<StunAddress>(&slf).await?;
+        params.env.subscribe::<direct::NewEndpoints>(&slf).await?;
 
         DerpLatencyMeasurer::supervise(&slf, params.env.clone())
             .spawn()
@@ -179,8 +158,7 @@ impl kameo::Actor for ControlRunner {
             },
             params,
             derp_latency_measurement: None,
-            local_endpoints: Default::default(),
-            stun_endpoint: None,
+            endpoints: Default::default(),
             self_node: None,
             pending_node_requests: Default::default(),
         })
@@ -278,7 +256,7 @@ impl ControlRunner {
 
         let mut mrb = ts_control::MapRequestBuilder::new(&self.params.env.keys)
             .as_request()
-            .endpoints(self.endpoints());
+            .endpoints(self.endpoints.clone());
 
         if let Some(hostname) = self.params.config.hostname.as_deref() {
             mrb = mrb.hostname(hostname);
@@ -313,13 +291,6 @@ impl ControlRunner {
         )
         .await
         .unwrap();
-    }
-
-    fn endpoints(&self) -> Vec<Endpoint> {
-        let mut eps = self.local_endpoints.clone();
-        eps.extend(self.stun_endpoint);
-
-        eps
     }
 }
 
@@ -465,6 +436,19 @@ impl Message<StreamMessage<Arc<StateUpdate>, (), ()>> for ControlRunner {
     }
 }
 
+impl Message<direct::NewEndpoints> for ControlRunner {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: direct::NewEndpoints, _ctx: &mut Context<Self, Self::Reply>) {
+        if self.endpoints == msg.0.as_ref() {
+            return;
+        }
+
+        self.endpoints = msg.0.to_vec();
+        self.update_map_request().await;
+    }
+}
+
 impl Message<DerpLatencyMeasurement> for ControlRunner {
     type Reply = ();
 
@@ -474,73 +458,6 @@ impl Message<DerpLatencyMeasurement> for ControlRunner {
         }
 
         self.derp_latency_measurement = Some(msg);
-        self.update_map_request().await;
-    }
-}
-
-const CGNAT_RANGE: ipnet::Ipv4Net = ipnet::Ipv4Net::new_assert(Ipv4Addr::new(100, 64, 0, 0), 10);
-const TS_IP6_ULA: ipnet::Ipv6Net =
-    ipnet::Ipv6Net::new_assert(Ipv6Addr::new(0xfd7a, 0x115c, 0xa1e0, 0, 0, 0, 0, 0), 48);
-
-impl Message<Arc<netmon::State>> for ControlRunner {
-    type Reply = ();
-
-    async fn handle(&mut self, msg: Arc<netmon::State>, _ctx: &mut Context<Self, Self::Reply>) {
-        if !SEND_DUMMY_ENDPOINTS {
-            return;
-        }
-
-        self.local_endpoints.clear();
-
-        for (_iface, addr) in msg.up_addrs() {
-            let ip = addr.addr();
-
-            let viable_endpoint = match ip {
-                IpAddr::V4(v4) => {
-                    let invalid_addr = v4.is_broadcast()
-                        || v4.is_loopback()
-                        || v4.is_unspecified()
-                        || v4.is_documentation()
-                        || v4.is_multicast();
-
-                    !invalid_addr && !CGNAT_RANGE.contains(&v4)
-                }
-                IpAddr::V6(v6) => {
-                    let invalid_addr = v6.is_multicast() || v6.is_unspecified() || v6.is_loopback();
-
-                    !invalid_addr && !TS_IP6_ULA.contains(&v6)
-                }
-            };
-
-            if !viable_endpoint {
-                continue;
-            }
-
-            let ep = Endpoint {
-                ty: EndpointType::Local,
-                endpoint: SocketAddr::new(ip, DUMMY_PORT),
-            };
-
-            self.local_endpoints.push(ep);
-        }
-
-        self.update_map_request().await;
-    }
-}
-
-impl Message<StunAddress> for ControlRunner {
-    type Reply = ();
-
-    async fn handle(&mut self, msg: StunAddress, _ctx: &mut Context<Self, Self::Reply>) {
-        if !SEND_DUMMY_ENDPOINTS {
-            return;
-        }
-
-        self.stun_endpoint = Some(Endpoint {
-            ty: EndpointType::Stun,
-            endpoint: SocketAddr::new(msg.addr, DUMMY_PORT),
-        });
-
         self.update_map_request().await;
     }
 }

--- a/ts_runtime/src/dataplane.rs
+++ b/ts_runtime/src/dataplane.rs
@@ -63,8 +63,8 @@ impl DataplaneActor {
 pub type DiscoPacket = yoke::Yoke<&'static Packet<Plaintext>, ts_packet::Packet>;
 
 #[derive(Clone)]
-#[expect(dead_code)]
 pub struct IncomingDiscoMsg {
+    #[expect(dead_code)]
     pub transport: UnderlayTransportId,
     pub sender: DynEndpoint,
     pub packet: DiscoPacket,

--- a/ts_runtime/src/dataplane.rs
+++ b/ts_runtime/src/dataplane.rs
@@ -64,7 +64,6 @@ pub type DiscoPacket = yoke::Yoke<&'static Packet<Plaintext>, ts_packet::Packet>
 
 #[derive(Clone)]
 pub struct IncomingDiscoMsg {
-    #[expect(dead_code)]
     pub transport: UnderlayTransportId,
     pub sender: DynEndpoint,
     pub packet: DiscoPacket,

--- a/ts_runtime/src/direct.rs
+++ b/ts_runtime/src/direct.rs
@@ -1,0 +1,415 @@
+//! Direct UDP transport actor.
+//!
+//! This is an involved wrapper around a [`UdpSocket`] to make it function as an underlay transport.
+//! Technically, it's actually two sockets, an IPv4 and an IPv6 (if available). Both are bound
+//! to the unspecified address for their network type (`0.0.0.0` or `::`), and the socket to use to
+//! send a packet is determined by its address type.
+//!
+//! The primary function of this actor is just to bridge UDP tx/rx to its dataplane queues. But
+//! also, because it's the actor that holds the UDP socket(s) (and hence knows the ports each is
+//! bound on), it's additionally responsible for reporting this node's UDP endpoints on the bus (the
+//! control actor reports these to control, and the path discovery actor uses this to set its
+//! `CallMeMaybe` endpoints). It just aggregates the netmon and stun discovered addresses to
+//! (combining the netmon addresses with the local port) to make this report.
+//!
+//! No disco concerns are directly handled by this actor; these are done in [`disco`][crate::disco]
+//! (incoming `CallMeMaybe` and `Ping`s from peers) and [`path_discoverer`][crate::path_discoverer]
+//! (PD for outgoing traffic). Other parts of the system can trigger underlay packets to be sent
+//! by this actor directly via [`dataplane::SendUnderlay`][crate::dataplane::SendUnderlay] (only to
+//! be used when absolutely necessary, i.e. disco).
+
+use std::{
+    borrow::Borrow,
+    collections::HashMap,
+    io,
+    io::ErrorKind,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    sync::Arc,
+};
+
+use bytes::BytesMut;
+use futures::Stream;
+use futures_util::StreamExt;
+use itertools::Itertools;
+use kameo::{
+    actor::ActorRef,
+    message::{Context, Message, StreamMessage},
+};
+use tokio::net::UdpSocket;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use ts_bart::RoutingTable;
+use ts_control::{Endpoint, EndpointType};
+use ts_dataplane::async_tokio::{FromUnderlay, ToUnderlay, Tx};
+use ts_packet::PacketMut;
+use ts_transport::{DynEndpoint, UnderlayTransportId};
+
+use crate::{
+    dataplane::DataplaneActor,
+    disco::SendDisco,
+    env::Env,
+    netmon,
+    peer_tracker::{PeerDb, PeerState},
+    stunner::StunAddress,
+};
+
+pub struct DirectActor {
+    transport_id: UnderlayTransportId,
+
+    sock4: Arc<UdpSocket>,
+    sock6: Option<Arc<UdpSocket>>,
+
+    tx: Tx<FromUnderlay>,
+
+    peers: Arc<PeerDb>,
+
+    stun_addr: Option<SocketAddr>,
+    addrs_v4: Vec<Endpoint>,
+    addrs_v6: Vec<Endpoint>,
+
+    reachable: ts_bart::Table<()>,
+
+    env: Env,
+}
+
+#[derive(Clone, Debug)]
+pub struct NewEndpoints(pub Arc<[Endpoint]>);
+
+struct UdpRx(io::Result<HashMap<SocketAddr, Vec<PacketMut>>>);
+struct UdpTx(ToUnderlay);
+
+impl DirectActor {
+    async fn publish_endpoints(&self) -> Result<(), crate::Error> {
+        self.env
+            .publish(NewEndpoints(
+                self.addrs_v4
+                    .iter()
+                    .copied()
+                    .chain(self.addrs_v6.iter().copied())
+                    .chain(self.stun_addr.into_iter().map(|addr| Endpoint {
+                        endpoint: addr,
+                        ty: EndpointType::Stun,
+                    }))
+                    .collect(),
+            ))
+            .await
+    }
+
+    fn sock(&self, ipv4: bool) -> Option<&UdpSocket> {
+        if ipv4 {
+            Some(self.sock4.as_ref())
+        } else {
+            self.sock6.as_deref()
+        }
+    }
+}
+
+impl kameo::Actor for DirectActor {
+    type Args = Env;
+    type Error = crate::Error;
+
+    async fn on_start(env: Self::Args, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
+        let (id, rx, tx) = env
+            .ask::<DataplaneActor, _>(None, crate::dataplane::NewUnderlayTransport, true)
+            .await?;
+
+        let sock4 = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let sock4 = Arc::new(sock4);
+        tracing::debug!(transport_id = ?id, local_addr = %sock4.local_addr().unwrap(), "direct udp4 socket bound");
+
+        slf.attach_stream(udp_rx(sock4.clone()).boxed(), (), ());
+
+        let sock6 = UdpSocket::bind("[::]:0").await.ok().map(Arc::new);
+        if let Some(sock6) = sock6.as_ref() {
+            tracing::debug!(transport_id = ?id, local_addr = %sock6.local_addr().unwrap(), "direct udp6 socket bound");
+            slf.attach_stream(udp_rx(sock6.clone()).boxed(), (), ());
+        } else {
+            tracing::debug!("could not bind ipv6 direct");
+        }
+
+        slf.attach_stream(UnboundedReceiverStream::new(rx).map(UdpTx), (), ());
+
+        env.subscribe::<Arc<PeerState>>(&slf).await?;
+        env.subscribe::<StunAddress>(&slf).await?;
+        env.subscribe::<Arc<netmon::State>>(&slf).await?;
+        env.subscribe::<SendDisco>(&slf).await?;
+
+        env.register(None, &slf).await?;
+
+        Ok(Self {
+            transport_id: id,
+            sock4,
+            sock6,
+            env,
+            peers: Default::default(),
+            stun_addr: None,
+            addrs_v4: vec![],
+            addrs_v6: vec![],
+            reachable: Default::default(),
+            tx,
+        })
+    }
+}
+
+fn udp_rx(sock: impl Borrow<UdpSocket>) -> impl Stream<Item = UdpRx> {
+    // Required capacity to receive a UDP datagram. Any smaller and data may technically be dropped
+    // with a large MTU or a large fragmented packet. We keep the buffer capacity topped off to this
+    // size each time we try a receive in the loop below.
+    const REQUIRED_CAPACITY: usize = u16::MAX as _;
+
+    let buf = BytesMut::zeroed(REQUIRED_CAPACITY);
+
+    futures_util::stream::try_unfold((sock, buf), async |(sock, mut buf)| {
+        let mut v = vec![];
+
+        // Batch receive: wait until any packets are available from the socket, then try
+        // to read as many as possible until we exhaust the underlying buffer and see a wouldblock.
+        {
+            let sock = sock.borrow();
+            sock.readable().await?;
+
+            loop {
+                if buf.len() < REQUIRED_CAPACITY {
+                    buf.resize(REQUIRED_CAPACITY, 0);
+                }
+
+                let (n, who) = match sock.try_recv_from(&mut buf) {
+                    Ok((n, who)) => (n, who),
+                    Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                        break;
+                    }
+                    Err(e) => return Err(e),
+                };
+
+                let pkt_buf = buf.split_to(n);
+                v.push((who, PacketMut::from(pkt_buf)));
+            }
+        };
+
+        tracing::trace!(n_pkts = v.len(), "udp rx batch");
+
+        Ok(Some((v.into_iter().into_group_map(), (sock, buf))))
+    })
+    .map(UdpRx)
+}
+
+impl Message<Arc<PeerState>> for DirectActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: Arc<PeerState>, _ctx: &mut Context<Self, Self::Reply>) {
+        self.peers = msg.peers.clone();
+    }
+}
+
+impl Message<SendDisco> for DirectActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        SendDisco { ep, buf }: SendDisco,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) {
+        let Some(ep) = ep.as_udp() else {
+            return;
+        };
+
+        let Some(sock) = self.sock(ep.is_ipv4()) else {
+            tracing::trace!(?ep, "can't send disco, no ipv6");
+            return;
+        };
+
+        if let Err(e) = sock.send_to(&buf, ep).await {
+            tracing::warn!(?ep, error = %e, ?sock, "sending disco msg");
+        } else {
+            tracing::trace!(?ep, "sent disco msg");
+        }
+    }
+}
+
+const CGNAT_RANGE: ipnet::Ipv4Net = ipnet::Ipv4Net::new_assert(Ipv4Addr::new(100, 64, 0, 0), 10);
+const TS_IP6_ULA: ipnet::Ipv6Net =
+    ipnet::Ipv6Net::new_assert(Ipv6Addr::new(0xfd7a, 0x115c, 0xa1e0, 0, 0, 0, 0, 0), 48);
+
+fn is_tailscale(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => CGNAT_RANGE.contains(v4),
+        IpAddr::V6(v6) => TS_IP6_ULA.contains(v6),
+    }
+}
+
+impl Message<Arc<netmon::State>> for DirectActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: Arc<netmon::State>, _ctx: &mut Context<Self, Self::Reply>) {
+        self.addrs_v4.clear();
+        self.addrs_v6.clear();
+        self.reachable.clear();
+
+        for (_id, addr) in msg.up_addrs() {
+            let ip = addr.addr();
+
+            let invalid = match ip {
+                IpAddr::V4(v4) => {
+                    v4.is_broadcast()
+                        || v4.is_loopback()
+                        || v4.is_unspecified()
+                        || v4.is_documentation()
+                        || v4.is_multicast()
+                }
+                IpAddr::V6(v6) => v6.is_multicast() || v6.is_unspecified() || v6.is_loopback(),
+            };
+
+            if invalid {
+                continue;
+            }
+
+            // NOTE(npry): this might be overly defensive -- while it probably makes sense to avoid
+            // nesting our traffic through a VPN tun device if possible, this does cut off a
+            // potential connectivity path, and we don't actually know for sure that it's tailscale.
+            // Notionally, it's better to connect through another tailnet (via tailscaled) or a
+            // 3rd-party VPN than not at all, but it may also make debugging horrible and this is
+            // likely an edge case, so skip for the time being.
+            if is_tailscale(&ip) {
+                continue;
+            }
+
+            let Some(port) = self
+                .sock(ip.is_ipv4())
+                .map(|x| x.local_addr().unwrap().port())
+            else {
+                continue;
+            };
+
+            let sockaddr = SocketAddr::new(ip, port);
+
+            let ty = match ip {
+                IpAddr::V4(x) => {
+                    if x.is_link_local() || x.is_private() {
+                        EndpointType::Local
+                    } else {
+                        EndpointType::Unknown
+                    }
+                }
+                IpAddr::V6(x) => {
+                    if x.is_unique_local() || x.is_unicast_link_local() {
+                        EndpointType::Local
+                    } else {
+                        EndpointType::Unknown
+                    }
+                }
+            };
+
+            let ep = Endpoint {
+                ty,
+                endpoint: sockaddr,
+            };
+
+            if ep.endpoint.is_ipv4() {
+                self.addrs_v4.push(ep);
+            } else if self.sock6.is_some() {
+                self.addrs_v6.push(ep);
+            }
+
+            self.reachable.insert(addr, ());
+        }
+
+        self.publish_endpoints().await.unwrap()
+    }
+}
+
+impl Message<StunAddress> for DirectActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _msg: StunAddress, _ctx: &mut Context<Self, Self::Reply>) {
+        // TODO(npry): currently we're STUNning with the wrong socket (the global one in the
+        //  stunner), so the local addr + NAT mapping is going to be wrong. don't add the STUNned
+        //  address to our endpoints until it can actually reach this socket.
+
+        // self.stun_addr = Some(msg.addr);
+        // self.publish_endpoints().await.unwrap()
+    }
+}
+
+impl Message<StreamMessage<UdpTx, (), ()>> for DirectActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: StreamMessage<UdpTx, (), ()>,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) {
+        let (ep_info, pkts) = match msg {
+            StreamMessage::Next(msg) => msg.0,
+            StreamMessage::Finished(_) => {
+                tracing::warn!("udp tx stream shut down, closing");
+                ctx.stop();
+                return;
+            }
+            _ => return,
+        };
+
+        if pkts.is_empty() {
+            return;
+        }
+
+        let Some(addr) = ep_info.as_udp() else {
+            tracing::warn!(?ep_info, "invalid endpoint info for udp direct");
+            return;
+        };
+
+        let Some(sock) = self.sock(addr.is_ipv4()) else {
+            tracing::debug!("trying to send ipv6 traffic without ipv6 connectivity");
+            return;
+        };
+
+        tracing::trace!(?ep_info, selected_addr = %addr, n_pkts = pkts.len(), "udp tx batch");
+
+        for pkt in pkts {
+            if let Err(e) = sock.send_to(&pkt, addr).await {
+                tracing::error!(error = %e, "sending packet");
+            }
+        }
+    }
+}
+
+impl Message<StreamMessage<UdpRx, (), ()>> for DirectActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: StreamMessage<UdpRx, (), ()>,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) {
+        let msg = match msg {
+            StreamMessage::Next(msg) => msg.0,
+            StreamMessage::Finished(_) => {
+                tracing::warn!("udp rx stream shut down, closing");
+                return;
+            }
+            _ => return,
+        };
+
+        const ACCEPTABLE_ERR: &[io::ErrorKind] = {
+            use io::ErrorKind::*;
+            &[NetworkDown, NetworkUnreachable, HostUnreachable, TimedOut]
+        };
+
+        match msg {
+            Ok(mp) => {
+                for (ep, pkts) in mp {
+                    tracing::trace!(who = %ep, n_pkts = pkts.len(), "udp rx batch (by sender)");
+
+                    self.tx
+                        .send((self.transport_id, DynEndpoint::udp(ep), pkts))
+                        .unwrap();
+                }
+            }
+            Err(e) if ACCEPTABLE_ERR.contains(&e.kind()) => {
+                tracing::error!(error = %e, "udp receive error");
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "unrecoverable error, die");
+                panic!()
+            }
+        }
+    }
+}

--- a/ts_runtime/src/lib.rs
+++ b/ts_runtime/src/lib.rs
@@ -24,6 +24,7 @@ mod multiderp;
 mod netmon;
 mod netstack_actor;
 mod packetfilter;
+mod path_discoverer;
 pub mod peer_tracker;
 mod registry;
 mod retained_bus;
@@ -98,6 +99,9 @@ impl kameo::Actor for Runtime {
             .spawn()
             .await;
         stunner::Stunner::supervise(&slf, env.clone()).spawn().await;
+        path_discoverer::PathDiscoverer::supervise(&slf, env.clone())
+            .spawn()
+            .await;
 
         if let Some(mon) = ts_netmon::platform_mon() {
             netmon::NetmonActor::supervise(&slf, (env.clone(), Arc::new(mon)))

--- a/ts_runtime/src/lib.rs
+++ b/ts_runtime/src/lib.rs
@@ -16,6 +16,7 @@ use crate::{
 pub mod control_runner;
 mod dataplane;
 mod derp_latency;
+mod direct;
 mod disco;
 mod env;
 mod error;
@@ -83,6 +84,9 @@ impl kameo::Actor for Runtime {
         disco::Disco::supervise(&slf, env.clone()).spawn().await;
 
         Multiderp::supervise(&slf, env.clone()).spawn().await;
+        direct::DirectActor::supervise(&slf, env.clone())
+            .spawn()
+            .await;
 
         route_updater::RouteUpdater::supervise(&slf, (env.clone(), netstack_id))
             .spawn()

--- a/ts_runtime/src/netmon.rs
+++ b/ts_runtime/src/netmon.rs
@@ -92,6 +92,7 @@ impl State {
     }
 
     /// Iterate the routes on all interfaces in the `up` state.
+    #[expect(dead_code)]
     pub fn up_routes(&self) -> impl Iterator<Item = (InterfaceId, ts_netmon::Route)> {
         self.routes
             .iter()

--- a/ts_runtime/src/path_discoverer.rs
+++ b/ts_runtime/src/path_discoverer.rs
@@ -1,0 +1,553 @@
+//! Peer path discovery agent.
+//!
+//! [`PathDiscoverer`] is the top-level supervisor responsible for creating [`PeerPd`] actors in
+//! response to [`ActivePeers`] updates (one [`PeerPd`] per peer we are trying to perform path
+//! discovery for). As a reminder, [`ActivePeers`] is the set of peers (tracked and published by the
+//! dataplane) that have recent _outgoing_ traffic (this node is trying to send packets to the
+//! peer). Peers not part of the [`ActivePeers`] set have no retained path information.
+//!
+//! [`PeerPd`]'s job is to generate disco traffic to attempt to reach the peer through an avenue
+//! other than DERP. Currently, this means probing for UDP connectivity by measuring RTT of a disco
+//! ping/pong. A `CallMeMaybe` message is sent to the peer before pings go out to attempt to get it
+//! to open a reverse path. Once a path is found, it's published to the bus and interested actors
+//! may consume it -- most importantly, the route updater will update the underlay route table to
+//! use the discovered path, meaning that dataplane traffic will begin using it. If more than one
+//! path is found, the path with the lowest RTT latency is selected and published as the best path
+//! for this peer.
+//!
+//! [`PeerPd`]s attempt to perform path discovery immediately on startup and on a repeating time
+//! interval thereafter. Currently, the timeout period for ping responses _is_ this interval
+//! (`PROBE_PERIOD`). After each interval, the in-flight state is wiped and a new set of
+//! `CallMeMaybe` and `Ping` messages go out; hence, if pongs take more time than the interval to
+//! come back, the [`PeerPd`] will never record them.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use kameo::{
+    actor::{ActorRef, Spawn, WeakActorRef},
+    error::ActorStopReason,
+    message::{Context, Message},
+    supervision::RestartPolicy,
+};
+use kameo_actors::scheduler::SetInterval;
+use smol_str::SmolStr;
+use tokio::time::MissedTickBehavior;
+use ts_dataplane::async_tokio::ActivePeers;
+use ts_disco_protocol::{CallMeMaybe, MessageType, Ping, Pong};
+use ts_keys::DiscoPublicKey;
+use ts_transport::{DynEndpoint, PeerId, UnderlayTransportId};
+
+use crate::{
+    Error,
+    dataplane::IncomingDiscoMsg,
+    direct::NewEndpoints,
+    disco::{Disco, SendDisco},
+    env::Env,
+    peer_tracker::PeerState,
+};
+
+/// Top-level actor responsible for coordinating path discovery for peers.
+///
+/// Spawns per-peer child actors to handle discovery, then aggregates and debounces results.
+pub struct PathDiscoverer {
+    active_peers: ActivePeers,
+    best_paths: BestPathMap,
+    env: Env,
+}
+
+pub type BestPathMap = HashMap<PeerId, (UnderlayTransportId, DynEndpoint)>;
+
+#[derive(Clone)]
+pub struct BestPaths(pub Arc<BestPathMap>);
+
+#[derive(Clone)]
+struct PeerBestPath {
+    peer: PeerId,
+    ep: Option<(UnderlayTransportId, DynEndpoint)>,
+}
+
+impl kameo::Actor for PathDiscoverer {
+    type Args = Env;
+    type Error = Error;
+
+    async fn on_start(env: Env, slf: ActorRef<Self>) -> Result<Self, Self::Error> {
+        env.subscribe::<ActivePeers>(&slf).await?;
+        env.subscribe::<PeerBestPath>(&slf).await?;
+        env.register(None, &slf).await?;
+
+        Ok(Self {
+            env,
+            best_paths: Default::default(),
+            active_peers: Default::default(),
+        })
+    }
+
+    async fn on_stop(
+        &mut self,
+        _: WeakActorRef<Self>,
+        _: ActorStopReason,
+    ) -> Result<(), Self::Error> {
+        self.best_paths.clear();
+        self.publish_best_paths().await;
+
+        Ok(())
+    }
+}
+
+impl PathDiscoverer {
+    async fn publish_best_paths(&self) {
+        self.env
+            .publish(BestPaths(Arc::new(self.best_paths.clone())))
+            .await
+            .unwrap();
+    }
+}
+
+impl Message<ActivePeers> for PathDiscoverer {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: ActivePeers, ctx: &mut Context<Self, Self::Reply>) {
+        for &to_create in msg.difference(&self.active_peers) {
+            tracing::trace!(peer_id = ?to_create, "spawning actor for active peer");
+
+            let aref = PeerPd::supervise(ctx.actor_ref(), (self.env.clone(), to_create))
+                .restart_policy(RestartPolicy::Transient)
+                .spawn()
+                .await;
+
+            aref.wait_for_startup_result().await.unwrap();
+        }
+
+        let mut any_deleted = false;
+        for to_delete in self.active_peers.difference(&msg) {
+            // deletions are handled by the PeerPds themselves
+            any_deleted = any_deleted || self.best_paths.remove(to_delete).is_some();
+        }
+
+        if any_deleted {
+            self.publish_best_paths().await;
+        }
+
+        self.active_peers = msg;
+    }
+}
+
+impl Message<PeerBestPath> for PathDiscoverer {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        PeerBestPath { peer, ep }: PeerBestPath,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) {
+        let changed = match ep {
+            Some(ep) => {
+                let ret = self.best_paths.insert(peer, ep.clone());
+                ret != Some(ep)
+            }
+            None => self.best_paths.remove(&peer).is_some(),
+        };
+
+        if !changed {
+            return;
+        }
+
+        self.publish_best_paths().await;
+    }
+}
+
+type TxId = [u8; 12];
+
+const PROBE_PERIOD: Duration = Duration::from_millis(5_000);
+
+enum ProbeState {
+    /// This probe is in-flight with the given transaction id. It was sent at `sent`.
+    InFlight { transaction: TxId, sent: Instant },
+    /// This probe succeeded, measuring the indicated `latency`.
+    Success {
+        /// The round-trip latency measured by this probe.
+        latency: Duration,
+        /// The transport used to perform this probe.
+        transport: UnderlayTransportId,
+    },
+}
+
+/// Single-peer path discovery agent.
+struct PeerPd {
+    peer_id: PeerId,
+    disco_key: Option<DiscoPublicKey>,
+
+    /// Indicates whether we've had enough information to send probes yet.
+    ///
+    /// If not, we try to immediately send a probe whenever we get new information that might make
+    /// this possible.
+    ///
+    /// This is used as a heuristic improvement to reduce the delay to first probe in the common
+    /// case. When [`PeerPd`] spawns, there is _usually_ enough info in the system (in retained bus
+    /// messages) to immediately start sending probes for the peer. But since bus messages are sent
+    /// asynchronously and with no guaranteed order, we will need to wait briefly (milliseconds at
+    /// most in a normal system) for all of them to be delivered/until we have enough local info to
+    /// actually send the probes. The message handlers for [`PeerState`] and [`NewEndpoints`] thus
+    /// _try_ to call [`PeerPd::start_probes`] only if this field is `false`; that function
+    /// evaluates whether it has enough info to actually send the probes, and if so, sets this field
+    /// to `true` (preventing anything other than the scheduled probe intervals from triggering
+    /// probes).
+    started_probing: bool,
+
+    /// Records for current-generation probes (in-flight, or newly succeeded).
+    current_probes: HashMap<DynEndpoint, ProbeState>,
+    /// Lookup from transaction id to the endpoint to which it corresponds.
+    ///
+    /// It is expected that we may get incoming pong traffic from endpoints not in this map, e.g.
+    /// from timed out probes.
+    tx_lookup: HashMap<TxId, DynEndpoint>,
+    /// Map holding the previous probe latencies for each endpoint (i.e. from the last probe
+    /// generation). This is used to decide a latency while the next probe is in-flight.
+    previous_probe_latencies: HashMap<(UnderlayTransportId, DynEndpoint), Duration>,
+
+    this_node_endpoints: Arc<[ts_control::Endpoint]>,
+
+    /// Peer's endpoints learned from control which can be used for disco coordination, i.e. which
+    /// can be used to send `CallMeMaybe` messages.
+    ///
+    /// This field is part of a pair with `endpoints_ctrl` -- the two fields are partitioned out of
+    /// the peer's endpoints (reported from control) on the basis of their answer to
+    /// [`Endpoint::is_disco_coordinator`][ts_transport::Endpoint::is_disco_coordinator]. This field
+    /// has those which respond `true`.
+    coord_endpoints_ctrl: HashSet<DynEndpoint>,
+
+    /// Endpoints for this peer derived from the most recent netmap.
+    /// Excludes endpoints in [`PeerPd::disco_endpoints_ctrl`].
+    endpoints_ctrl: HashSet<DynEndpoint>,
+
+    /// Endpoints for this peer derived from the most recent
+    /// [`CallMeMaybe`][ts_disco_protocol::CallMeMaybe] disco message.
+    endpoints_cmm: HashSet<DynEndpoint>,
+
+    env: Env,
+}
+
+impl PeerPd {
+    pub fn actor_name(peer_id: PeerId) -> SmolStr {
+        smol_str::format_smolstr!("peerpd_{}", peer_id.0)
+    }
+
+    async fn start_probes(&mut self) {
+        let Some(disco_key) = self.disco_key else {
+            tracing::trace!("no disco key known for peer, can't send pings");
+            return;
+        };
+
+        if self.coord_endpoints_ctrl.is_empty() {
+            tracing::trace!("no disco coordinator endpoints, can't send callmemaybes");
+            return;
+        }
+
+        if self.this_node_endpoints.is_empty() {
+            tracing::trace!("no node endpoints, skip");
+            return;
+        }
+
+        self.started_probing = true;
+
+        self.tx_lookup.clear();
+        self.previous_probe_latencies.clear();
+
+        let latencies_was_empty = self.previous_probe_latencies.is_empty();
+
+        for (ep, state) in self.current_probes.drain() {
+            let ProbeState::Success { latency, transport } = state else {
+                tracing::trace!(?ep, "probe did not succeed before next start_probe");
+                continue;
+            };
+
+            tracing::trace!(?ep, ?latency, "valid latency");
+            self.previous_probe_latencies
+                .insert((transport, ep), latency);
+        }
+
+        if latencies_was_empty != self.previous_probe_latencies.is_empty() {
+            let best = self
+                .previous_probe_latencies
+                .iter()
+                .min_by_key(|&(_, dur)| dur);
+
+            self.env
+                .publish_noretain(PeerBestPath {
+                    peer: self.peer_id,
+                    ep: best.map(|((transport, ep), _latency)| (*transport, ep.clone())),
+                })
+                .await
+                .unwrap();
+        }
+
+        // Send `CallMeMaybe`s on all disco coordinator endpoints. Reminder: coord_endpoints_ctrl is
+        // already filtered at reception-time by Endpoint::is_disco_coordinator.
+        for ep in &self.coord_endpoints_ctrl {
+            let cmm_pkt = Disco::mk_pkt::<CallMeMaybe>(
+                CallMeMaybe::size_for_endpoint_count(self.this_node_endpoints.len()),
+                &self.env.keys.disco_keys,
+                &disco_key,
+                |cmm| {
+                    for (tgt, ep) in cmm
+                        .endpoints
+                        .iter_mut()
+                        .zip(self.this_node_endpoints.iter())
+                    {
+                        *tgt = ep.endpoint.into();
+                    }
+                },
+            );
+
+            self.env
+                .publish_noretain(SendDisco {
+                    ep: ep.clone(),
+                    buf: cmm_pkt,
+                })
+                .await
+                .unwrap();
+
+            tracing::trace!(?ep, sent_eps = ?self.this_node_endpoints, "sent callmemaybe");
+        }
+
+        // Send pings for all non-disco-coordinator endpoints.
+        for ep in self.endpoints_cmm.union(&self.endpoints_ctrl) {
+            if ep.is_disco_coordinator() {
+                continue;
+            }
+
+            Self::send_disco_ping(
+                &self.env,
+                ep.clone(),
+                disco_key,
+                &mut self.current_probes,
+                &mut self.tx_lookup,
+            )
+            .await;
+        }
+    }
+
+    // this is an associated fn because we need to do a partial reborrow through self
+    #[tracing::instrument(skip_all, fields(?ep, %disco_key, tx_id = tracing::field::Empty))]
+    async fn send_disco_ping(
+        env: &Env,
+        ep: DynEndpoint,
+        disco_key: DiscoPublicKey,
+        probe_state: &mut HashMap<DynEndpoint, ProbeState>,
+        tx_lookup: &mut HashMap<TxId, DynEndpoint>,
+    ) {
+        // TODO(npry): this currently makes the implicit, awkward, and not-generally-correct
+        //   assumption that at most one underlay transport id can carry traffic of a given endpoint
+        //   type. this isn't a problem currently because derp (the transport that can currently
+        //   have multiple transport ids) doesn't exchange ping/pong traffic, and udp only has one
+        //   transport id at the moment, so there's no race (currently, the first latency
+        //   report for a given endpoint will win). that's fine conceptually -- we want the fastest
+        //   endpoint -- but we should be able to measure all paths concurrently/unambiguously.
+        //   intend to refactor so that transaction id allocation occurs in the transport --
+        //   probably it reports back to us that it's issued a ping (with timestamp + txid), so we
+        //   can correlate it to a possible returned pong
+
+        let tx_id = rand::random();
+        tracing::Span::current().record(
+            "tx_id",
+            tracing::field::debug(ts_hexdump::IterFmt::contiguous(&tx_id)),
+        );
+
+        let ping_buf = Disco::mk_pkt::<Ping>(
+            Ping::size_with_padding(0),
+            &env.keys.disco_keys,
+            &disco_key,
+            |msg| {
+                msg.node_key = env.keys.node_keys.public;
+                msg.tx_id = tx_id;
+            },
+        );
+
+        env.publish_noretain(SendDisco {
+            ep: ep.clone(),
+            buf: ping_buf,
+        })
+        .await
+        .unwrap();
+
+        probe_state.insert(
+            ep.clone(),
+            ProbeState::InFlight {
+                sent: Instant::now(),
+                transaction: tx_id,
+            },
+        );
+        tx_lookup.insert(tx_id, ep);
+
+        tracing::trace!(tx_id = ?format_args!("{:x?}", ts_hexdump::IterFmt::contiguous(&tx_id)), "sent disco ping");
+    }
+}
+
+/// Periodic maintenance message triggering probes.
+#[derive(Clone, Copy)]
+struct ScheduleProbe;
+
+impl kameo::Actor for PeerPd {
+    type Args = (Env, PeerId);
+    type Error = Error;
+
+    async fn on_start(
+        (env, peer_id): Self::Args,
+        slf: ActorRef<Self>,
+    ) -> Result<Self, Self::Error> {
+        env.subscribe::<ActivePeers>(&slf).await?;
+        env.subscribe::<IncomingDiscoMsg>(&slf).await?;
+        env.subscribe::<Arc<PeerState>>(&slf).await?;
+        env.subscribe::<NewEndpoints>(&slf).await?;
+
+        env.scheduler
+            .ask(
+                SetInterval::new(slf.downgrade(), PROBE_PERIOD, ScheduleProbe)
+                    .set_missed_tick_behaviour(MissedTickBehavior::Skip),
+            )
+            .send()
+            .await?;
+
+        env.register(Some(Self::actor_name(peer_id)), &slf).await?;
+
+        Ok(Self {
+            env,
+            peer_id,
+            started_probing: false,
+            previous_probe_latencies: Default::default(),
+            this_node_endpoints: Default::default(),
+            disco_key: Default::default(),
+            tx_lookup: Default::default(),
+            current_probes: Default::default(),
+            endpoints_cmm: Default::default(),
+            coord_endpoints_ctrl: Default::default(),
+            endpoints_ctrl: Default::default(),
+        })
+    }
+}
+
+impl Message<ScheduleProbe> for PeerPd {
+    type Reply = ();
+
+    async fn handle(&mut self, _: ScheduleProbe, _: &mut Context<Self, Self::Reply>) {
+        self.start_probes().await;
+    }
+}
+
+impl Message<Arc<PeerState>> for PeerPd {
+    type Reply = ();
+
+    async fn handle(&mut self, state: Arc<PeerState>, _: &mut Context<Self, Self::Reply>) {
+        // if this peer was deleted from the netmap, let removal from ActivePeers handle killing
+        // this actor, otherwise control flow to PathDiscoverer may get confused. we can wipe out
+        // our endpoints and stop doing anything because that doesn't interfere.
+
+        if state.deletions.contains(&self.peer_id) {
+            for ep in self
+                .endpoints_ctrl
+                .drain()
+                .chain(self.coord_endpoints_ctrl.drain())
+            {
+                if self.endpoints_cmm.contains(&ep) {
+                    continue;
+                }
+
+                if let Some(ent) = self.current_probes.remove(&ep)
+                    && let ProbeState::InFlight { transaction, .. } = ent
+                {
+                    self.tx_lookup.remove(&transaction);
+                }
+            }
+
+            tracing::debug!(peer_id = ?self.peer_id, "peer deletion: state wiped, waiting for disappearance from activepeers");
+
+            return;
+        }
+
+        let Some((_, node)) = state.peers.get(&self.peer_id) else {
+            return;
+        };
+
+        self.disco_key = node.disco_key;
+
+        (self.coord_endpoints_ctrl, self.endpoints_ctrl) = node
+            .underlay_addresses
+            .iter()
+            .copied()
+            .map(DynEndpoint::udp)
+            .chain(core::iter::once(DynEndpoint::derp(node.node_key)))
+            .partition(|x| x.is_disco_coordinator());
+
+        tracing::trace!(peer_id = ?self.peer_id, endpoints_ctrl = ?self.endpoints_ctrl, disco_endpoints_ctrl = ?self.coord_endpoints_ctrl, "endpoint state updated");
+
+        if !self.started_probing {
+            self.start_probes().await;
+        }
+    }
+}
+
+impl Message<NewEndpoints> for PeerPd {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: NewEndpoints, _ctx: &mut Context<Self, Self::Reply>) {
+        self.this_node_endpoints = msg.0;
+
+        if !self.started_probing {
+            self.start_probes().await;
+        }
+    }
+}
+
+impl Message<ActivePeers> for PeerPd {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: ActivePeers, ctx: &mut Context<Self, Self::Reply>) {
+        if !msg.contains(&self.peer_id) {
+            tracing::debug!(peer_id = %self.peer_id, "peer went inactive, stopping path discovery");
+            ctx.stop();
+        }
+    }
+}
+
+impl Message<IncomingDiscoMsg> for PeerPd {
+    type Reply = ();
+
+    #[tracing::instrument(skip_all, fields(sender = ?msg.sender, transport_id = ?msg.transport))]
+    async fn handle(&mut self, msg: IncomingDiscoMsg, _ctx: &mut Context<Self, Self::Reply>) {
+        let pkt = msg.packet.get();
+
+        let Some(pong) = pkt.as_msg::<Pong>() else {
+            return;
+        };
+
+        tracing::trace!("got pong");
+
+        let Some(ep) = self.tx_lookup.remove(&pong.tx_id) else {
+            tracing::trace!(tx_id = ?format_args!("{:x?}", ts_hexdump::IterFmt::contiguous(&pong.tx_id)), "no pong known with this tx id");
+            return;
+        };
+
+        let Some(entry) = self.current_probes.get_mut(&ep) else {
+            // this endpoint must have been removed while the check was in-flight, drop it
+            tracing::trace!(peer_id = ?self.peer_id, ?ep, "drop probe with missing state entry");
+            return;
+        };
+
+        let ProbeState::InFlight { sent, .. } = &entry else {
+            tracing::warn!("got ping response but it wasn't in-flight in endpoint entry");
+            return;
+        };
+
+        let elapsed = Instant::now() - *sent;
+        tracing::trace!(rtt = ?elapsed, endpoint = ?ep, peer_id = %self.peer_id, "measured latency");
+
+        *entry = ProbeState::Success {
+            latency: elapsed,
+            transport: msg.transport,
+        };
+    }
+}

--- a/ts_runtime/src/path_discoverer.rs
+++ b/ts_runtime/src/path_discoverer.rs
@@ -37,7 +37,7 @@ use kameo_actors::scheduler::SetInterval;
 use smol_str::SmolStr;
 use tokio::time::MissedTickBehavior;
 use ts_dataplane::async_tokio::ActivePeers;
-use ts_disco_protocol::{CallMeMaybe, MessageType, Ping, Pong};
+use ts_disco_protocol::{CallMeMaybe, Ping, Pong};
 use ts_keys::DiscoPublicKey;
 use ts_transport::{DynEndpoint, PeerId, UnderlayTransportId};
 

--- a/ts_runtime/src/route_updater.rs
+++ b/ts_runtime/src/route_updater.rs
@@ -10,59 +10,66 @@ use ts_overlay_router::{
 };
 use ts_transport::{DynEndpoint, OverlayTransportId, PeerId, UnderlayTransportId};
 
-use crate::{Error, env::Env, multiderp::DerpTransportMap, peer_tracker::PeerState};
+use crate::{
+    Error,
+    env::Env,
+    multiderp::DerpTransportMap,
+    path_discoverer::{BestPathMap, BestPaths},
+    peer_tracker::PeerState,
+};
 
 pub struct RouteUpdater {
     default_overlay_transport: OverlayTransportId,
     /// Map of all available DERP regions to the ID of the underlay transport that handles that
-    /// region.  If `None`, we haven't received a `DerpTransportMap` message yet. `Some` but empty
-    /// is a valid state meaning there aren't any regions available or underlay transports to handle
-    /// them; usually means connectivity loss or we're shutting down.
-    derp_transport_map: Option<DerpTransportMap>,
+    /// region.
+    derp_transport_map: DerpTransportMap,
     peer_state: Arc<PeerState>,
+    best_paths: Arc<BestPathMap>,
     env: Env,
 }
 
 impl RouteUpdater {
-    fn build_routes(&self) -> PeerRoutesInner {
+    fn build_peer_routes(&self) -> PeerRoutesInner {
         tracing::trace!(
             n_peers = self.peer_state.peers.peers().len(),
             "reconstructing routes for peer update"
         );
 
         let mut routes = PeerRoutesInner::default();
-        let Some(derp_map) = &self.derp_transport_map else {
-            tracing::debug!("not building routes, derp map unpopulated");
-            return routes;
-        };
 
         for (id, peer) in self.peer_state.peers.peers() {
             let span = tracing::trace_span!(
-                "peer_update",
+                "peer_route_update",
                 peer_key = %peer.node_key,
                 region = ?peer.derp_region,
                 underlay_transport = tracing::field::Empty,
+                ep = tracing::field::Empty,
                 peer_id = ?id,
             )
             .entered();
 
-            let Some(region) = peer.derp_region else {
+            let (transport_id, ep) = if let Some((transport_id, ep)) = self.best_paths.get(id) {
+                (*transport_id, ep.clone())
+            } else if let Some(region) = peer.derp_region
+                && let Some(transport_id) = self.derp_transport_map.0.get(&region)
+            {
+                (*transport_id, DynEndpoint::derp(peer.node_key))
+            } else {
+                if !self.derp_transport_map.0.is_empty() {
+                    tracing::error!("no region stored in multiderp, no underlay route");
+                }
+
                 continue;
             };
 
-            match derp_map.0.get(&region) {
-                Some(&transport_id) => {
-                    span.record("underlay_transport", tracing::field::debug(transport_id));
-                    routes
-                        .underlay_routes
-                        .insert(*id, (transport_id, DynEndpoint::derp(peer.node_key)));
-                }
-                None => {
-                    tracing::error!("no region stored in multiderp, no underlay route");
-                }
-            }
+            routes
+                .underlay_routes
+                .insert(*id, (transport_id, ep.clone()));
 
-            tracing::trace!(routes = ?peer.accepted_routes);
+            span.record("underlay_transport", tracing::field::debug(&transport_id));
+            span.record("ep", tracing::field::debug(&ep));
+
+            tracing::trace!(?ep, ?transport_id, "selected route for peer");
 
             for route in &peer.accepted_routes {
                 routes
@@ -72,6 +79,20 @@ impl RouteUpdater {
         }
 
         routes
+    }
+
+    async fn publish_peer_routes(&mut self) {
+        let new_routes = self.build_peer_routes();
+
+        if let Err(e) = self
+            .env
+            .publish(PeerRouteUpdate {
+                inner: Arc::new(new_routes),
+            })
+            .await
+        {
+            tracing::error!(error = %e, "publishing peer route update");
+        }
     }
 }
 
@@ -86,13 +107,15 @@ impl kameo::Actor for RouteUpdater {
         env.subscribe::<Arc<PeerState>>(&slf).await?;
         env.subscribe::<Arc<ts_control::StateUpdate>>(&slf).await?;
         env.subscribe::<DerpTransportMap>(&slf).await?;
+        env.subscribe::<BestPaths>(&slf).await?;
 
         env.register(None, &slf).await?;
 
         Ok(Self {
             default_overlay_transport: default_transport,
-            derp_transport_map: None,
+            derp_transport_map: Default::default(),
             peer_state: Default::default(),
+            best_paths: Default::default(),
             env,
         })
     }
@@ -120,7 +143,7 @@ impl Message<Arc<PeerState>> for RouteUpdater {
     async fn handle(&mut self, msg: Arc<PeerState>, _ctx: &mut Context<Self, Self::Reply>) {
         self.peer_state = msg;
 
-        let new_routes = self.build_routes();
+        let new_routes = self.build_peer_routes();
 
         if let Err(e) = self
             .env
@@ -138,28 +161,14 @@ impl Message<DerpTransportMap> for RouteUpdater {
     type Reply = ();
 
     async fn handle(&mut self, msg: DerpTransportMap, _ctx: &mut Context<Self, Self::Reply>) {
-        if self
-            .derp_transport_map
-            .as_ref()
-            .is_some_and(|map| map.0 == msg.0)
-        {
+        if self.derp_transport_map.0 == msg.0 {
             return;
         }
 
         tracing::debug!("derp transport map changed, building new routes");
 
-        self.derp_transport_map = Some(msg);
-
-        let new_routes = self.build_routes();
-        if let Err(e) = self
-            .env
-            .publish(PeerRouteUpdate {
-                inner: Arc::new(new_routes),
-            })
-            .await
-        {
-            tracing::error!(error = %e, "publishing peer route update");
-        }
+        self.derp_transport_map = msg;
+        self.publish_peer_routes().await;
     }
 }
 
@@ -195,5 +204,24 @@ impl Message<Arc<ts_control::StateUpdate>> for RouteUpdater {
         {
             tracing::error!(error = %e, "publishing self route update");
         }
+    }
+}
+
+impl Message<BestPaths> for RouteUpdater {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        BestPaths(new_bps): BestPaths,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) {
+        if self.best_paths == new_bps {
+            tracing::trace!("no change to best paths, skip");
+            return;
+        }
+
+        self.best_paths = new_bps;
+
+        self.publish_peer_routes().await;
     }
 }


### PR DESCRIPTION
2(.5) new actors: path discoverer (the .5 is its per-peer supervised children) and direct udp. Recommend reviewing commit-by-commit.

The direct udp actor is basically plumbing between the dataplane queues and two udp sockets (one IPv4 and one IPv6 (if available)) -- it mostly just shuttles packets back and forth from the socket to the queue. Since it's the only part of the system that knows the UDP local ports, it's also responsible for publishing the fully resolved local endpoints on the bus (it listens to netmon for the set of locally bound addresses, combines with the port, and merges in the IPv4 stun address verbatim). The control actor grabs those and reports them up, and the pd actor also uses them to construct its `CallMeMaybe`. I actually totally skipped the underlay transport trait here. I think for modularity, it's probably preferable to use the trait, but it really also felt fine just to plumb it in directly. It just doesn't feel like there's actually that much to it, and we currently don't have a "transport registry" of any description because the transports are all connected through channels instead, and have kind of bespoke shapes anyway. To revisit -- I don't think this should block this PR.

The path discoverer actor tracks the `ActivePeers` set introduced in #312, and in a similar structure as multiderp, spawns a supervised child actor per active peer. Each of these `PeerPd` children is responsible for running a periodic `CallMeMaybe` + `Ping` probe and noting which paths come back with `Pong`s from the peer, and with what latency. The best path is chosen and published back to the parent, which aggregates a map of `PeerId -> DynEndpoint` (best paths) over time, which gets published to the bus. The route updater is updated to merge in this new best path information. Currently this is strictly preferred over derp, even if in reality derp would have a shorter latency (derp paths aren't pinged currently, just used for `CallMeMaybe`) -- derp is only used if there is no UDP path for the peer at all. We do it this way just because the derp latency isn't immediately accessible to the route updater -- it could listen for the derp latency map and reconcile this against the peer's derp region, but this will be much simpler to do with the kv store and feels like an edge case, so I left it out for now.