### PR TITLE
ts_runtime: drop unregistered map request update log to debug

### DIFF
--- a/ts_runtime/src/control_runner.rs
+++ b/ts_runtime/src/control_runner.rs
@@ -250,7 +250,7 @@ impl ControlRunner {
 impl ControlRunner {
     async fn update_map_request(&self) {
         let RegState::Registered(conn) = &self.state else {
-            tracing::error!("attempt to update map request while not registered");
+            tracing::debug!("attempt to update map request while not registered");
             return;
         };
 


### PR DESCRIPTION
Drops a spurious log message to DEBUG-level; with the current architecture, this is expected to happen once on startup.
