### PR TITLE
all: update versions from 0.4.0 to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,38 +2,34 @@
 
 Record breaking or significant changes here. All dates are UTC.
 
-## Unreleased - August 2026
+## Unreleased - September 2026
 
 Put changes for the upcoming release here!
 
+## [0.5.0](https://github.com/tailscale/tailscale-rs/releases/tag/v0.5.0) - 2026-08-14
+
 - **Breaking** (Rust API, lang bindings, ts_control): Support for `ephemeral`
-  config option. This was previously effectively hardcoded to `true`, the default
-  is now `false` (tailscale-rs nodes are _not_ ephemeral unless you explicitly
-  configure them to be).
+  config option. This was previously effectively hardcoded to `true`, the default is now `false` (tailscale-rs nodes are
+  _not_ ephemeral unless you explicitly configure them to be).
   [#292](https://github.com/tailscale/tailscale-rs/pull/292).
-- **Security** (C bindings): Don't log private keys in `ts_load_key_file`. Previously
-  loaded keys were logged at INFO priority. These logs aren't persisted or streamed
-  anywhere by default, so this is only a concern in non-default configurations. Users
-  of the C bindings who persisted logs should provision new nodes with fresh keys and
-  invalidate existing credentials.
-- **Security** (ts_netmon, Windows): Fix use-after-free in Windows network monitoring
-  code. During client shutdown, there is a short window in which network change
-  notifications could fire with an already freed context pointer.
-- **Security** (ts_control_serde): don't print authkeys when logging RegistrationRequests.
-  Previously when TRACE level logging was enabled, the client printed the authkey as part
-  of logging the serialized registration request.
-- **Security** (ts_keys): remove Debug/Display implementation for private keys to
-  avoid inadvertent logging via Debug/Display impls of structs that carry private keys.
-  Private keys now Debug format themselves as `[redacted]` and do not have a Display impl.
-  Private keys continue to have serde implementations for serializing to/from disk.
-- **Security** (ts_elixir): don't print fields of the Keystate struct when inspected.
-  Previously a GenServer crash would print the keystate in logs.
-- **Security** (ts_tunnel): fix DoS in handshake logic, where an attacker could force
-  handshakes to fail by racing an invalid response to the initiator. (#334)
-- Fixed (ts_keys): Return an error when parsing a key string with invalid hex digits,
-  rather than panic.
-- Fixed(ts_tunnel): adjust session rotation logic to match the spec (#286)
-- Fixed(ts_tunnel): don't yield empty decrypted keepalive packets to the caller (#287)
+- **Security** (C bindings): Don't log private keys in `ts_load_key_file`. Previously loaded keys were logged at INFO
+  priority. These logs aren't persisted or streamed anywhere by default, so this is only a concern in non-default
+  configurations. Users of the C bindings who persisted logs should provision new nodes with fresh keys and invalidate
+  existing credentials.
+- **Security** (ts_netmon, Windows): Fix use-after-free in Windows network monitoring code. During client shutdown,
+  there is a short window in which network change notifications could fire with an already freed context pointer.
+- **Security** (ts_control_serde): don't print authkeys when logging `RegistrationRequest`s. Previously when TRACE level
+  logging was enabled, the client printed the authkey as part of logging the serialized registration request.
+- **Security** (ts_keys): remove Debug/Display implementation for private keys to avoid inadvertent logging via
+  Debug/Display impls of structs that carry private keys. Private keys now `Debug`-format themselves as `[redacted]` and
+  do not have a `Display` impl. Private keys continue to have serde implementations for serializing to/from disk.
+- **Security** (ts_elixir): don't print fields of the Keystate struct when inspected. Previously a GenServer crash would
+  print the keystate in logs.
+- **Security** (ts_tunnel): fix DoS in handshake logic, where an attacker could force handshakes to fail by racing an
+  invalid response to the initiator. (#334)
+- Fixed (ts_keys): Return an error when parsing a key string with invalid hex digits, rather than panic.
+- Fixed (ts_tunnel): adjust session rotation logic to match the spec (#286)
+- Fixed (ts_tunnel): don't yield empty decrypted keepalive packets to the caller (#287)
 
 ## [0.4.0](https://github.com/tailscale/tailscale-rs/releases/tag/v0.4.0) - 2026-07-08
 
@@ -41,11 +37,10 @@ Put changes for the upcoming release here!
   [`russh`](https://docs.rs/russh/latest/russh/) and (optionally)
   [`ratatui`](https://docs.rs/ratatui/latest/ratatui/).
   [#178](https://github.com/tailscale/tailscale-rs/pull/178).
-- Added (ts_netmon): Monitor network interface changes across Linux and Windows (macOS coming in a
-  future release).
+- Added (ts_netmon): Monitor network interface changes across Linux and Windows (macOS coming in a future release).
   [#214](https://github.com/tailscale/tailscale-rs/pull/214).
-- Added (ts_kv_store): Transactional KV store for future use by multiple components (peer tracker,
-  control client, etc.).
+- Added (ts_kv_store): Transactional KV store for future use by multiple components (peer tracker, control client,
+  etc.).
   [#208](https://github.com/tailscale/tailscale-rs/pull/208).
   [#223](https://github.com/tailscale/tailscale-rs/pull/223).
   [#228](https://github.com/tailscale/tailscale-rs/pull/228).
@@ -53,8 +48,7 @@ Put changes for the upcoming release here!
   [#252](https://github.com/tailscale/tailscale-rs/pull/252).
   [#263](https://github.com/tailscale/tailscale-rs/pull/263).
   [#265](https://github.com/tailscale/tailscale-rs/pull/265).
-- Added (ts_control*, ts_derp, ts_runtime): Handling of various peer change messages from the
-  control plane.
+- Added (ts_control*, ts_derp, ts_runtime): Handling of various peer change messages from the control plane.
   [#185](https://github.com/tailscale/tailscale-rs/pull/185).
   [#248](https://github.com/tailscale/tailscale-rs/pull/248).
 - Added (ts_runtime): STUN protocol support and periodic STUN checks.
@@ -62,12 +56,11 @@ Put changes for the upcoming release here!
   [#244](https://github.com/tailscale/tailscale-rs/pull/244).
 - Added (ts_tunnel): Cleanup of expired sessions that no longer receive traffic.
   [#264](https://github.com/tailscale/tailscale-rs/pull/264).
-- Added (ts_python): Type stubs for the `tailscale-py` package, along with minor improvements to
-  documentation.
+- Added (ts_python): Type stubs for the `tailscale-py` package, along with minor improvements to documentation.
   [#211](https://github.com/tailscale/tailscale-rs/pull/211).
   [#247](https://github.com/tailscale/tailscale-rs/pull/247).
-- Fixed (ts_keys, ts_noise): Private key types are properly zeroized on drop and are now passed by
-  reference rather than Copy.
+- Fixed (ts_keys, ts_noise): Private key types are properly zeroized on drop and are now passed by reference rather than
+  Copy.
   [#221](https://github.com/tailscale/tailscale-rs/pull/221).
   [#245](https://github.com/tailscale/tailscale-rs/pull/245).
   [#249](https://github.com/tailscale/tailscale-rs/pull/249).
@@ -75,11 +68,11 @@ Put changes for the upcoming release here!
 - Fixed (ts_packetfilter_serde): `IpRange::Wildcard.iter_prefixes()` now covers the full `::/0`
   IPv6 address space. Thanks to @immanuwell for the report!
   [#212](https://github.com/tailscale/tailscale-rs/pull/212).
-- Fixed (ts_netstack_smoltcp{_core}): Overlay network stack now returns an error on IP version
-  mismatch between local/remote endpoints instead of panicking.
+- Fixed (ts_netstack_smoltcp{_core}): Overlay network stack now returns an error on IP version mismatch between
+  local/remote endpoints instead of panicking.
   [#213](https://github.com/tailscale/tailscale-rs/pull/213).
-- Fixed (ts_netstack_smoltcp_core): TCP accept loop now correctly handles CLOSE_WAIT transitions and
-  half-open sockets that transition back to the LISTEN state.
+- Fixed (ts_netstack_smoltcp_core): TCP accept loop now correctly handles CLOSE_WAIT transitions and half-open sockets
+  that transition back to the LISTEN state.
   [#200](https://github.com/tailscale/tailscale-rs/pull/200).
   [#239](https://github.com/tailscale/tailscale-rs/pull/239).
 - Fixed (ts_runtime): DERP connectivity is now re-established after a control client reconnect.
@@ -112,12 +105,12 @@ Partial release; this version is tagged and published to PyPI, but was not publi
 
 Internal release; this version is tagged, but was not published to any package repositories.
 
-- **Breaking** (Rust API): exports `config`, `netstack`, and `keys` modules and moves some functionality
-  from the crate root to these modules. Replaces `load_key_file` with `Config::default_with_key_file`.
-  Exports a few more types so fewer users will have to depend on internal crates.
+- **Breaking** (Rust API): exports `config`, `netstack`, and `keys` modules and moves some functionality from the crate
+  root to these modules. Replaces `load_key_file` with `Config::default_with_key_file`. Exports a few more types so
+  fewer users will have to depend on internal crates.
   [#105](https://github.com/tailscale/tailscale-rs/pull/105).
-- **Breaking** (Rust API, ts_netstack_smoltcp, ts_control): errors have been refactored, some minor
-  changes to APIs around errors.
+- **Breaking** (Rust API, ts_netstack_smoltcp, ts_control): errors have been refactored, some minor changes to APIs
+  around errors.
   [#154](https://github.com/tailscale/tailscale-rs/pull/154).
 - Added (Rust API): load configuration options from environment variables. Adds `config::auth_key_from_env`
   and `config::Config::default_from_env`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "checks"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "globwalk",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "tailscale"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "axum",
  "bytes",
@@ -5796,7 +5796,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ts_array256"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "heapless",
  "lazy_static",
@@ -5808,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "ts_bart"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cfg-if",
  "divan",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "ts_bart_packetfilter"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "hashbrown 0.17.1",
  "ipnet",
@@ -5842,7 +5842,7 @@ dependencies = [
 
 [[package]]
 name = "ts_bitset"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cfg-if",
  "divan",
@@ -5852,14 +5852,14 @@ dependencies = [
 
 [[package]]
 name = "ts_capabilityversion"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ts_cli_util"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cfg-if",
  "clap",
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "ts_control"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -5911,7 +5911,7 @@ dependencies = [
 
 [[package]]
 name = "ts_control_noise"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5934,7 +5934,7 @@ dependencies = [
 
 [[package]]
 name = "ts_control_serde"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5952,7 +5952,7 @@ dependencies = [
 
 [[package]]
 name = "ts_dataplane"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitrs",
  "bytes",
@@ -5972,7 +5972,7 @@ dependencies = [
 
 [[package]]
 name = "ts_derp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "crypto_box",
@@ -6000,7 +6000,7 @@ dependencies = [
 
 [[package]]
 name = "ts_devtools"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "clap",
@@ -6016,7 +6016,7 @@ dependencies = [
 
 [[package]]
 name = "ts_disco_protocol"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aead 0.5.2",
  "crypto_box",
@@ -6031,7 +6031,7 @@ dependencies = [
 
 [[package]]
 name = "ts_dynbitset"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proptest",
  "smallvec",
@@ -6040,7 +6040,7 @@ dependencies = [
 
 [[package]]
 name = "ts_elixir"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "rustler",
  "static_assertions",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "ts_ffi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cbindgen",
  "tailscale",
@@ -6064,14 +6064,14 @@ dependencies = [
 
 [[package]]
 name = "ts_hexdump"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "heapless",
 ]
 
 [[package]]
 name = "ts_http_util"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "futures",
@@ -6092,7 +6092,7 @@ dependencies = [
 
 [[package]]
 name = "ts_keys"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "crypto_box",
  "serde",
@@ -6104,14 +6104,14 @@ dependencies = [
 
 [[package]]
 name = "ts_kv_store"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "ts_kv_store_tokio"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "ts_netcheck"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "dashmap",
@@ -6142,7 +6142,7 @@ dependencies = [
 
 [[package]]
 name = "ts_netmon"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cfg-if",
  "flume",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "ts_netstack_smoltcp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "axum",
  "bytes",
@@ -6183,7 +6183,7 @@ dependencies = [
 
 [[package]]
 name = "ts_netstack_smoltcp_core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "flume",
@@ -6197,7 +6197,7 @@ dependencies = [
 
 [[package]]
 name = "ts_netstack_smoltcp_socket"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "futures-io",
@@ -6208,7 +6208,7 @@ dependencies = [
 
 [[package]]
 name = "ts_nodecapability"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cfg-if",
  "serde",
@@ -6217,7 +6217,7 @@ dependencies = [
 
 [[package]]
 name = "ts_noise"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aead 0.5.2",
  "blake2",
@@ -6233,7 +6233,7 @@ dependencies = [
 
 [[package]]
 name = "ts_overlay_router"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "itertools",
  "tracing",
@@ -6244,7 +6244,7 @@ dependencies = [
 
 [[package]]
 name = "ts_packet"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "crypto_box",
@@ -6255,7 +6255,7 @@ dependencies = [
 
 [[package]]
 name = "ts_packetfilter"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "hashbrown 0.17.1",
  "ipnet",
@@ -6265,7 +6265,7 @@ dependencies = [
 
 [[package]]
 name = "ts_packetfilter_serde"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ipnet",
  "nom 8.0.0",
@@ -6278,7 +6278,7 @@ dependencies = [
 
 [[package]]
 name = "ts_packetfilter_state"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "divan",
  "serde_json",
@@ -6289,7 +6289,7 @@ dependencies = [
 
 [[package]]
 name = "ts_peercapability"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "url",
@@ -6297,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "ts_python"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "hex",
  "pyo3",
@@ -6308,7 +6308,7 @@ dependencies = [
 
 [[package]]
 name = "ts_runtime"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -6353,18 +6353,18 @@ dependencies = [
 
 [[package]]
 name = "ts_test_util"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "ts_time"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "ts_tls_util"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "tokio-rustls",
@@ -6375,7 +6375,7 @@ dependencies = [
 
 [[package]]
 name = "ts_transport"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "dyn-eq",
  "dyn-hash",
@@ -6387,7 +6387,7 @@ dependencies = [
 
 [[package]]
 name = "ts_transport_tun"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "ipnet",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "ts_tunnel"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aead 0.5.2",
  "base64 0.22.1",
@@ -6426,7 +6426,7 @@ dependencies = [
 
 [[package]]
 name = "ts_underlay_router"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ts_packet",
  "ts_transport",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ members = [
 edition = "2024"
 license = "BSD-3-Clause"
 publish = true
-version = "0.4.0"
+version = "0.5.0"
 repository = "https://github.com/tailscale/tailscale-rs"
 
 # This disagrees with the README's stated MSRV. That's intentional: this field causes cargo to error
@@ -109,46 +109,46 @@ zerocopy = { version = "0.8", features = ["derive"] }
 zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 
 # local workspace deps
-tailscale = { path = ".", version = "0.4.0" }
-ts_array256 = { path = "ts_array256", version = "0.4.0" }
-ts_bart = { path = "ts_bart", version = "0.4.0" }
-ts_bart_packetfilter = { path = "ts_bart_packetfilter", version = "0.4.0" }
-ts_bitset = { path = "ts_bitset", default-features = false, version = "0.4.0" }
-ts_capabilityversion = { path = "ts_capabilityversion", version = "0.4.0" }
+tailscale = { path = ".", version = "0.5.0" }
+ts_array256 = { path = "ts_array256", version = "0.5.0" }
+ts_bart = { path = "ts_bart", version = "0.5.0" }
+ts_bart_packetfilter = { path = "ts_bart_packetfilter", version = "0.5.0" }
+ts_bitset = { path = "ts_bitset", default-features = false, version = "0.5.0" }
+ts_capabilityversion = { path = "ts_capabilityversion", version = "0.5.0" }
 ts_cli_util = { path = "ts_cli_util" }
-ts_control = { path = "ts_control", version = "0.4.0" }
-ts_control_noise = { path = "ts_control_noise", version = "0.4.0" }
-ts_control_serde = { path = "ts_control_serde", version = "0.4.0" }
-ts_dataplane = { path = "ts_dataplane", version = "0.4.0" }
-ts_derp = { path = "ts_derp", version = "0.4.0" }
-ts_disco_protocol = { path = "ts_disco_protocol", version = "0.4.0" }
-ts_dynbitset = { path = "ts_dynbitset", version = "0.4.0" }
-ts_hexdump = { path = "ts_hexdump", version = "0.4.0" }
-ts_keys = { path = "ts_keys", version = "0.4.0" }
-ts_kv_store = { path = "ts_kv_store", version = "0.4.0" }
-ts_kv_store_tokio = { path = "ts_kv_store_tokio", version = "0.4.0" }
-ts_netcheck = { path = "ts_netcheck", version = "0.4.0" }
-ts_netmon = { path = "ts_netmon", version = "0.4.0" }
-ts_netstack_smoltcp = { path = "ts_netstack_smoltcp", version = "0.4.0" }
-ts_netstack_smoltcp_core = { path = "ts_netstack_smoltcp_core", version = "0.4.0" }
-ts_netstack_smoltcp_socket = { path = "ts_netstack_smoltcp_socket", version = "0.4.0" }
-ts_nodecapability = { path = "ts_nodecapability", version = "0.4.0" }
-ts_noise = { path = "ts_noise", version = "0.4.0" }
-ts_overlay_router = { path = "ts_overlay_router", version = "0.4.0" }
-ts_packet = { path = "ts_packet", version = "0.4.0" }
-ts_packetfilter = { path = "ts_packetfilter", version = "0.4.0" }
-ts_packetfilter_serde = { path = "ts_packetfilter_serde", version = "0.4.0" }
-ts_packetfilter_state = { path = "ts_packetfilter_state", version = "0.4.0" }
-ts_peercapability = { path = "ts_peercapability", version = "0.4.0" }
-ts_http_util = { path = "ts_http_util", version = "0.4.0" }
-ts_tls_util = { path = "ts_tls_util", version = "0.4.0" }
-ts_runtime = { path = "ts_runtime", version = "0.4.0" }
+ts_control = { path = "ts_control", version = "0.5.0" }
+ts_control_noise = { path = "ts_control_noise", version = "0.5.0" }
+ts_control_serde = { path = "ts_control_serde", version = "0.5.0" }
+ts_dataplane = { path = "ts_dataplane", version = "0.5.0" }
+ts_derp = { path = "ts_derp", version = "0.5.0" }
+ts_disco_protocol = { path = "ts_disco_protocol", version = "0.5.0" }
+ts_dynbitset = { path = "ts_dynbitset", version = "0.5.0" }
+ts_hexdump = { path = "ts_hexdump", version = "0.5.0" }
+ts_keys = { path = "ts_keys", version = "0.5.0" }
+ts_kv_store = { path = "ts_kv_store", version = "0.5.0" }
+ts_kv_store_tokio = { path = "ts_kv_store_tokio", version = "0.5.0" }
+ts_netcheck = { path = "ts_netcheck", version = "0.5.0" }
+ts_netmon = { path = "ts_netmon", version = "0.5.0" }
+ts_netstack_smoltcp = { path = "ts_netstack_smoltcp", version = "0.5.0" }
+ts_netstack_smoltcp_core = { path = "ts_netstack_smoltcp_core", version = "0.5.0" }
+ts_netstack_smoltcp_socket = { path = "ts_netstack_smoltcp_socket", version = "0.5.0" }
+ts_nodecapability = { path = "ts_nodecapability", version = "0.5.0" }
+ts_noise = { path = "ts_noise", version = "0.5.0" }
+ts_overlay_router = { path = "ts_overlay_router", version = "0.5.0" }
+ts_packet = { path = "ts_packet", version = "0.5.0" }
+ts_packetfilter = { path = "ts_packetfilter", version = "0.5.0" }
+ts_packetfilter_serde = { path = "ts_packetfilter_serde", version = "0.5.0" }
+ts_packetfilter_state = { path = "ts_packetfilter_state", version = "0.5.0" }
+ts_peercapability = { path = "ts_peercapability", version = "0.5.0" }
+ts_http_util = { path = "ts_http_util", version = "0.5.0" }
+ts_tls_util = { path = "ts_tls_util", version = "0.5.0" }
+ts_runtime = { path = "ts_runtime", version = "0.5.0" }
 ts_test_util = { path = "ts_test_util" }
-ts_time = { path = "ts_time", version = "0.4.0" }
-ts_transport = { path = "ts_transport", version = "0.4.0" }
-ts_transport_tun = { path = "ts_transport_tun", version = "0.4.0" }
-ts_underlay_router = { path = "ts_underlay_router", version = "0.4.0" }
-ts_tunnel = { path = "ts_tunnel", version = "0.4.0" }
+ts_time = { path = "ts_time", version = "0.5.0" }
+ts_transport = { path = "ts_transport", version = "0.5.0" }
+ts_transport_tun = { path = "ts_transport_tun", version = "0.5.0" }
+ts_underlay_router = { path = "ts_underlay_router", version = "0.5.0" }
+ts_tunnel = { path = "ts_tunnel", version = "0.5.0" }
 
 [workspace.lints.rust]
 closure_returning_async_block = "warn"

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 
 https://tailscale.com
 
-`tailscale-rs` is a work-in-progress Tailscale library written in Rust, with language bindings to
-C, Elixir, and Python.
+`tailscale-rs` is a work-in-progress Tailscale library written in Rust, with language bindings to C, Elixir, and Python.
 
 > [!CAUTION]
 > This software is unstable and insecure.
@@ -29,14 +28,13 @@ Add this dependency line to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tailscale = { version = "0.4" }
+tailscale = { version = "0.5" }
 ```
 
 Examples of using the `tailscale` crate can be found in [`examples/`](examples/README.md).
 
 For instructions on how to run tests, lints, etc., see [CONTRIBUTING.md](CONTRIBUTING.md). For the high-level
-architecture and
-repository layout, see [ARCHITECTURE.md](ARCHITECTURE.md).
+architecture and repository layout, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ### Code sample
 
@@ -71,37 +69,36 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 ## Caveats
 
-This software is still a work-in-progress! We are providing it in the open at this stage out of a
-belief in open-source and to see where the community runs with it, but please be aware of a few
-important considerations:
+This software is still a work-in-progress! We are providing it in the open at this stage out of a belief in open-source
+and to see where the community runs with it, but please be aware of a few important considerations:
 
-- This implementation contains unaudited cryptography and hasn't undergone a comprehensive security
-  analysis. Conservatively, assume there could be a critical security hole meaning anything you send
-  or receive could be in the clear on the public Internet.
-- There are no compatibility guarantees at the moment. This is early-days software &mdash; we may
-  break dependent code in order to get things right.
-- We currently rely on DERP relays for all communication. Direct connections via NAT holepunching
-  will be a seamless upgrade in the future, but for now, this puts a cap on data throughput.
+- This implementation contains unaudited cryptography and hasn't undergone a comprehensive security analysis.
+  Conservatively, assume there could be a critical security hole meaning anything you send or receive could be in the
+  clear on the public Internet.
+- There are no compatibility guarantees at the moment. This is early-days software &mdash; we may break dependent code
+  in order to get things right.
+- We currently rely on DERP relays for all communication. Direct connections via NAT holepunching will be a seamless
+  upgrade in the future, but for now, this puts a cap on data throughput.
 - The `TS_RS_EXPERIMENT` environment variable is required to be set to `this_is_unstable_software`
-  for all code linked against `tailscale-rs`; this includes Rust, C, Elixir, and Python code. We'll
-  remove this requirement after a third-party code/cryptography audit and any necessary fixes.
+  for all code linked against `tailscale-rs`; this includes Rust, C, Elixir, and Python code. We'll remove this
+  requirement after a third-party code/cryptography audit and any necessary fixes.
 
 ## Versioning, Releases, and Compatability
 
 We follow semver and aim to make a point release roughly monthly. Since we are pre-1.0, we make no
-backwards-compatability guarantees. We are aiming to have a stable 1.0 release as soon as we can, but
-we currently don't have a timeline.
+backwards-compatability guarantees. We are aiming to have a stable 1.0 release as soon as we can, but we currently don't
+have a timeline.
 
 ## MSRV and Edition
 
 The current MSRV is 1.94.1. The current edition is Rust 2024.
 
-`tailscale-rs` has a rolling MSRV (Minimum Supported Rust Version) policy to support the current
-and previous Rust compiler versions, and the latest
+`tailscale-rs` has a rolling MSRV (Minimum Supported Rust Version) policy to support the current and previous Rust
+compiler versions, and the latest
 [edition of Rust](https://doc.rust-lang.org/edition-guide/editions/index.html).
 
-We may lag the latest version/edition in rare cases for our dependencies to catch up and for us to
-perform any necessary fixes.
+We may lag the latest version/edition in rare cases for our dependencies to catch up and for us to perform any necessary
+fixes.
 
 ## Platform Support
 
@@ -113,9 +110,8 @@ We support the following platforms and architectures:
 
 ## Status
 
-`tailscale-rs` is a work-in-progress - we're still rapidly iterating, fixing bugs, and adding new
-features. We aim to keep this section up-to-date, but
-our [issue tracker](https://github.com/tailscale/tailscale-rs/issues)
+`tailscale-rs` is a work-in-progress - we're still rapidly iterating, fixing bugs, and adding new features. We aim to
+keep this section up-to-date, but our [issue tracker](https://github.com/tailscale/tailscale-rs/issues)
 is the best way to see the latest updates.
 
 ### Implemented
@@ -132,8 +128,8 @@ These are features that we currently implement:
 
 ### Coming Soon
 
-These are features or efforts we have in the pipeline and are actively working towards, but provide
-no guarantees on timeline or completion:
+These are features or efforts we have in the pipeline and are actively working towards, but provide no guarantees on
+timeline or completion:
 
 - Direct connections (NAT traversal, STUN, and Disco)
 - Peer lookups (addressing peers by hostname)
@@ -142,9 +138,8 @@ no guarantees on timeline or completion:
 ### Unsupported
 
 This is an incomplete list of features in the Tailscale Go client, `tsnet`, and/or `libtailscale`
-that we currently *do not* support. We'd like to add all of these eventually! If there's something
-on this list you'd like to see supported, or something _not_ on this list you're not sure about,
-please open an issue!
+that we currently *do not* support. We'd like to add all of these eventually! If there's something on this list you'd
+like to see supported, or something _not_ on this list you're not sure about, please open an issue!
 
 <details>
 <summary>

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1,3 +1,4 @@
+
 # cargo-vet config file
 
 [cargo-vet]
@@ -39,6 +40,9 @@ audit-as-crates-io = false
 [policy.ts_dataplane]
 audit-as-crates-io = false
 
+[policy.ts_derp]
+audit-as-crates-io = false
+
 [policy.ts_disco_protocol]
 audit-as-crates-io = false
 
@@ -63,6 +67,9 @@ audit-as-crates-io = false
 [policy.ts_netcheck]
 audit-as-crates-io = false
 
+[policy.ts_netmon]
+audit-as-crates-io = false
+
 [policy.ts_netstack_smoltcp]
 audit-as-crates-io = false
 
@@ -73,6 +80,9 @@ audit-as-crates-io = false
 audit-as-crates-io = false
 
 [policy.ts_nodecapability]
+audit-as-crates-io = false
+
+[policy.ts_noise]
 audit-as-crates-io = false
 
 [policy.ts_overlay_router]
@@ -583,10 +593,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.indexmap]]
 version = "1.9.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.indexmap]]
-version = "2.13.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.inout]]
@@ -1121,10 +1127,6 @@ criteria = "safe-to-deploy"
 version = "0.9.12+spec-1.1.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.toml_datetime]]
-version = "1.0.0+spec-1.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.toml_parser]]
 version = "1.0.9+spec-1.1.0"
 criteria = "safe-to-deploy"
@@ -1415,8 +1417,4 @@ criteria = "safe-to-deploy"
 
 [[exemptions.zerovec-derive]]
 version = "0.11.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.zmij]]
-version = "1.0.21"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -213,6 +213,12 @@ delta = "0.1.4 -> 0.1.5"
 notes = "No new `unsafe`."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.glob]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
 [[audits.google.audits.httpdate]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
@@ -315,6 +321,31 @@ who = "Manish Goregaokar <manishearth@google.com>"
 criteria = "safe-to-deploy"
 delta = "2.0.0-beta1 -> 2.0.0-beta2"
 notes = "from_utf8_unchecked unsafe remove, all other unsafe not meaningfully changed"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.indexmap]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "2.7.1"
+notes = '''
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'`
+and there were no hits.
+
+There is a little bit of `unsafe` Rust code - the audit can be found at
+https://chromium-review.googlesource.com/c/chromium/src/+/6187726/2
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.indexmap]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "2.7.1 -> 2.8.0"
+notes = """
+No `unsafe` introduced or affected in:
+* `indexmap_with_default!` and `indexset_with_default!` macros
+* New `PartialEq` implementations
+* `fn slice_eq` in `util.rs`
+"""
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.lazy_static]]
@@ -877,6 +908,13 @@ criteria = "safe-to-deploy"
 delta = "1.2.1 -> 1.2.2"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.glob]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.1 -> 0.3.3"
+notes = "Very few changes.  No new unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.hashbrown]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -1011,6 +1049,19 @@ criteria = "safe-to-deploy"
 delta = "1.2.0 -> 1.2.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.indexmap]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.8.0 -> 2.11.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.indexmap]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.11.4 -> 2.14.0"
+notes = "Mostly internal refactorings.  No new unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.libloading]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -1124,6 +1175,13 @@ delta = "1.1.0 -> 2.1.1"
 notes = "Simple hashing crate, no unsafe code."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.serde_json]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.149 -> 1.0.150"
+notes = "Minimal changes, no new unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.serde_spanned]]
 who = "Ben Dean-Kawamura <bdk@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -1132,11 +1190,11 @@ notes = "Relatively simple Serde trait implementations.  No IO or unsafe code."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.serde_spanned]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
 criteria = "safe-to-deploy"
-delta = "1.0.3 -> 1.0.4"
-notes = "Unchanged"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+delta = "1.0.3 -> 1.1.1"
+notes = "No code changes, just dependency updates."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.smallvec]]
 who = "Erich Gubler <erichdongubler@gmail.com>"
@@ -1230,10 +1288,45 @@ criteria = "safe-to-deploy"
 delta = "0.1.0 -> 0.1.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.toml_datetime]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.7.5+spec-1.1.0"
+notes = "Pure data type crate with some datetime parsing. No unsafe."
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.toml_datetime]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.3 -> 1.1.1+spec-1.1.0"
+notes = "Minimal changes, no new unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.toml_datetime]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.5+spec-1.1.0 -> 0.7.3"
+notes = "Version downgrade to cover the full vetted version range"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.toml_writer]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
 version = "1.0.6+spec-1.1.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.toml_writer]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.4 -> 1.1.1+spec-1.1.0"
+notes = "No code changes, just dependency updates."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.toml_writer]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.6+spec-1.1.0 -> 1.0.4"
+notes = "Version downgrade to cover the full vetted version range"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.utf8parse]]
@@ -1252,4 +1345,22 @@ aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-c
 who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
 criteria = "safe-to-deploy"
 delta = "0.6.1 -> 0.6.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zmij]]
+who = "Benjamin VanderSloot <bvandersloot@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "1.0.20"
+notes = """
+A lot of unsafe code here, included as a dependency of serde_json.
+The testing is very thorough, validating all 32-bit floats, and 100m
+random 64-bit floats. No unsafe imports.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zmij]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.20 -> 1.0.21"
+notes = "Almost no code changes.  No new unsafe code."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"

--- a/ts_elixir/mix.exs
+++ b/ts_elixir/mix.exs
@@ -6,7 +6,7 @@ defmodule TsElixir.MixProject do
   def project do
     [
       app: :tailscale,
-      version: "0.4.0",
+      version: "0.5.0",
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/ts_python/pyproject.toml
+++ b/ts_python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tailscale-py"
-version = "0.4.0"
+version = "0.5.0"
 description = "Work-in-progress Tailscale library written in Rust."
 license = "BSD-3-Clause"
 readme = "README.md"

--- a/ts_python/uv.lock
+++ b/ts_python/uv.lock
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "tailscale-py"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Updates all versions from `0.4.0` to `0.5.0`, updates the CHANGELOG for the `0.5.0` release, and updates the `cargo vet` config/lockfile.