### PR TITLE
Update 'spin' from 0.9.8 to 0.9.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5000,9 +5000,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1034,7 +1034,7 @@ version = "0.6.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.spin]]
-version = "0.9.8"
+version = "0.9.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.stable_deref_trait]]


### PR DESCRIPTION
0.9.8 was yanked due to a soundess bug. We only use spin via the flume crate, and flume doesn't use the buggy codepath, so this is really a no-op to keep supply chain analysis clean.

Change-Id: I375facbb3c428fc9976975c1afab89a76a6a6964

---

I also updated the exemption version in supply-chain/config.toml, but I'm not sure if that's the right thing to do? I audited the change from 0.9.8 to 0.9.9 and found it to be benign, and ideally I'd like to record this fact somehow, but I don't know if these tools support a notion of vetting individual patch releases while still accepting the original baseline as an exemption.