### PR TITLE
Update to rust 1.98.1

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -29,7 +29,7 @@ jobs:
           - ${{github.event_name == 'pull_request' || github.event_name == 'push'}}
 
         rust_toolchain:
-          - version: 1.95.0
+          - version: 1.98.1
             label: latest
 
         build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ env:
   is_tag_push: ${{ startsWith(github.ref, 'refs/tags/') }}
   is_dispatch: ${{ github.event_name == 'workflow_dispatch' }}
 
-  prev_rust: &prev_rust 1.94.1
-  latest_rust: &latest_rust 1.95.0
+  prev_rust: &prev_rust 1.97.1
+  latest_rust: &latest_rust 1.98.1
 
 defaults:
   run:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -37,7 +37,7 @@ env:
 
   latest_elixir: &latest_elixir 1.19.5
   latest_otp: &latest_otp 28.4.2
-  latest_rust: &latest_rust 1.95.0
+  latest_rust: &latest_rust 1.98.1
 
 defaults:
   run:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -45,7 +45,7 @@ env:
   python_version: 3.12
   # The Rust toolchain version to build the wheels with. Should be latest supported
   # version (MSRV + 1).
-  rust_toolchain: 1.95.0
+  rust_toolchain: 1.98.1
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Put changes for the upcoming release here!
 
 - Changed (Rust API, lang bindings): the `TS_RS_EXPERIMENT` environment variable is no longer required to use the
   library. The library logs a warning during initialization, as a reminder that it's still work-in-progress software.
+- Updated MSRV to 1.97.
 
 ## [0.5.0](https://github.com/tailscale/tailscale-rs/releases/tag/v0.5.0) - 2026-08-14
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ backwards-compatibility guarantees.
 
 ## MSRV and Edition
 
-The current MSRV is 1.94.1. The current edition is Rust 2024.
+The current MSRV is 1.97. The current edition is Rust 2024.
 
 `tailscale-rs` has a rolling MSRV (Minimum Supported Rust Version) policy to support the current and previous Rust
 compiler versions, and the latest [edition of Rust](https://doc.rust-lang.org/edition-guide/editions/index.html).

--- a/flake.lock
+++ b/flake.lock
@@ -96,11 +96,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778642276,
-        "narHash": "sha256-bhk4lawR4ZnFhPtamB5WkCyvfgyZmsEUbWfT/3FRxFY=",
+        "lastModified": 1788456718,
+        "narHash": "sha256-TxHC0sBjV2pmsBLKAX02JTXlye/EOLt6Do+WNtGofGw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "77265d2dc1e61b2abfd3b1d6609dbb66fe75e0a5",
+        "rev": "0b20a18e84d9164464739189c2b2a1b00f6f0e4b",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.98.1"
 components = ["rustfmt", "clippy"]

--- a/ts_netstack_smoltcp/examples/common/mod.rs
+++ b/ts_netstack_smoltcp/examples/common/mod.rs
@@ -203,7 +203,7 @@ where
 
     let mut last_send = std::time::Instant::now();
 
-    for i in 0.. {
+    for i in 0..i32::MAX {
         std::thread::sleep(
             core::time::Duration::from_millis(300).saturating_sub(last_send.elapsed()),
         );
@@ -233,7 +233,7 @@ where
 
     let mut ticker = tokio::time::interval(core::time::Duration::from_millis(300));
 
-    for i in 0.. {
+    for i in 0..i32::MAX {
         ticker.tick().await;
 
         sock.write_all(format!("hello {i}").as_bytes())

--- a/ts_netstack_smoltcp/examples/udp_tun.rs
+++ b/ts_netstack_smoltcp/examples/udp_tun.rs
@@ -77,7 +77,7 @@ fn netstack_send(sock: impl Borrow<UdpSocket>, peer: SocketAddr) {
     sock.send_to_blocking(SocketAddr::from(([1, 2, 3, 4], 53)), b"hello")
         .unwrap();
 
-    for i in 0.. {
+    for i in 0..i32::MAX {
         sock.send_to_blocking(peer, format!("hello{i}").as_bytes())
             .unwrap();
         tracing::debug!(i, "sent hello packet");

--- a/ts_netstack_smoltcp/examples/udp_tun_async.rs
+++ b/ts_netstack_smoltcp/examples/udp_tun_async.rs
@@ -80,7 +80,7 @@ async fn netstack_send(sock: impl Borrow<UdpSocket>, peer: SocketAddr) {
         .await
         .unwrap();
 
-    for i in 0.. {
+    for i in 0..i32::MAX {
         sock.send_to(peer, format!("hello{i}").as_bytes())
             .await
             .unwrap();


### PR DESCRIPTION
In addition to our CI's current+prev testing, I'm locally running `cargo test` against all versions from 1.92 (our secret MSRV in Cargo.toml) and current, to make sure we still at least compile and pass basic tests on all versions. I won't merge until that's finished.