### PR TITLE
ts_tunnel: move more handshake logic into handshake.rs

### DIFF
--- a/ts_tunnel/src/endpoint.rs
+++ b/ts_tunnel/src/endpoint.rs
@@ -5,16 +5,15 @@ use itertools::Itertools;
 use ts_keys::{NodeKeyPair, NodePublicKey};
 use ts_packet::PacketMut;
 use ts_time::{Handle, Scheduler, TimeRange};
-use zerocopy::IntoBytes;
 
 use crate::{
     config::{PeerConfig, PeerId},
-    handshake::{Handshake, ReceivedHandshake, initiate_handshake},
+    handshake::{Handshake, ReceivedHandshake},
     ids::IdMap,
-    macs::{MACReceiver, MACSender},
-    messages::{CookieReply, HandshakeResponse, Message, MessageMut, SessionId},
+    macs::MACReceiver,
+    messages::{HandshakeResponse, Message, MessageMut, SessionId},
     session::Session,
-    time::{TAI64N, TAI64NClock},
+    time::TAI64NClock,
 };
 
 /// If an endpoint hasn't sent any packets to a peer for `KEEPALIVE_TIMEOUT` after receiving a
@@ -28,8 +27,6 @@ struct Peer {
     config: PeerConfig,
     session: Session,
     handshake: Handshake,
-    last_seen_timestamp: Option<TAI64N>,
-    cookie_sender: MACSender,
     keepalive: Option<Handle<Event>>,
     session_cleanup: Option<Handle<Event>>,
     send_another_keepalive: bool,
@@ -37,14 +34,13 @@ struct Peer {
 
 impl Peer {
     fn new(id: PeerId, config: PeerConfig) -> Self {
-        let macs = MACSender::new(&config.key);
+        let handshake = Handshake::new(&config.key);
         Self {
             id,
             config,
+            handshake,
+
             session: Default::default(),
-            handshake: Handshake::None,
-            last_seen_timestamp: None,
-            cookie_sender: macs,
             keepalive: None,
             session_cleanup: None,
             send_another_keepalive: false,
@@ -109,7 +105,7 @@ impl Peer {
                 false
             }
             Ok(MessageMut::CookieReply(resp)) => {
-                self.recv_cookie_reply(resp);
+                self.handshake.cookie_reply(resp);
                 false
             }
             Ok(MessageMut::HandshakeInitiation(_)) => {
@@ -127,14 +123,6 @@ impl Peer {
         }
 
         self.recv_transport_data(endpoint, session_id, packets, now, out);
-    }
-
-    fn recv_cookie_reply(&mut self, packet: &CookieReply) {
-        let Handshake::Initiated(_, _, handshake_mac1) = &mut self.handshake else {
-            tracing::trace!("dropping cookie reply received outside of handshake");
-            return;
-        };
-        self.cookie_sender.receive_cookie(packet, handshake_mac1);
     }
 
     fn recv_handshake_response(
@@ -187,8 +175,13 @@ impl Peer {
             return;
         }
 
-        let Some((session, packets)) = self.handshake.confirm(session_id, packets) else {
-            // TODO: log
+        let Some(tentative_id) = self.handshake.session_id() else {
+            return;
+        };
+        if tentative_id != session_id {
+            return;
+        }
+        let Some((session, packets)) = self.handshake.confirm(packets) else {
             return;
         };
 
@@ -216,29 +209,15 @@ impl Peer {
         now: Instant,
         out: &mut RecvResult,
     ) {
-        if let Some(timestamp) = self.last_seen_timestamp
-            && handshake.timestamp < timestamp
-        {
-            // Replayed handshake initiation
-            // TODO: because we buffer the raw initiation packet on the sender side, we need to accept
-            // initiations with an equal timestamp to the last one received. Check against reference
-            // implementations and see if we should instead regenerate a fresh handshake with new timestamp
-            // on retransmit.
-            tracing::warn!("handshake replay detected, bailing out");
-            return;
-        }
-        self.last_seen_timestamp = Some(handshake.timestamp);
-
-        let session_id = endpoint.ids.allocate_session(self.id);
-
         let packet = self.handshake.respond(
-            session_id,
             handshake,
+            || endpoint.ids.allocate_session(self.id),
             &self.config.psk,
-            &self.cookie_sender,
             now,
         );
-        out.queue_to_peer(self.id, [packet]);
+        if let Some(packet) = packet {
+            out.queue_to_peer(self.id, [packet]);
+        }
     }
 
     fn handshake_timeout(
@@ -251,8 +230,6 @@ impl Peer {
             // Handshake completed prior to timeout firing.
             return;
         }
-
-        self.handshake = Handshake::None;
 
         self.start_handshake(endpoint, now, out);
     }
@@ -283,8 +260,7 @@ impl Peer {
 
     fn shutdown(&mut self) {
         self.session.deactivate();
-
-        self.handshake = Handshake::None;
+        self.handshake.abandon();
         if let Some(handle) = self.session_cleanup.take() {
             handle.cancel();
         }
@@ -301,24 +277,17 @@ impl Peer {
         now: Instant,
         out: &mut impl QueueToPeer,
     ) {
-        // TODO most of this logic might be better in the `handshake` module.
         let session_id = endpoint.ids.allocate_session(self.id);
-        tracing::debug!(peer_id = ?self.id, ?session_id, "enqueue handshake start");
-        let (handshake, packet) = initiate_handshake(
+        let packet = self.handshake.initiate(
+            &mut endpoint.scheduler,
+            session_id,
             &endpoint.my_key,
             &self.config.key,
-            session_id,
+            Event::HandshakeTimeout(self.id),
             endpoint.timestamps.now(),
+            now,
         );
-
-        let mut packet = PacketMut::from(packet.as_bytes());
-        let mac = self.cookie_sender.write_macs(packet.as_mut());
-
         out.queue_to_peer(self.id, [packet]);
-        let tr = TimeRange::new_around(now + HANDSHAKE_TIMEOUT, Duration::from_millis(500));
-
-        let timeout = endpoint.scheduler.add(tr, Event::HandshakeTimeout(self.id));
-        self.handshake = Handshake::Initiated(handshake, timeout, mac);
     }
 }
 
@@ -468,14 +437,9 @@ impl Endpoint {
         ret
     }
 
-    fn process_one_handshake(&mut self, mut packet: PacketMut, now: Instant, out: &mut RecvResult) {
-        let Ok(MessageMut::HandshakeInitiation(init)) = MessageMut::try_from(packet.as_mut())
-        else {
-            tracing::error!("message parsing failed");
-            return;
-        };
+    fn process_one_handshake(&mut self, packet: PacketMut, now: Instant, out: &mut RecvResult) {
         let Some(handshake) =
-            ReceivedHandshake::new(init, &self.state.my_key, &self.state.my_cookie)
+            ReceivedHandshake::new(packet, &self.state.my_key, &self.state.my_cookie)
         else {
             tracing::error!("parsing received handshake failed");
             return;
@@ -611,8 +575,6 @@ pub enum Event {
     /// Clean up expired session state.
     ExpireSession(PeerId),
 }
-
-const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[cfg(test)]
 mod tests {

--- a/ts_tunnel/src/handshake.rs
+++ b/ts_tunnel/src/handshake.rs
@@ -1,9 +1,12 @@
-use std::time::Instant;
+use std::{
+    mem::replace,
+    time::{Duration, Instant},
+};
 
 use ts_keys::{NodeKeyPair, NodePublicKey};
 use ts_noise::ikpsk2;
 use ts_packet::PacketMut;
-use ts_time::Handle;
+use ts_time::{Handle, Scheduler, TimeRange};
 use zerocopy::IntoBytes;
 
 use crate::{
@@ -18,124 +21,76 @@ use crate::{
 
 const PROLOGUE: &[u8] = b"WireGuard v1 zx2c4 Jason@zx2c4.com";
 
-/// A partially completed incoming handshake.
+/// A partially processed incoming handshake.
+///
+/// Incoming handshakes have to be decrypted in order to know who the remote peer is, before a reply
+/// can be generated. [`ReceivedHandshake`] holds this half-handled incoming handshake until it's
+/// dispatched to the correct peer's [`Handshake::respond`] for further processing.
 pub struct ReceivedHandshake {
+    /// The session ID the initiator wants us to use when sending it packets.
     responder_to_initiator_id: SessionId,
+    /// The half-completed Noise handshake with the peer. It is far enough along to provide the
+    /// peer's static public key.
     noise: ikpsk2::ReceivedHandshake,
-    // Info decrypted from the HandshakeInitiation
-    pub timestamp: TAI64N,
+    /// The packet's anti-replay timestamp.
+    timestamp: TAI64N,
 }
 
 impl ReceivedHandshake {
-    /// Process a peer's handshake initiation message.
-    pub fn new(
-        pkt: &mut HandshakeInitiation,
-        my_static: &NodeKeyPair,
-        macs: &MACReceiver,
-    ) -> Option<ReceivedHandshake> {
-        if !macs.verify_macs(pkt.as_bytes()) {
+    pub fn new(mut pkt: PacketMut, my_static: &NodeKeyPair, macs: &MACReceiver) -> Option<Self> {
+        if !macs.verify_macs(pkt.as_ref()) {
+            return None;
+        }
+
+        let Ok(MessageMut::HandshakeInitiation(init)) = MessageMut::try_from(pkt.as_mut()) else {
+            tracing::debug!("invalid handshake initiation message");
             return None;
         };
 
         let (noise, timestamp) =
-            ikpsk2::ReceivedHandshake::new(&mut pkt.noise, PROLOGUE, my_static.into())?;
+            ikpsk2::ReceivedHandshake::new::<TAI64N>(&mut init.noise, PROLOGUE, my_static.into())?;
 
-        Some(ReceivedHandshake {
-            responder_to_initiator_id: pkt.sender_id,
+        Some(Self {
+            responder_to_initiator_id: init.sender_id,
             noise,
             timestamp: *timestamp,
         })
     }
 
-    /// Finalize the handshake, producing a HandshakeResponse.
-    pub fn respond(
-        self,
-        initiator_to_responder_id: SessionHandle,
-        psk: &Psk,
-        macs: &MACSender,
-        now: Instant,
-    ) -> (BidiSession, PacketMut) {
-        let mut response = HandshakeResponse {
-            sender_id: initiator_to_responder_id.id(),
-            receiver_id: self.responder_to_initiator_id,
-            ..Default::default()
-        };
-
-        let session_keys = self.noise.finish(psk, response.noise.as_mut_bytes());
-
-        let session = BidiSession::new_responder(
-            session_keys,
-            initiator_to_responder_id,
-            self.responder_to_initiator_id,
-            now,
-        );
-        let mut pkt = PacketMut::new(size_of::<HandshakeResponse>());
-        // Packet is allocated above with the correct size.
-        response.write_to(pkt.as_mut()).unwrap();
-        macs.write_macs(pkt.as_mut());
-        (session, pkt)
-    }
-
+    /// Return the peer's static public key.
     pub fn peer_static(&self) -> NodePublicKey {
         self.noise.peer_static_pub.to_bytes().into()
     }
 }
 
-/// Generate a handshake initiation message for a peer.
-pub fn initiate_handshake(
-    endpoint_static: &NodeKeyPair,
-    peer_static: &NodePublicKey,
-    session_id: SessionHandle,
-    timestamp: TAI64N,
-) -> (SentHandshake, HandshakeInitiation) {
-    let mut pkt = HandshakeInitiation {
-        sender_id: session_id.id(),
-        ..Default::default()
-    };
-
-    let noise = ikpsk2::SentHandshake::new(
-        endpoint_static.into(),
-        peer_static.into(),
-        PROLOGUE,
-        timestamp,
-        pkt.noise.as_mut_bytes(),
-    );
-
-    let ret = SentHandshake {
-        responder_to_initiator_id: session_id,
-        noise,
-    };
-
-    (ret, pkt)
-}
-
 /// A partially completed sent handshake.
-pub struct SentHandshake {
-    pub responder_to_initiator_id: SessionHandle,
+struct SentHandshake {
+    responder_to_initiator_handle: SessionHandle,
     noise: ikpsk2::SentHandshake<TAI64N>,
+    timeout: Handle<Event>,
+    // The mac1 of the transmitted handshake, required to process CookieReply messages.
+    mac1: Mac,
 }
 
-/// A handshake with a peer.
-pub(crate) enum Handshake {
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// The state machine portion of a handshake.
+#[derive(Default)]
+enum State {
     /// No handshake in progress.
+    #[default]
     None,
     /// We are the initiator, awaiting a response.
-    ///
-    /// Second field is the timeout for the handshake.
-    Initiated(SentHandshake, Handle<Event>, Mac),
+    Initiated(SentHandshake),
     /// We are the responder, awaiting an initial transport
     /// message to confirm the new session.
     Responded(Box<BidiSession>),
 }
 
-impl Handshake {
-    pub(crate) fn is_active(&self) -> bool {
-        !matches!(self, Handshake::None)
-    }
-
-    pub(crate) fn take_initiated(&mut self) -> Option<(SentHandshake, Handle<Event>, Mac)> {
-        match std::mem::replace(self, Handshake::None) {
-            Handshake::Initiated(sent, timeout, mac) => Some((sent, timeout, mac)),
+impl State {
+    fn take_if_initiated(&mut self) -> Option<SentHandshake> {
+        match replace(self, State::None) {
+            State::Initiated(sent) => Some(sent),
             other => {
                 *self = other;
                 None
@@ -143,18 +98,197 @@ impl Handshake {
         }
     }
 
-    /// Respond to a peer's handshake initiation, and switch to the responder state to await
-    /// session confirmation.
+    fn take_if_responded(&mut self) -> Option<Box<BidiSession>> {
+        match replace(self, State::None) {
+            State::Responded(session) => Some(session),
+            other => {
+                *self = other;
+                None
+            }
+        }
+    }
+
+    fn as_initiated_mut(&mut self) -> Option<&mut SentHandshake> {
+        if let State::Initiated(sent) = self {
+            Some(sent)
+        } else {
+            None
+        }
+    }
+
+    fn as_responded_mut(&mut self) -> Option<&mut BidiSession> {
+        if let State::Responded(session) = self {
+            Some(session.as_mut())
+        } else {
+            None
+        }
+    }
+}
+
+/// The handshake state for a peer.
+///
+/// Handshake state can be idle, or in-flight. As soon as a handshake completes, it yields a new
+/// usable [`BidiSession`] and goes back to being idle.
+pub struct Handshake {
+    cookie_sender: MACSender,
+    last_seen_timestamp: Option<TAI64N>,
+    state: State,
+}
+
+impl Handshake {
+    pub fn new(peer_key: &NodePublicKey) -> Self {
+        let cookie_sender = MACSender::new(peer_key);
+        Self {
+            cookie_sender,
+            last_seen_timestamp: None,
+            state: State::None,
+        }
+    }
+
+    /// Report whether a handshake is currently in flight.
+    pub fn is_active(&self) -> bool {
+        !matches!(self.state, State::None)
+    }
+
+    /// Abandon any in-flight handshake, returning to the idle state.
+    pub fn abandon(&mut self) {
+        self.state = State::None;
+    }
+
+    /// Return the session ID of the handshake's tentative session, if one exists.
     ///
-    /// Responding replaces any other handshake state unconditionally.
-    pub(crate) fn respond(
+    /// Callers wishing to use [`Handshake::confirm`] can use this method to check if it's worth
+    /// attempting.
+    pub fn session_id(&self) -> Option<SessionId> {
+        match &self.state {
+            State::Responded(session) => Some(session.recv_id()),
+            _ => None,
+        }
+    }
+
+    /// Start a new handshake in the initiator role.
+    ///
+    /// Starting a new handshake abandons any other handshake that was already in flight.
+    pub fn initiate(
         &mut self,
-        session_id: SessionHandle,
-        handshake: ReceivedHandshake,
-        psk: &Psk,
-        cookie_sender: &MACSender,
+        scheduler: &mut Scheduler<Event>,
+        session_handle: SessionHandle,
+        my_static: &NodeKeyPair,
+        peer_static: &NodePublicKey,
+        timeout_event: Event,
+        timestamp: TAI64N,
         now: Instant,
     ) -> PacketMut {
+        let mut pkt = HandshakeInitiation {
+            sender_id: session_handle.id(),
+            ..Default::default()
+        };
+
+        let noise = ikpsk2::SentHandshake::new(
+            my_static.into(),
+            peer_static.into(),
+            PROLOGUE,
+            timestamp,
+            pkt.noise.as_mut_bytes(),
+        );
+        let mut pkt = PacketMut::from(pkt.as_bytes());
+        let mac1 = self.cookie_sender.write_macs(pkt.as_mut());
+
+        let tr = TimeRange::new_around(now + HANDSHAKE_TIMEOUT, Duration::from_millis(500));
+        let timeout = scheduler.add(tr, timeout_event);
+
+        self.state = State::Initiated(SentHandshake {
+            responder_to_initiator_handle: session_handle,
+            noise,
+            timeout,
+            mac1,
+        });
+
+        pkt
+    }
+
+    /// Finish a handshake as the initiator, returning the newly established sessions.
+    ///
+    /// The handshake state is unchanged if the handshake cannot complete, either because
+    /// it's not in an appropriate state or because the handshake response isn't a valid
+    /// completion of the handshake.
+    pub fn finish(
+        &mut self,
+        packet: &mut HandshakeResponse,
+        endpoint_static: &NodeKeyPair,
+        psk: &Psk,
+        cookies: &MACReceiver,
+        now: Instant,
+    ) -> Option<BidiSession> {
+        let mut sent_handshake = self.state.take_if_initiated()?;
+
+        if !cookies.verify_macs(packet.as_bytes()) {
+            self.state = State::Initiated(sent_handshake);
+            return None;
+        };
+
+        let session_keys =
+            match sent_handshake
+                .noise
+                .try_finish(&mut packet.noise, endpoint_static.into(), psk)
+            {
+                Ok(session_keys) => session_keys,
+                Err(handshake) => {
+                    sent_handshake.noise = handshake;
+                    self.state = State::Initiated(sent_handshake);
+                    return None;
+                }
+            };
+
+        let session = BidiSession::new_initiator(
+            session_keys,
+            sent_handshake.responder_to_initiator_handle,
+            packet.sender_id,
+            now,
+        );
+
+        sent_handshake.timeout.cancel();
+
+        Some(session)
+    }
+
+    /// Respond to a [`ReceivedHandshake`] from the peer.
+    ///
+    /// The session must be confirmed before it can be used to communicate, by calling
+    /// [`Handshake::confirm`] with valid data packets from the initiator.
+    ///
+    /// Responding abandons any other handshake that was already in flight.
+    pub fn respond(
+        &mut self,
+        handshake: ReceivedHandshake,
+        allocate_session_handle: impl FnOnce() -> SessionHandle,
+        psk: &Psk,
+        now: Instant,
+    ) -> Option<PacketMut> {
+        if let Some(last_seen_timestamp) = self.last_seen_timestamp
+            && handshake.timestamp < last_seen_timestamp
+        {
+            tracing::trace!("handshake replay detected, bailing out");
+            return None;
+        }
+
+        let session_handle = allocate_session_handle();
+        let mut response = HandshakeResponse {
+            sender_id: session_handle.id(),
+            receiver_id: handshake.responder_to_initiator_id,
+            ..Default::default()
+        };
+        let session_keys = handshake.noise.finish(psk, response.noise.as_mut_bytes());
+        let mut pkt = PacketMut::from(response.as_bytes());
+        self.cookie_sender.write_macs(pkt.as_mut());
+
+        let session = Box::new(BidiSession::new_responder(
+            session_keys,
+            session_handle,
+            handshake.responder_to_initiator_id,
+            now,
+        ));
+
         // TODO: tie-breaker for simultaneous initiation.
         // When both peers initiate simultaneously, it's possible to get into a sticky situation
         // where each peer completes their own initiation based on the other's response, and in
@@ -168,54 +302,8 @@ impl Handshake {
         // We may also be able to resolve this race with a 4th handshake state wherein we are
         // simultaneously initiator and responder, and temporarily exist in quantum superposition
         // until confirmation packets collapse the state again.
-        let (session, packet) = handshake.respond(session_id, psk, cookie_sender, now);
-        *self = Handshake::Responded(Box::new(session));
-        packet
-    }
-
-    /// Finish a handshake as the initiator, returning the newly established sessions.
-    ///
-    /// The handshake state is unchanged if the handshake cannot complete, either because
-    /// it's not in an appropriate state or because the handshake response isn't a valid
-    /// completion of the handshake.
-    pub(crate) fn finish(
-        &mut self,
-        packet: &mut HandshakeResponse,
-        endpoint_static: &NodeKeyPair,
-        psk: &Psk,
-        cookies: &MACReceiver,
-        now: Instant,
-    ) -> Option<BidiSession> {
-        let (mut sent_handshake, timeout, mac) = self.take_initiated()?;
-
-        if !cookies.verify_macs(packet.as_bytes()) {
-            *self = Handshake::Initiated(sent_handshake, timeout, mac);
-            return None;
-        };
-
-        let session_keys =
-            match sent_handshake
-                .noise
-                .try_finish(&mut packet.noise, endpoint_static.into(), psk)
-            {
-                Ok(session_keys) => session_keys,
-                Err(handshake) => {
-                    sent_handshake.noise = handshake;
-                    *self = Handshake::Initiated(sent_handshake, timeout, mac);
-                    return None;
-                }
-            };
-
-        let session = BidiSession::new_initiator(
-            session_keys,
-            sent_handshake.responder_to_initiator_id,
-            packet.sender_id,
-            now,
-        );
-
-        timeout.cancel();
-
-        Some(session)
+        self.state = State::Responded(session);
+        Some(pkt)
     }
 
     /// Confirm a handshake as responder, using the provided ciphertext packets.
@@ -227,29 +315,33 @@ impl Handshake {
     ///
     /// Upon successful confirmation, returns the newly established sessions as well as the one
     /// or more packets that decrypted successfully
-    pub(crate) fn confirm(
+    pub fn confirm(
         &mut self,
-        session_id: SessionId,
         mut packets: Vec<PacketMut>,
     ) -> Option<(BidiSession, Vec<PacketMut>)> {
-        let Handshake::Responded(tentative) = self else {
-            return None;
-        };
-
-        if tentative.recv_id() != session_id {
-            return None;
-        };
+        let tentative = self.state.as_responded_mut()?;
 
         packets = tentative.decrypt(packets);
         if packets.is_empty() {
             return None;
         }
 
-        let Handshake::Responded(tentative) = std::mem::replace(self, Handshake::None) else {
-            unreachable!();
-        };
+        // as_responded_mut above confirmed that the handshake is in the responded state.
+        let tentative = *self.state.take_if_responded().unwrap();
 
-        Some((*tentative, packets))
+        Some((tentative, packets))
+    }
+
+    /// Process a cookie reply packet from the peer.
+    ///
+    /// If present, the handshake that caused the cookie reply is not changed: processing a cookie
+    /// reply merely updates the state that will be used in future handshakes.
+    pub fn cookie_reply(&mut self, packet: &CookieReply) {
+        let Some(handshake) = self.state.as_initiated_mut() else {
+            tracing::trace!("got cookie reply outside of handshake initiation");
+            return;
+        };
+        self.cookie_sender.receive_cookie(packet, &handshake.mac1);
     }
 }
 
@@ -260,7 +352,7 @@ mod tests {
     use zerocopy::TryFromBytes;
 
     use super::*;
-    use crate::{PeerId, ids::IdMap};
+    use crate::{Event::HandshakeTimeout, PeerId, ids::IdMap};
 
     #[test]
     fn test_handshake() {
@@ -268,38 +360,38 @@ mod tests {
         let psk = rand::random();
 
         // Peer A sends a handshake initiation...
-        let a_mac_send = MACSender::new(&b_static.public);
         let a_mac_recv = MACReceiver::new(&a_static.public);
         let mut ids = IdMap::default();
         let a_session = ids.allocate_session(PeerId(1)); // A wants to receive at this ID
         let a_init_time = TAI64N::now();
-        let (a_handshake, init_pkt) =
-            initiate_handshake(&a_static, &b_static.public, a_session, a_init_time);
+        let mut a_sched = Scheduler::default();
 
-        let mut init_pkt = PacketMut::from(init_pkt.as_bytes());
-        let handshake_mac = a_mac_send.write_macs(init_pkt.as_mut());
-
-        let mut scheduler = Scheduler::default();
-        let timeout = scheduler.add(
-            ts_time::TimeRange::new_around(Instant::now(), std::time::Duration::from_secs(1000)),
-            Event::HandshakeTimeout(crate::config::PeerId(0)),
+        let mut a_handshake = Handshake::new(&b_static.public);
+        let init_pkt = a_handshake.initiate(
+            &mut a_sched,
+            a_session,
+            &a_static,
+            &b_static.public,
+            HandshakeTimeout(PeerId(0)),
+            a_init_time,
+            Instant::now(),
         );
-        let mut a_handshake = Handshake::Initiated(a_handshake, timeout, handshake_mac);
-
         // Peer B receives it and responds
-        let init_pkt = HandshakeInitiation::try_mut_from_bytes(init_pkt.as_mut())
-            .expect("init_pkt should be a valid handshake initiation message");
-        let b_mac_send = MACSender::new(&a_static.public);
         let b_mac_recv = MACReceiver::new(&b_static.public);
-        let b_handshake = ReceivedHandshake::new(init_pkt, &b_static, &b_mac_recv)
-            .expect("peer B should successfully process A's handshake initiation");
-        assert_eq!(b_handshake.peer_static(), a_static.public);
-        assert_eq!(b_handshake.timestamp, a_init_time);
-        let b_session = ids.allocate_session(PeerId(2)); // B wants to receive at this ID
-        let (mut b_session, mut response_pkt) =
-            b_handshake.respond(b_session, &psk, &b_mac_send, Instant::now());
+        let init_pkt = ReceivedHandshake::new(init_pkt, &b_static, &b_mac_recv)
+            .expect("B should parse the initiation message");
 
-        // Peer A receives response
+        let mut b_handshake = Handshake::new(&a_static.public);
+        let mut response_pkt = b_handshake
+            .respond(
+                init_pkt,
+                || ids.allocate_session(PeerId(2)),
+                &psk,
+                Instant::now(),
+            )
+            .expect("B should respond to handshake");
+
+        // Peer A receives response, sends confirmation
         let response_pkt = HandshakeResponse::try_mut_from_bytes(response_pkt.as_mut())
             .expect("response_pkt should be a valid handshake response message");
         let Some(mut a_session) =
@@ -307,13 +399,13 @@ mod tests {
         else {
             panic!("failed to process handshake response from peer B");
         };
-
-        // They can now communicate
         let a_plaintext = vec![PacketMut::from("xyzzy".as_bytes())];
         let mut packets = a_plaintext.clone();
         a_session.encrypt(packets.iter_mut());
-        let b_received = b_session.decrypt(packets);
-        assert_eq!(b_received, a_plaintext);
+
+        // Peer B confirms and decrypts packet
+        let (b_session, mut packets) = b_handshake.confirm(packets).expect("B should confirm");
+        assert_eq!(packets, a_plaintext);
 
         let b_plaintext = vec![PacketMut::from("plover".as_bytes())];
         packets = b_plaintext.clone();
@@ -330,32 +422,35 @@ mod tests {
         let mut ids = IdMap::default();
 
         // A sends a handshake
-        let a_mac_send = MACSender::new(&b_static.public);
         let a_mac_recv = MACReceiver::new(&a_static.public);
         let a_session = ids.allocate_session(PeerId(1)); // A wants to receive at this ID
         let a_init_time = TAI64N::now();
-        let (a_handshake, init_pkt) =
-            initiate_handshake(&a_static, &b_static.public, a_session, a_init_time);
-
-        let mut init_pkt = PacketMut::from(init_pkt.as_bytes());
-        let handshake_mac = a_mac_send.write_macs(init_pkt.as_mut());
-        let mut scheduler = Scheduler::default();
-        let timeout = scheduler.add(
-            ts_time::TimeRange::new_around(Instant::now(), std::time::Duration::from_secs(1000)),
-            Event::HandshakeTimeout(crate::PeerId(0)),
+        let mut a_scheduler = Scheduler::default();
+        let mut a_handshake = Handshake::new(&b_static.public);
+        let init_pkt = a_handshake.initiate(
+            &mut a_scheduler,
+            a_session,
+            &a_static,
+            &b_static.public,
+            HandshakeTimeout(PeerId(0)),
+            a_init_time,
+            Instant::now(),
         );
-        let mut a_handshake = Handshake::Initiated(a_handshake, timeout, handshake_mac);
 
         // B receives and responds
-        let init_pkt = HandshakeInitiation::try_mut_from_bytes(init_pkt.as_mut())
-            .expect("init_pkt should be a valid handshake initiation message");
-        let b_mac_send = MACSender::new(&a_static.public);
         let b_mac_recv = MACReceiver::new(&b_static.public);
-        let b_handshake = ReceivedHandshake::new(init_pkt, &b_static, &b_mac_recv)
-            .expect("peer B should successfully process A's handshake initiation");
-        let b_session = ids.allocate_session(PeerId(2)); // B wants to receive at this ID
-        let (_b_session, mut response_pkt) =
-            b_handshake.respond(b_session, &psk, &b_mac_send, Instant::now());
+        let init_pkt = ReceivedHandshake::new(init_pkt, &b_static, &b_mac_recv)
+            .expect("B should parse the initiation message");
+        let mut b_handshake = Handshake::new(&a_static.public);
+
+        let mut response_pkt = b_handshake
+            .respond(
+                init_pkt,
+                || ids.allocate_session(PeerId(2)),
+                &psk,
+                Instant::now(),
+            )
+            .expect("B responds to handshake");
 
         // A receives several invalid responses: one with bad MACs, one with a bad Noise handshake
         assert!(
@@ -371,7 +466,7 @@ mod tests {
         );
         let mut corrupt_pkt = response_pkt.clone();
         let corrupt_pkt = HandshakeResponse::try_mut_from_bytes(corrupt_pkt.as_mut()).unwrap();
-        corrupt_pkt.noise[3] += 1;
+        corrupt_pkt.noise[3] = corrupt_pkt.noise[3].wrapping_add(1);
         assert!(
             a_handshake
                 .finish(corrupt_pkt, &a_static, &psk, &a_mac_recv, Instant::now())

--- a/ts_tunnel/src/session.rs
+++ b/ts_tunnel/src/session.rs
@@ -138,7 +138,7 @@ pub const SESSION_CLEANUP_GRACE: Duration = Duration::from_secs(5);
 /// Established session that can only receive.
 pub struct ReceiveSession {
     cipher: ChaCha20Poly1305,
-    id: SessionHandle,
+    session_handle: SessionHandle,
     expiry: Instant,
     window: ReplayWindow,
 }
@@ -146,16 +146,16 @@ pub struct ReceiveSession {
 impl Debug for ReceiveSession {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ReceiveSession")
-            .field("id", self.id.as_ref())
+            .field("id", self.session_handle.as_ref())
             .finish_non_exhaustive()
     }
 }
 
 impl ReceiveSession {
-    pub fn new(key: SessionKey, id: SessionHandle, now: Instant) -> Self {
+    pub fn new(key: SessionKey, session_handle: SessionHandle, now: Instant) -> Self {
         ReceiveSession {
             cipher: ChaCha20Poly1305::new(&key),
-            id,
+            session_handle,
             expiry: now + SESSION_LIFETIME,
             window: ReplayWindow::default(),
         }
@@ -170,7 +170,7 @@ impl ReceiveSession {
     }
 
     /// Decrypt a wireguard transport data message in place.
-    #[tracing::instrument(skip_all, fields(session_id = ?self.id))]
+    #[tracing::instrument(skip_all, fields(session_id = ?self.session_handle))]
     #[must_use]
     fn decrypt_one(&mut self, pkt: &mut PacketMut) -> bool {
         let Ok((header, _)) = TransportDataHeader::try_ref_from_prefix(pkt.as_ref()) else {
@@ -222,7 +222,7 @@ impl ReceiveSession {
 
     /// Return the session ID that will appear on received packets meant for this session.
     pub fn id(&self) -> SessionId {
-        self.id.id()
+        self.session_handle.id()
     }
 
     /// Report whether the session is expired.
@@ -246,12 +246,16 @@ impl BidiSession {
     /// Create a new session in the initiator role.
     pub fn new_initiator(
         keys: ts_noise::core::Session,
-        responder_to_initiator_id: SessionHandle,
+        responder_to_initiator_handle: SessionHandle,
         initiator_to_responder_id: SessionId,
         now: Instant,
     ) -> Self {
         Self {
-            recv: ReceiveSession::new(keys.responder_to_initiator, responder_to_initiator_id, now),
+            recv: ReceiveSession::new(
+                keys.responder_to_initiator,
+                responder_to_initiator_handle,
+                now,
+            ),
             send_id: initiator_to_responder_id,
             send_cipher: ChaCha20Poly1305::new(&keys.initiator_to_responder),
             send_nonce: Default::default(),
@@ -262,12 +266,16 @@ impl BidiSession {
     /// Create a new session in the responder role.
     pub fn new_responder(
         keys: ts_noise::core::Session,
-        initiator_to_responder_id: SessionHandle,
+        initiator_to_responder_handle: SessionHandle,
         responder_to_initiator_id: SessionId,
         now: Instant,
     ) -> Self {
         Self {
-            recv: ReceiveSession::new(keys.initiator_to_responder, initiator_to_responder_id, now),
+            recv: ReceiveSession::new(
+                keys.initiator_to_responder,
+                initiator_to_responder_handle,
+                now,
+            ),
             send_id: responder_to_initiator_id,
             send_cipher: ChaCha20Poly1305::new(&keys.responder_to_initiator),
             send_nonce: Default::default(),
@@ -309,7 +317,7 @@ impl BidiSession {
 
     /// Return the session ID that will appear on received packets meant for this session.
     pub fn recv_id(&self) -> SessionId {
-        self.recv.id.id()
+        self.recv.session_handle.id()
     }
 
     pub fn rotation_time(&self) -> Instant {
@@ -608,7 +616,7 @@ mod tests {
     }
 
     impl PeerSession {
-        fn allocate_id(&mut self) -> SessionHandle {
+        fn allocate_handle(&mut self) -> SessionHandle {
             self.recv_id_prev = self.recv_id.take();
             let ret = self.ids.allocate_session(PeerId(1));
             self.recv_id = Some(ret.id());
@@ -621,9 +629,9 @@ mod tests {
             now: Instant,
         ) -> (Vec<PacketMut>, Vec<PacketMut>) {
             let (k1, k2): ([u8; 32], [u8; 32]) = rand::random();
-            let sid1 = self.allocate_id();
+            let sid1 = self.allocate_handle();
             let sid1_id = sid1.id();
-            let sid2 = other.allocate_id();
+            let sid2 = other.allocate_handle();
             let s1 = BidiSession::new_initiator(
                 ts_noise::core::Session {
                     initiator_to_responder: k1.into(),


### PR DESCRIPTION
Updates #339


Change-Id: I490aa5aff93b5b894d3feaf6f027abf36a6a6964

---

The main change is that logic in Endpoint that had to match on the handshake enum's variants has moved into handshake.rs, and the state enum is now bundled inside a Handshake struct which carries other per-peer data that's only relevant for handshaking.

I don't love how many arguments the methods on Handshake need, but it's either that or bloat the state of idle peers with more copies of data, or Arcs, or similar sadness. At least moving the handshake replay protection and MAC handling into the Handshake struct cut out a few arguments.

The major remaining bit of handshake management that still straddles Endpoint and Handshake is the handling of timeouts and retries. That will be the next PR, and the one that should finally fix #339.